### PR TITLE
fix: Harden against shell injection + remove undeclared env var

### DIFF
--- a/scripts/nex-api.sh
+++ b/scripts/nex-api.sh
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 BASE_URL="https://app.nex.ai/api/developers"
-TIMEOUT="${NEX_API_TIMEOUT:-120}"
+TIMEOUT=120
 
 # --- Validate environment ---
 if [[ -z "${NEX_API_KEY:-}" ]]; then


### PR DESCRIPTION
## Summary
- Replace all 24 `echo '{...}'` examples with `printf '%s' '{...}'` — prevents shell interpretation if agent interpolates user text
- Add explicit security instructions for safe dynamic JSON construction (`jq -n --arg`)
- Remove undeclared `NEX_API_TIMEOUT` env var from wrapper script (hardcode 120s)

## Context
ClawhubAI scanner flagged:
1. `echo '{...}'` pattern enables shell injection if agent interpolates unescaped user content
2. `NEX_API_TIMEOUT` env var used in script but not declared in `requires.env` metadata

## Test plan
- [ ] Re-run ClawhubAI scan — expect Benign
- [ ] Verify `printf '%s' '{"query":"test"}' | bash scripts/nex-api.sh POST /v1/search` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)