### PR TITLE
fix: Remove jq injection surface from wrapper script

### DIFF
--- a/scripts/nex-api.sh
+++ b/scripts/nex-api.sh
@@ -17,10 +17,9 @@ fi
 # --- Parse arguments ---
 METHOD="${1:-}"
 API_PATH="${2:-}"
-JQ_FILTER="${3:-}"
 
 if [[ -z "$METHOD" ]]; then
-  echo "Usage: nex-api.sh <METHOD|sse> <path> [jq-filter]" >&2
+  echo "Usage: nex-api.sh <METHOD|sse> <path>" >&2
   echo "  METHOD: GET, POST, PUT, PATCH, DELETE, or sse" >&2
   exit 2
 fi
@@ -92,12 +91,5 @@ if [[ "$HTTP_CODE" -ge 400 ]] 2>/dev/null; then
   exit 4
 fi
 
-# --- Apply jq filter or output raw ---
-if [[ -n "$JQ_FILTER" ]]; then
-  echo "$BODY" | jq "$JQ_FILTER" || {
-    echo "Error: jq filter failed" >&2
-    exit 5
-  }
-else
-  echo "$BODY"
-fi
+# --- Output response ---
+echo "$BODY"


### PR DESCRIPTION
## Summary
- Removes `JQ_FILTER` 3rd argument from `nex-api.sh` — script is now a pure HTTP client (method + path only)
- Updates all SKILL.md examples to use standard shell piping (`| jq '...'`) instead of script-embedded jq execution

## Context
ClawhubAI scanner (v1.0.2) flagged the skill as **Suspicious** because SKILL.md instructed the agent to construct jq filters passed as a 3rd argument to the wrapper script. This creates a prompt injection surface where malicious user input could manipulate data extraction.

With this fix, `nex-api.sh` outputs raw JSON and jq filtering happens via standard shell pipes — which is normal shell behavior, not a skill-controlled vector.

## Test plan
- [ ] Re-run ClawhubAI scan — expect Benign on both VirusTotal and OpenClaw
- [ ] Verify `nex-api.sh GET /v1/objects` still returns valid JSON
- [ ] Verify `nex-api.sh GET /v1/insights?last=1h | jq '.insights | length'` works via pipe

🤖 Generated with [Claude Code](https://claude.com/claude-code)