### PR TITLE
Add MCP server for Claude Desktop, ChatGPT, Cursor, and any MCP client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,114 +1,109 @@
-# Nex as a Skill for OpenClaw
+# Nex — AI Agent Integrations
 
-Give your OpenClaw agent a Context Graph.
+Give any AI agent a Context Graph. Two integration paths: **MCP Server** (Claude Desktop, ChatGPT, Cursor, Windsurf) and **OpenClaw Skill**.
 
 ## What is Nex?
 
-Nex is a real-time context layer for AI agents. It builds a Context Graph from your conversations and shares organizational context with your agents. This skill allows OpenClaw agents to:
+Nex is a real-time context layer for AI agents. It builds a Context Graph from your conversations and shares organizational context with your agents — query contacts, companies, relationships, tasks, notes, and insights.
 
-- **Query context** - Ask natural language questions about your contacts and companies
-- **Add context** - Process conversation transcripts to extract entities and insights
-- **Stream insights** - (Coming soon) Receive real-time notifications when new insights are discovered
+## Integration Options
 
-## Installation
+| | MCP Server | OpenClaw Skill |
+|---|---|---|
+| **Format** | TypeScript MCP server | SKILL.md + bash scripts |
+| **Platforms** | Claude Desktop, ChatGPT, Cursor, Windsurf, any MCP client | OpenClaw |
+| **Transport** | stdio (local) or Streamable HTTP (remote) | Shell exec |
+| **Tools** | 47 typed tools with Zod schemas | Bash wrapper around curl |
+| **Auth** | Auto-registration or manual API key | Auto-registration or manual |
+| **Setup** | `npm install` + add to client config | Copy SKILL.md to skills dir |
 
-### Prerequisites
+## MCP Server (recommended)
 
-- [OpenClaw](https://github.com/openclaw/openclaw) installed and configured
-- A Nex account with Developer API access
+Works with Claude Desktop, ChatGPT (agent mode), Cursor, Windsurf, and any MCP-compatible client.
 
-### Step 1: Get Your API Key
-
-1. Log in to [Nex](https://app.nex.ai)
-2. Go to **Settings > Developer**
-3. Create a new API key with the following scopes:
-   - `record.read` - For querying context
-   - `record.write` - For processing text
-
-### Step 2: Install the Skill
-
-#### Option A: Manual Installation
-
-1. Create the skill directory:
-   ```bash
-   mkdir -p ~/.openclaw/workspace/skills/nex
-   ```
-
-2. Copy `SKILL.md` to the directory:
-   ```bash
-   cp SKILL.md ~/.openclaw/workspace/skills/nex/
-   ```
-
-#### Option B: Clone Repository
+### Quick Start
 
 ```bash
-git clone https://github.com/nex-crm/nex-as-a-skill.git
-cp nex-as-a-skill/SKILL.md ~/.openclaw/workspace/skills/nex/
+cd mcp && npm install
 ```
 
-### Step 3: Configure Your API Key
+#### Claude Desktop
 
-Add your API key to `~/.openclaw/openclaw.json`:
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 
 ```json
 {
-  "skills": {
-    "entries": {
-      "nex": {
-        "enabled": true,
-        "env": {
-          "NEX_API_KEY": "nex_dev_your_key_here"
-        }
+  "mcpServers": {
+    "nex": {
+      "command": "npx",
+      "args": ["tsx", "/path/to/nex-as-a-skill/mcp/src/index.ts"],
+      "env": {
+        "NEX_API_KEY": "sk-your_key_here"
       }
     }
   }
 }
 ```
 
-### Step 4: Verify Installation
+#### Cursor
 
-Start OpenClaw and check that the skill is loaded:
+Add to `.cursor/mcp.json`:
 
-```bash
-openclaw agent --message "What skills do you have?"
+```json
+{
+  "mcpServers": {
+    "nex": {
+      "command": "npx",
+      "args": ["tsx", "/path/to/nex-as-a-skill/mcp/src/index.ts"],
+      "env": {
+        "NEX_API_KEY": "sk-your_key_here"
+      }
+    }
+  }
+}
 ```
 
-The agent should list "nex" among its available skills.
+#### No API Key? Auto-register
 
-## Usage Examples
+If you don't set `NEX_API_KEY`, the server starts in registration mode. Just call the `register` tool with your email — it gets an API key and saves it to `~/.nex-mcp.json` for all future sessions.
 
-### Query Context
+See [`mcp/README.md`](mcp/README.md) for the full tool reference and setup guide.
 
-```
-You: What do I know about Acme Corp?
+## OpenClaw Skill
 
-OpenClaw: [Uses Nex skill to query context]
-Based on your context graph, Acme Corp is a technology company you've been
-working with for 3 months. Key contacts include John Smith (VP Sales) and
-Sarah Chen (CTO). Recent activity shows discussions about their APAC expansion.
-```
+For OpenClaw agents specifically.
 
-### Add Context
+### Setup
 
-```
-You: I just had a call with John. He mentioned they're closing their Series B
-next month and plan to hire 50 engineers.
+1. Copy `SKILL.md` to your OpenClaw skills directory:
+   ```bash
+   mkdir -p ~/.openclaw/workspace/skills/nex
+   cp SKILL.md ~/.openclaw/workspace/skills/nex/
+   ```
 
-OpenClaw: [Uses Nex skill to process text]
-I've added this context to your graph. Created/updated:
-- John (contact) - linked to Series B and hiring plans
-- Added insight: Acme Corp closing Series B next month
-- Added insight: Acme Corp planning to hire 50 engineers
-```
+2. Add your API key to `~/.openclaw/openclaw.json`:
+   ```json
+   {
+     "skills": {
+       "entries": {
+         "nex": {
+           "enabled": true,
+           "env": {
+             "NEX_API_KEY": "sk-your_key_here"
+           }
+         }
+       }
+     }
+   }
+   ```
+
+3. Verify: `openclaw agent --message "What skills do you have?"`
+
+Or skip the API key — the skill can auto-register on first use.
 
 ## API Documentation
 
 See [docs.nex.ai](https://docs.nex.ai) for full API documentation.
-
-## Support
-
-- GitHub Issues: [nex-crm/nex-as-a-skill/issues](https://github.com/nex-crm/nex-as-a-skill/issues)
-- OpenClaw Discord: #nex-skill channel
 
 ## License
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -144,7 +144,7 @@ Nex API responses (especially Insights and List Records) can be 10KB-100KB+. The
 
 ## API Scopes
 
-Each API key has scopes that control access. Request the scopes you need when creating your key at https://app.nex.ai/settings/developer
+Each API key has scopes that control access.
 
 | Scope | Grants Access To |
 |-------|-----------------|

--- a/SKILL.md
+++ b/SKILL.md
@@ -64,7 +64,7 @@ jq -e '.skills.entries.nex.env.NEX_API_KEY | type == "string" and length > 0' "$
 
 - All Nex Developer API calls are routed through a validated wrapper script (`scripts/nex-api.sh`)
 - OpenClaw registration calls must go through `scripts/nex-openclaw-register.sh`
-- The wrapper validates that all requests go to `http://localhost:3000/api/developers` only
+- The wrapper validates that all requests go to `http://localhost:30000/api/developers` only
 - API key is read from `$NEX_API_KEY` environment variable (never from prompts)
 - JSON request bodies are passed via stdin (`printf '%s'` pipe) to avoid shell injection
 - The wrapper uses `set -euo pipefail` for safe shell execution
@@ -80,7 +80,7 @@ jq -e '.skills.entries.nex.env.NEX_API_KEY | type == "string" and length > 0' "$
 | URL Pattern | Methods | Data Sent |
 |-------------|---------|-----------|
 | `POST /api/v1/openclaw/register` | POST | OpenClaw onboarding registration payload (`email`, optional `name`, optional `company_name`) |
-| `http://localhost:3000/api/developers/v1/*` | GET, POST, PUT, PATCH, DELETE | Context queries, records, insights, text content |
+| `http://localhost:30000/api/developers/v1/*` | GET, POST, PUT, PATCH, DELETE | Context queries, records, insights, text content |
 
 ## How to Make API Calls
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -64,7 +64,7 @@ jq -e '.skills.entries.nex.env.NEX_API_KEY | type == "string" and length > 0' "$
 
 - All Nex Developer API calls are routed through a validated wrapper script (`scripts/nex-api.sh`)
 - OpenClaw registration calls must go through `scripts/nex-openclaw-register.sh`
-- The wrapper validates that all requests go to `https://app.nex.ai/api/developers` only
+- The wrapper validates that all requests go to `http://localhost:3000/api/developers` only
 - API key is read from `$NEX_API_KEY` environment variable (never from prompts)
 - JSON request bodies are passed via stdin (`printf '%s'` pipe) to avoid shell injection
 - The wrapper uses `set -euo pipefail` for safe shell execution
@@ -80,7 +80,7 @@ jq -e '.skills.entries.nex.env.NEX_API_KEY | type == "string" and length > 0' "$
 | URL Pattern | Methods | Data Sent |
 |-------------|---------|-----------|
 | `POST /api/v1/openclaw/register` | POST | OpenClaw onboarding registration payload (`email`, optional `name`, optional `company_name`) |
-| `https://app.nex.ai/api/developers/v1/*` | GET, POST, PUT, PATCH, DELETE | Context queries, records, insights, text content |
+| `http://localhost:3000/api/developers/v1/*` | GET, POST, PUT, PATCH, DELETE | Context queries, records, insights, text content |
 
 ## How to Make API Calls
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -20,7 +20,7 @@ Run this flow only when `NEX_API_KEY` is missing.
 
 2. Register:
 - Command: `bash {baseDir}/scripts/nex-openclaw-register.sh <email> [name] [company_name]`
-- Endpoint used by script: `POST /api/v1/openclaw/register`
+- Endpoint used by script: `POST /api/v1/agents/register`
 - Expected response fields: `api_key`, `workspace_id`, `workspace_slug`, `plan`, issued limits/scopes metadata.
 
 3. Persist returned key before any Nex API call:
@@ -79,7 +79,7 @@ jq -e '.skills.entries.nex.env.NEX_API_KEY | type == "string" and length > 0' "$
 
 | URL Pattern | Methods | Data Sent |
 |-------------|---------|-----------|
-| `POST /api/v1/openclaw/register` | POST | OpenClaw onboarding registration payload (`email`, optional `name`, optional `company_name`) |
+| `POST /api/v1/agents/register` | POST | OpenClaw onboarding registration payload (`email`, optional `name`, optional `company_name`) |
 | `http://localhost:30000/api/developers/v1/*` | GET, POST, PUT, PATCH, DELETE | Context queries, records, insights, text content |
 
 ## How to Make API Calls

--- a/SKILL.md
+++ b/SKILL.md
@@ -15,12 +15,18 @@ Run this flow only when `NEX_API_KEY` is missing.
 1. Prompt user for registration fields:
 - Required: `email`
 - Optional: `name`, `company_name`
+- `source` is required by API and is sent by the script as `openclaw` (override with `NEX_AGENT_SOURCE` if needed).
 - Never infer/autofill from memory, prior chats, profile hints, defaults, or guesses.
 - If `email` is missing, stop and explain registration cannot proceed.
 
 2. Register:
 - Command: `bash {baseDir}/scripts/nex-openclaw-register.sh <email> [name] [company_name]`
 - Endpoint used by script: `POST /api/v1/agents/register`
+- Request payload sent by script:
+  - `email` (required)
+  - `source` (required)
+  - `name` (optional)
+  - `company_name` (optional)
 - Expected response fields: `api_key`, `workspace_id`, `workspace_slug`, `plan`, issued limits/scopes metadata.
 
 3. Persist returned key before any Nex API call:
@@ -79,7 +85,7 @@ jq -e '.skills.entries.nex.env.NEX_API_KEY | type == "string" and length > 0' "$
 
 | URL Pattern | Methods | Data Sent |
 |-------------|---------|-----------|
-| `POST /api/v1/agents/register` | POST | OpenClaw onboarding registration payload (`email`, optional `name`, optional `company_name`) |
+| `POST /api/v1/agents/register` | POST | OpenClaw onboarding registration payload (`email`, required `source`, optional `name`, optional `company_name`) |
 | `http://localhost:30000/api/developers/v1/*` | GET, POST, PUT, PATCH, DELETE | Context queries, records, insights, text content |
 
 ## How to Make API Calls

--- a/mcp/.env.example
+++ b/mcp/.env.example
@@ -1,0 +1,3 @@
+NEX_API_KEY=sk-your_key_here
+# MCP_TRANSPORT=http
+# MCP_PORT=3001

--- a/mcp/.gitignore
+++ b/mcp/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.env
+.env.local

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,241 @@
+# Nex MCP Server
+
+Give any MCP-compatible AI client access to your Nex CRM — contacts, companies, deals, notes, tasks, and the context graph.
+
+## Quick Start
+
+```bash
+cd mcp
+npm install
+npm run build
+```
+
+## Setup
+
+### Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `NEX_API_KEY` | Yes | — | Your Nex Developer API key |
+| `MCP_TRANSPORT` | No | `stdio` | Transport mode: `stdio` or `http` |
+| `MCP_PORT` | No | `3001` | HTTP server port (only when `MCP_TRANSPORT=http`) |
+
+### Get Your API Key
+
+1. Log in to [Nex](https://app.nex.ai)
+2. Go to **Settings > Developer**
+3. Create a new API key with `record.read` and `record.write` scopes
+
+## Client Configuration
+
+### Claude Desktop
+
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "nex": {
+      "command": "node",
+      "args": ["/absolute/path/to/nex-as-a-skill/mcp/dist/index.js"],
+      "env": {
+        "NEX_API_KEY": "nex_dev_your_key_here"
+      }
+    }
+  }
+}
+```
+
+### Claude Code
+
+```bash
+claude mcp add nex -- node /absolute/path/to/nex-as-a-skill/mcp/dist/index.js
+```
+
+Set the env var before launching, or add it to your shell profile:
+
+```bash
+export NEX_API_KEY="nex_dev_your_key_here"
+```
+
+### Cursor
+
+Add to `.cursor/mcp.json` in your project root (or `~/.cursor/mcp.json` for global):
+
+```json
+{
+  "mcpServers": {
+    "nex": {
+      "command": "node",
+      "args": ["/absolute/path/to/nex-as-a-skill/mcp/dist/index.js"],
+      "env": {
+        "NEX_API_KEY": "nex_dev_your_key_here"
+      }
+    }
+  }
+}
+```
+
+### ChatGPT (Desktop)
+
+ChatGPT uses Streamable HTTP transport. Start the server in HTTP mode:
+
+```bash
+NEX_API_KEY="nex_dev_your_key_here" MCP_TRANSPORT=http npm start
+```
+
+Then in ChatGPT Desktop, add a new MCP server pointing to:
+
+```
+http://localhost:3001/mcp
+```
+
+### Any Streamable HTTP Client
+
+Start the server in HTTP mode and point your client at the `/mcp` endpoint:
+
+```bash
+NEX_API_KEY="nex_dev_your_key_here" MCP_TRANSPORT=http MCP_PORT=3001 npm start
+```
+
+- MCP endpoint: `http://localhost:3001/mcp`
+- Health check: `http://localhost:3001/health`
+
+## Tools (46)
+
+### Context (5 tools)
+
+| Tool | Description |
+|------|-------------|
+| `query_context` | Ask natural language questions about contacts, companies, and relationships |
+| `add_context` | Ingest unstructured text (meeting notes, emails, transcripts) into the context graph |
+| `get_artifact_status` | Check processing status of a submitted text artifact |
+| `create_list_job` | AI-powered list generation from natural language queries |
+| `get_list_job_status` | Poll for AI list generation results |
+
+### Search (1 tool)
+
+| Tool | Description |
+|------|-------------|
+| `search_records` | Search records by name across all object types |
+
+### Schema (8 tools)
+
+| Tool | Description |
+|------|-------------|
+| `create_object` | Create a new custom object type (e.g. Project, Deal) |
+| `get_object` | Get an object type definition with its attributes |
+| `list_objects` | List all object type definitions in the workspace |
+| `update_object` | Update an object type definition |
+| `delete_object` | Delete an object type and all its records |
+| `create_attribute` | Add a field to an object type |
+| `update_attribute` | Update a field definition |
+| `delete_attribute` | Delete a field from an object type |
+
+### Records (7 tools)
+
+| Tool | Description |
+|------|-------------|
+| `create_record` | Create a new record for an object type |
+| `upsert_record` | Create or update a record with deduplication |
+| `get_record` | Retrieve a record by ID |
+| `update_record` | Update specific attributes on a record |
+| `delete_record` | Permanently delete a record |
+| `list_records` | List records with filtering, sorting, and pagination |
+| `get_record_timeline` | Get timeline events for a record |
+
+### Relationships (5 tools)
+
+| Tool | Description |
+|------|-------------|
+| `create_relationship_definition` | Define a relationship type between object types |
+| `list_relationship_definitions` | List all relationship type definitions |
+| `delete_relationship_definition` | Delete a relationship type and all its instances |
+| `create_relationship` | Link two records using a relationship definition |
+| `delete_relationship` | Remove a relationship between two records |
+
+### Lists (9 tools)
+
+| Tool | Description |
+|------|-------------|
+| `list_object_lists` | Get all lists for an object type |
+| `create_list` | Create a new list under an object type |
+| `get_list` | Get a list definition by ID |
+| `delete_list` | Delete a list |
+| `add_list_member` | Add a record to a list |
+| `upsert_list_member` | Add or update a record in a list |
+| `list_list_records` | Get paginated records from a list |
+| `update_list_record` | Update list-specific attributes for a record |
+| `delete_list_record` | Remove a record from a list |
+
+### Tasks (5 tools)
+
+| Tool | Description |
+|------|-------------|
+| `create_task` | Create a task, optionally linked to records |
+| `list_tasks` | List tasks with filtering and search |
+| `get_task` | Get a task by ID |
+| `update_task` | Update a task's fields |
+| `delete_task` | Archive a task |
+
+### Notes (5 tools)
+
+| Tool | Description |
+|------|-------------|
+| `create_note` | Create a note, optionally linked to a record |
+| `list_notes` | List notes, optionally filtered by record |
+| `get_note` | Get a note by ID |
+| `update_note` | Update a note's fields |
+| `delete_note` | Archive a note |
+
+### Insights (1 tool)
+
+| Tool | Description |
+|------|-------------|
+| `get_insights` | Query insights by time window (opportunities, risks, relationship changes) |
+
+## Development
+
+```bash
+# Run with hot reload
+npm run dev
+
+# Build
+npm run build
+
+# Run production
+npm start
+```
+
+### MCP Inspector
+
+Debug tools interactively using the MCP Inspector:
+
+```bash
+NEX_API_KEY="nex_dev_your_key_here" npm run inspect
+```
+
+This opens a browser UI where you can list tools, call them with test inputs, and inspect responses.
+
+## Architecture
+
+```
+src/
+  index.ts          # Entry point — stdio or HTTP transport
+  server.ts         # McpServer creation and tool registration
+  client.ts         # Nex Developer API HTTP client
+  tools/
+    context.ts      # Context graph: query, ingest, artifacts, AI lists
+    search.ts       # Cross-object search
+    schema.ts       # Object types and attributes (CRUD)
+    records.ts      # Records (CRUD + timeline)
+    relationships.ts # Relationship definitions and instances
+    lists.ts        # List management and membership
+    tasks.ts        # Task management
+    notes.ts        # Note management
+    insights.ts     # Insight queries
+```
+
+## License
+
+MIT

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,0 +1,1724 @@
+{
+  "name": "@nex-crm/mcp-server",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@nex-crm/mcp-server",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.0",
+        "zod": "^3.25.0"
+      },
+      "bin": {
+        "nex-mcp": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "tsx": "^4.19.0",
+        "typescript": "^5.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
+      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.0.tgz",
+      "integrity": "sha512-qOdO524oPMkUsOJTrsH9vz/HN3B5pKyW+9zIW51A9kDMVe7ON70drz1ouoyoyOcfzc+oxhkQ6jWmbyKnlWmYqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
+      "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
+      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.2.tgz",
+      "integrity": "sha512-gJnaDHXKDayjt8ue0n8Gs0A007yKXj4Xzb8+cNjZeYsSzzwKc0Lr+OZgYwVfB0pHfUs17EPoLvrOsEaJ9mj+Tg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
+      }
+    }
+  }
+}

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@nex-crm/mcp-server",
+  "version": "0.1.0",
+  "description": "Nex MCP server — use Nex as a tool in Claude Desktop, ChatGPT, Cursor, and any MCP client",
+  "type": "module",
+  "bin": {
+    "nex-mcp": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts",
+    "inspect": "npx @modelcontextprotocol/inspector tsx src/index.ts"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "zod": "^3.25.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.7.0"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "license": "MIT"
+}

--- a/mcp/src/client.ts
+++ b/mcp/src/client.ts
@@ -1,0 +1,130 @@
+const BASE_URL = "http://localhost:30000/api/developers";
+const REGISTER_URL = "http://localhost:30000/api/v1/agents/register";
+
+export class NexApiError extends Error {
+  constructor(
+    public status: number,
+    public statusText: string,
+    public body: unknown,
+  ) {
+    super(`Nex API error ${status}: ${statusText}`);
+    this.name = "NexApiError";
+  }
+}
+
+export class NexApiClient {
+  private apiKey: string | undefined;
+
+  constructor(apiKey?: string) {
+    this.apiKey = apiKey;
+  }
+
+  get isAuthenticated(): boolean {
+    return this.apiKey !== undefined && this.apiKey.length > 0;
+  }
+
+  setApiKey(key: string): void {
+    this.apiKey = key;
+  }
+
+  private requireAuth(): void {
+    if (!this.isAuthenticated) {
+      throw new NexApiError(401, "Not registered", {
+        message: "No API key configured. Call the 'register' tool first with your email to get an API key.",
+      });
+    }
+  }
+
+  private async request(
+    method: string,
+    path: string,
+    body?: unknown,
+  ): Promise<unknown> {
+    this.requireAuth();
+    const url = `${BASE_URL}${path}`;
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${this.apiKey}`,
+    };
+    if (body !== undefined) {
+      headers["Content-Type"] = "application/json";
+    }
+
+    const res = await fetch(url, {
+      method,
+      headers,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+      signal: AbortSignal.timeout(120_000),
+    });
+
+    if (!res.ok) {
+      let errorBody: unknown;
+      try {
+        errorBody = await res.json();
+      } catch {
+        errorBody = await res.text();
+      }
+      throw new NexApiError(res.status, res.statusText, errorBody);
+    }
+
+    const text = await res.text();
+    if (!text) return {};
+    try {
+      return JSON.parse(text);
+    } catch {
+      return { message: text };
+    }
+  }
+
+  async register(email: string, name?: string, companyName?: string, source?: string): Promise<unknown> {
+    const body: Record<string, string> = {
+      email,
+      source: source ?? "mcp",
+    };
+    if (name !== undefined) body.name = name;
+    if (companyName !== undefined) body.company_name = companyName;
+
+    const res = await fetch(REGISTER_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(120_000),
+    });
+
+    if (!res.ok) {
+      let errorBody: unknown;
+      try {
+        errorBody = await res.json();
+      } catch {
+        errorBody = await res.text();
+      }
+      throw new NexApiError(res.status, res.statusText, errorBody);
+    }
+
+    const data = await res.json();
+    const apiKey = (data as Record<string, unknown>).api_key;
+    if (typeof apiKey === "string" && apiKey.length > 0) {
+      this.apiKey = apiKey;
+    }
+    return data;
+  }
+
+  async get(path: string): Promise<unknown> {
+    return this.request("GET", path);
+  }
+
+  async post(path: string, body?: unknown): Promise<unknown> {
+    return this.request("POST", path, body);
+  }
+
+  async put(path: string, body?: unknown): Promise<unknown> {
+    return this.request("PUT", path, body);
+  }
+
+  async patch(path: string, body?: unknown): Promise<unknown> {
+    return this.request("PATCH", path, body);
+  }
+
+  async delete(path: string): Promise<unknown> {
+    return this.request("DELETE", path);
+  }
+}

--- a/mcp/src/config.ts
+++ b/mcp/src/config.ts
@@ -1,0 +1,42 @@
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, dirname } from "node:path";
+
+const CONFIG_PATH = join(homedir(), ".nex-mcp.json");
+
+interface NexMcpConfig {
+  api_key?: string;
+  workspace_id?: string;
+  workspace_slug?: string;
+  [key: string]: unknown;
+}
+
+export function loadConfig(): NexMcpConfig {
+  try {
+    const raw = readFileSync(CONFIG_PATH, "utf-8");
+    return JSON.parse(raw) as NexMcpConfig;
+  } catch {
+    return {};
+  }
+}
+
+export function saveConfig(config: NexMcpConfig): void {
+  mkdirSync(dirname(CONFIG_PATH), { recursive: true });
+  writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2) + "\n", "utf-8");
+}
+
+export function loadApiKey(): string | undefined {
+  return process.env.NEX_API_KEY || loadConfig().api_key || undefined;
+}
+
+export function persistRegistration(data: Record<string, unknown>): void {
+  const existing = loadConfig();
+  if (typeof data.api_key === "string") existing.api_key = data.api_key;
+  if (typeof data.workspace_id === "string" || typeof data.workspace_id === "number") {
+    existing.workspace_id = String(data.workspace_id);
+  }
+  if (typeof data.workspace_slug === "string") existing.workspace_slug = data.workspace_slug;
+  saveConfig(existing);
+}
+
+export { CONFIG_PATH };

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { createServer } from "./server.js";
+import { createServer as createHttpServer } from "node:http";
+import { loadApiKey } from "./config.js";
+
+const apiKey = loadApiKey();
+if (!apiKey) {
+  console.error("No API key found (checked NEX_API_KEY env and ~/.nex-mcp.json). Starting in registration mode — use the 'register' tool to get an API key.");
+}
+
+const transport = process.env.MCP_TRANSPORT ?? "stdio";
+
+async function main() {
+  const server = createServer(apiKey);
+
+  if (transport === "http") {
+    const port = parseInt(process.env.MCP_PORT ?? "3001", 10);
+
+    const httpTransport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+    });
+
+    const httpServer = createHttpServer(async (req, res) => {
+      const url = new URL(req.url ?? "/", `http://localhost:${port}`);
+      if (url.pathname === "/mcp") {
+        await httpTransport.handleRequest(req, res);
+      } else if (url.pathname === "/health") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ status: "ok" }));
+      } else {
+        res.writeHead(404);
+        res.end("Not found");
+      }
+    });
+
+    await server.connect(httpTransport);
+    httpServer.listen(port, () => {
+      console.error(`Nex MCP server running on http://localhost:${port}/mcp`);
+    });
+  } else {
+    const stdioTransport = new StdioServerTransport();
+    await server.connect(stdioTransport);
+    console.error("Nex MCP server running on stdio");
+  }
+}
+
+main().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exit(1);
+});

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -1,0 +1,34 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { NexApiClient } from "./client.js";
+import { registerContextTools } from "./tools/context.js";
+import { registerSearchTools } from "./tools/search.js";
+import { registerSchemaTools } from "./tools/schema.js";
+import { registerRecordTools } from "./tools/records.js";
+import { registerRelationshipTools } from "./tools/relationships.js";
+import { registerListTools } from "./tools/lists.js";
+import { registerTaskTools } from "./tools/tasks.js";
+import { registerNoteTools } from "./tools/notes.js";
+import { registerInsightTools } from "./tools/insights.js";
+import { registerRegistrationTools } from "./tools/register.js";
+
+export function createServer(apiKey?: string): McpServer {
+  const server = new McpServer({
+    name: "nex",
+    version: "0.1.0",
+  });
+
+  const client = new NexApiClient(apiKey);
+
+  registerRegistrationTools(server, client);
+  registerContextTools(server, client);
+  registerSearchTools(server, client);
+  registerSchemaTools(server, client);
+  registerRecordTools(server, client);
+  registerRelationshipTools(server, client);
+  registerListTools(server, client);
+  registerTaskTools(server, client);
+  registerNoteTools(server, client);
+  registerInsightTools(server, client);
+
+  return server;
+}

--- a/mcp/src/tools/context.ts
+++ b/mcp/src/tools/context.ts
@@ -1,0 +1,81 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { NexApiClient } from "../client.js";
+
+export function registerContextTools(server: McpServer, client: NexApiClient) {
+  server.tool(
+    "query_context",
+    "Query the Nex context graph with a natural language question. Returns an AI-generated answer with supporting entities and evidence. Use for open-ended questions about contacts, companies, relationships, or history.",
+    { query: z.string().describe("Natural language question about your contacts, companies, or relationships") },
+    { readOnlyHint: true, openWorldHint: true },
+    async ({ query }) => {
+      const result = await client.post("/v1/context/ask", { query });
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "add_context",
+    "Ingest unstructured text (meeting notes, emails, conversation transcripts) into the Nex context graph. Automatically extracts entities, relationships, and insights. Returns an artifact_id — use get_artifact_status to check processing results.",
+    {
+      content: z.string().describe("The text content to process (meeting notes, email, conversation transcript, etc.)"),
+      context: z.string().optional().describe("Additional context about the text, e.g. 'Sales call notes' or 'Email from client'"),
+    },
+    { readOnlyHint: false },
+    async ({ content, context }) => {
+      const body: Record<string, string> = { content };
+      if (context !== undefined) body.context = context;
+      const result = await client.post("/v1/context/text", body);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "get_artifact_status",
+    "Check the processing status and results of a previously submitted text artifact. Poll until status is 'completed' or 'failed'. Returns extracted entities, relationships, and insights.",
+    { artifact_id: z.string().describe("The artifact ID returned by add_context") },
+    { readOnlyHint: true },
+    async ({ artifact_id }) => {
+      const result = await client.get(`/v1/context/artifacts/${encodeURIComponent(artifact_id)}`);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "create_list_job",
+    "Create an AI-powered list generation job. Uses natural language to search the context graph and generate a curated list of contacts or companies. Returns a job_id — use get_list_job_status to poll for results.",
+    {
+      query: z.string().describe("Natural language description of the list you want, e.g. 'high priority contacts in enterprise deals'"),
+      object_type: z.enum(["contact", "company"]).optional().describe("Type of entities to search for (default: contact)"),
+      limit: z.number().optional().describe("Maximum number of results (default: 50, max: 100)"),
+      include_attributes: z.boolean().optional().describe("Include full attribute values for each entity"),
+    },
+    { readOnlyHint: false },
+    async ({ query, object_type, limit, include_attributes }) => {
+      const body: Record<string, unknown> = { query };
+      if (object_type) body.object_type = object_type;
+      if (limit !== undefined) body.limit = limit;
+      if (include_attributes !== undefined) body.include_attributes = include_attributes;
+      const result = await client.post("/v1/context/list/jobs", body);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "get_list_job_status",
+    "Check the status and results of an AI list generation job. Poll until status is 'completed' or 'failed'. Returns matched entities with reasons and highlights.",
+    {
+      job_id: z.string().describe("The job ID returned by create_list_job"),
+      include_attributes: z.boolean().optional().describe("Include full attribute values for each entity"),
+    },
+    { readOnlyHint: true },
+    async ({ job_id, include_attributes }) => {
+      const params = new URLSearchParams();
+      if (include_attributes) params.set("include_attributes", "true");
+      const qs = params.toString();
+      const path = `/v1/context/list/jobs/${encodeURIComponent(job_id)}${qs ? `?${qs}` : ""}`;
+      const result = await client.get(path);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}

--- a/mcp/src/tools/insights.ts
+++ b/mcp/src/tools/insights.ts
@@ -1,0 +1,28 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { NexApiClient } from "../client.js";
+
+export function registerInsightTools(server: McpServer, client: NexApiClient) {
+  server.tool(
+    "get_insights",
+    "Query insights by time window. Returns discovered opportunities, risks, relationship changes, milestones, and other insights. Use 'last' for a duration window (e.g. '30m', '2h') or 'from'/'to' for an absolute time range.",
+    {
+      last: z.string().optional().describe("Duration window, e.g. '30m', '2h', '1h30m'"),
+      from: z.string().optional().describe("Start of time range in RFC3339 format"),
+      to: z.string().optional().describe("End of time range in RFC3339 format"),
+      limit: z.number().optional().describe("Max results (default: 20, max: 100)"),
+    },
+    { readOnlyHint: true },
+    async ({ last, from, to, limit }) => {
+      const params = new URLSearchParams();
+      if (last) params.set("last", last);
+      if (from) params.set("from", from);
+      if (to) params.set("to", to);
+      if (limit !== undefined) params.set("limit", String(limit));
+      const qs = params.toString();
+      const path = `/v1/insights${qs ? `?${qs}` : ""}`;
+      const result = await client.get(path);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}

--- a/mcp/src/tools/lists.ts
+++ b/mcp/src/tools/lists.ts
@@ -1,0 +1,156 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { NexApiClient } from "../client.js";
+
+export function registerListTools(server: McpServer, client: NexApiClient) {
+  server.tool(
+    "list_object_lists",
+    "Get all lists associated with an object type.",
+    {
+      object_slug: z.string().describe("Object type slug (e.g. 'person', 'company')"),
+      include_attributes: z.boolean().optional().describe("Include attribute definitions"),
+    },
+    { readOnlyHint: true },
+    async ({ object_slug, include_attributes }) => {
+      const params = new URLSearchParams();
+      if (include_attributes) params.set("include_attributes", "true");
+      const qs = params.toString();
+      const path = `/v1/objects/${encodeURIComponent(object_slug)}/lists${qs ? `?${qs}` : ""}`;
+      const result = await client.get(path);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "create_list",
+    "Create a new list under an object type.",
+    {
+      object_slug: z.string().describe("Object type slug"),
+      name: z.string().describe("List display name"),
+      slug: z.string().describe("URL-safe identifier"),
+      name_plural: z.string().optional().describe("Plural name"),
+      description: z.string().optional().describe("List description"),
+    },
+    { readOnlyHint: false },
+    async ({ object_slug, name, slug, name_plural, description }) => {
+      const body: Record<string, unknown> = { name, slug };
+      if (name_plural !== undefined) body.name_plural = name_plural;
+      if (description !== undefined) body.description = description;
+      const result = await client.post(`/v1/objects/${encodeURIComponent(object_slug)}/lists`, body);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "get_list",
+    "Get a list definition by ID.",
+    { list_id: z.string().describe("List ID") },
+    { readOnlyHint: true },
+    async ({ list_id }) => {
+      const result = await client.get(`/v1/lists/${encodeURIComponent(list_id)}`);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "delete_list",
+    "Delete a list definition. Cannot be undone.",
+    { list_id: z.string().describe("List ID to delete") },
+    { readOnlyHint: false, destructiveHint: true },
+    async ({ list_id }) => {
+      const result = await client.delete(`/v1/lists/${encodeURIComponent(list_id)}`);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "add_list_member",
+    "Add an existing record to a list with optional list-specific attributes.",
+    {
+      list_id: z.string().describe("List ID"),
+      parent_id: z.string().describe("ID of the existing record to add"),
+      attributes: z.record(z.unknown()).optional().describe("List-specific attribute values"),
+    },
+    { readOnlyHint: false },
+    async ({ list_id, parent_id, attributes }) => {
+      const body: Record<string, unknown> = { parent_id };
+      if (attributes) body.attributes = attributes;
+      const result = await client.post(`/v1/lists/${encodeURIComponent(list_id)}`, body);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "upsert_list_member",
+    "Add a record to a list, or update its list-specific attributes if already a member.",
+    {
+      list_id: z.string().describe("List ID"),
+      parent_id: z.string().describe("ID of the record"),
+      attributes: z.record(z.unknown()).optional().describe("List-specific attribute values"),
+    },
+    { readOnlyHint: false, idempotentHint: true },
+    async ({ list_id, parent_id, attributes }) => {
+      const body: Record<string, unknown> = { parent_id };
+      if (attributes) body.attributes = attributes;
+      const result = await client.put(`/v1/lists/${encodeURIComponent(list_id)}`, body);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "list_list_records",
+    "Get paginated records from a specific list.",
+    {
+      list_id: z.string().describe("List ID"),
+      attributes: z.union([
+        z.enum(["all", "primary", "none"]),
+        z.record(z.unknown()),
+      ]).optional().describe("Which attributes to return"),
+      limit: z.number().optional().describe("Number of records to return"),
+      offset: z.number().optional().describe("Pagination offset"),
+      sort: z.object({
+        attribute: z.string(),
+        direction: z.enum(["asc", "desc"]),
+      }).optional().describe("Sort configuration"),
+    },
+    { readOnlyHint: true },
+    async ({ list_id, attributes, limit, offset, sort }) => {
+      const body: Record<string, unknown> = {};
+      if (attributes !== undefined) body.attributes = attributes;
+      if (limit !== undefined) body.limit = limit;
+      if (offset !== undefined) body.offset = offset;
+      if (sort) body.sort = sort;
+      const result = await client.post(`/v1/lists/${encodeURIComponent(list_id)}/records`, body);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "update_list_record",
+    "Update list-specific attributes for a record within a list.",
+    {
+      list_id: z.string().describe("List ID"),
+      record_id: z.string().describe("Record ID within the list"),
+      attributes: z.record(z.unknown()).describe("Attributes to update"),
+    },
+    { readOnlyHint: false },
+    async ({ list_id, record_id, attributes }) => {
+      const result = await client.patch(`/v1/lists/${encodeURIComponent(list_id)}/records/${encodeURIComponent(record_id)}`, { attributes });
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "delete_list_record",
+    "Remove a record from a list. The record itself is not deleted.",
+    {
+      list_id: z.string().describe("List ID"),
+      record_id: z.string().describe("Record ID to remove from the list"),
+    },
+    { readOnlyHint: false, destructiveHint: true },
+    async ({ list_id, record_id }) => {
+      const result = await client.delete(`/v1/lists/${encodeURIComponent(list_id)}/records/${encodeURIComponent(record_id)}`);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}

--- a/mcp/src/tools/notes.ts
+++ b/mcp/src/tools/notes.ts
@@ -1,0 +1,82 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { NexApiClient } from "../client.js";
+
+export function registerNoteTools(server: McpServer, client: NexApiClient) {
+  server.tool(
+    "create_note",
+    "Create a new note, optionally linked to a record.",
+    {
+      title: z.string().min(1).describe("Note title"),
+      content: z.string().optional().describe("Note body text"),
+      entity_id: z.string().optional().describe("Associated record ID"),
+    },
+    { readOnlyHint: false },
+    async ({ title, content, entity_id }) => {
+      const body: Record<string, unknown> = { title };
+      if (content !== undefined) body.content = content;
+      if (entity_id !== undefined) body.entity_id = entity_id;
+      const result = await client.post("/v1/notes", body);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "list_notes",
+    "List notes, optionally filtered by associated record. Returns up to 200 notes.",
+    {
+      entity_id: z.string().optional().describe("Filter notes by associated record ID"),
+    },
+    { readOnlyHint: true },
+    async ({ entity_id }) => {
+      const params = new URLSearchParams();
+      if (entity_id) params.set("entity_id", entity_id);
+      const qs = params.toString();
+      const path = `/v1/notes${qs ? `?${qs}` : ""}`;
+      const result = await client.get(path);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "get_note",
+    "Get a single note by ID.",
+    { note_id: z.string().describe("Note ID") },
+    { readOnlyHint: true },
+    async ({ note_id }) => {
+      const result = await client.get(`/v1/notes/${encodeURIComponent(note_id)}`);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "update_note",
+    "Update a note's fields. All fields are optional — only provided fields are changed.",
+    {
+      note_id: z.string().describe("Note ID to update"),
+      title: z.string().optional().describe("New title"),
+      content: z.string().optional().describe("New content"),
+      entity_id: z.string().optional().describe("Change associated record"),
+    },
+    { readOnlyHint: false },
+    async ({ note_id, title, content, entity_id }) => {
+      const body: Record<string, unknown> = {};
+      if (title !== undefined) body.title = title;
+      if (content !== undefined) body.content = content;
+      if (entity_id !== undefined) body.entity_id = entity_id;
+      const result = await client.patch(`/v1/notes/${encodeURIComponent(note_id)}`, body);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "delete_note",
+    "Archive a note (soft delete). Cannot be undone via API.",
+    { note_id: z.string().describe("Note ID to delete") },
+    { readOnlyHint: false, destructiveHint: true },
+    async ({ note_id }) => {
+      const result = await client.delete(`/v1/notes/${encodeURIComponent(note_id)}`);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}

--- a/mcp/src/tools/records.ts
+++ b/mcp/src/tools/records.ts
@@ -1,0 +1,118 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { NexApiClient } from "../client.js";
+
+export function registerRecordTools(server: McpServer, client: NexApiClient) {
+  server.tool(
+    "create_record",
+    "Create a new record for an object type. Use only when you have clean, structured data with known attribute slugs. For unstructured text, use add_context instead.",
+    {
+      object_slug: z.string().describe("Object type slug (e.g. 'person', 'company')"),
+      attributes: z.record(z.unknown()).describe("Record attributes — must include 'name'. Additional fields depend on the object schema."),
+    },
+    { readOnlyHint: false },
+    async ({ object_slug, attributes }) => {
+      const result = await client.post(`/v1/objects/${encodeURIComponent(object_slug)}`, { attributes });
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "upsert_record",
+    "Create a record if it doesn't exist, or update it if a match is found on the specified attribute. Useful for deduplication (e.g. match on email).",
+    {
+      object_slug: z.string().describe("Object type slug (e.g. 'person', 'company')"),
+      matching_attribute: z.string().describe("Attribute slug or ID to match on for dedup (e.g. 'email')"),
+      attributes: z.record(z.unknown()).describe("Record attributes — must include 'name' when creating"),
+    },
+    { readOnlyHint: false, idempotentHint: true },
+    async ({ object_slug, matching_attribute, attributes }) => {
+      const result = await client.put(`/v1/objects/${encodeURIComponent(object_slug)}`, { matching_attribute, attributes });
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "get_record",
+    "Retrieve a specific record by its ID, including all its attributes.",
+    { record_id: z.string().describe("Record ID") },
+    { readOnlyHint: true },
+    async ({ record_id }) => {
+      const result = await client.get(`/v1/records/${encodeURIComponent(record_id)}`);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "update_record",
+    "Update specific attributes on an existing record. Only the provided attributes are changed.",
+    {
+      record_id: z.string().describe("Record ID to update"),
+      attributes: z.record(z.unknown()).describe("Attributes to update (only provided fields are changed)"),
+    },
+    { readOnlyHint: false },
+    async ({ record_id, attributes }) => {
+      const result = await client.patch(`/v1/records/${encodeURIComponent(record_id)}`, { attributes });
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "delete_record",
+    "Permanently delete a record. This cannot be undone.",
+    { record_id: z.string().describe("Record ID to delete") },
+    { readOnlyHint: false, destructiveHint: true },
+    async ({ record_id }) => {
+      const result = await client.delete(`/v1/records/${encodeURIComponent(record_id)}`);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "list_records",
+    "List records for an object type with optional filtering, sorting, and pagination.",
+    {
+      object_slug: z.string().describe("Object type slug (e.g. 'person', 'company')"),
+      attributes: z.union([
+        z.enum(["all", "primary", "none"]),
+        z.record(z.unknown()),
+      ]).optional().describe("Which attributes to return: 'all', 'primary', 'none', or a custom object"),
+      limit: z.number().optional().describe("Number of records to return"),
+      offset: z.number().optional().describe("Pagination offset"),
+      sort: z.object({
+        attribute: z.string().describe("Attribute slug to sort by"),
+        direction: z.enum(["asc", "desc"]).describe("Sort direction"),
+      }).optional().describe("Sort configuration"),
+    },
+    { readOnlyHint: true },
+    async ({ object_slug, attributes, limit, offset, sort }) => {
+      const body: Record<string, unknown> = {};
+      if (attributes !== undefined) body.attributes = attributes;
+      if (limit !== undefined) body.limit = limit;
+      if (offset !== undefined) body.offset = offset;
+      if (sort) body.sort = sort;
+      const result = await client.post(`/v1/objects/${encodeURIComponent(object_slug)}/records`, body);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "get_record_timeline",
+    "Get paginated timeline events for a record (tasks, notes, attribute changes, etc.).",
+    {
+      record_id: z.string().describe("Record ID"),
+      limit: z.number().optional().describe("Max events (1-100, default: 50)"),
+      cursor: z.string().optional().describe("Pagination cursor from previous response"),
+    },
+    { readOnlyHint: true },
+    async ({ record_id, limit, cursor }) => {
+      const params = new URLSearchParams();
+      if (limit !== undefined) params.set("limit", String(limit));
+      if (cursor) params.set("cursor", cursor);
+      const qs = params.toString();
+      const path = `/v1/records/${encodeURIComponent(record_id)}/timeline${qs ? `?${qs}` : ""}`;
+      const result = await client.get(path);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}

--- a/mcp/src/tools/register.ts
+++ b/mcp/src/tools/register.ts
@@ -1,0 +1,38 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { NexApiClient } from "../client.js";
+import { persistRegistration, CONFIG_PATH } from "../config.js";
+
+export function registerRegistrationTools(server: McpServer, client: NexApiClient) {
+  server.tool(
+    "register",
+    `Register for a Nex API key. Call this first if no NEX_API_KEY is configured. Requires the user's email. After successful registration, the API key is saved to ${CONFIG_PATH} and all other tools become available immediately. Returns the API key, workspace info, and plan details.`,
+    {
+      email: z.string().email().describe("User's email address (required for registration)"),
+      name: z.string().optional().describe("User's full name"),
+      company_name: z.string().optional().describe("Company or organization name"),
+    },
+    { readOnlyHint: false },
+    async ({ email, name, company_name }) => {
+      if (client.isAuthenticated) {
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({ message: "Already registered. API key is configured and active. You can use all other tools." }),
+          }],
+        };
+      }
+      const result = await client.register(email, name, company_name);
+      persistRegistration(result as Record<string, unknown>);
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify({
+            ...(result as Record<string, unknown>),
+            _config_saved_to: CONFIG_PATH,
+          }, null, 2),
+        }],
+      };
+    },
+  );
+}

--- a/mcp/src/tools/relationships.ts
+++ b/mcp/src/tools/relationships.ts
@@ -1,0 +1,81 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { NexApiClient } from "../client.js";
+
+export function registerRelationshipTools(server: McpServer, client: NexApiClient) {
+  server.tool(
+    "create_relationship_definition",
+    "Define a new relationship type between two object types (e.g. person 'works at' company).",
+    {
+      type: z.enum(["one_to_one", "one_to_many", "many_to_many"]).describe("Relationship cardinality"),
+      entity_definition_1_id: z.string().describe("First object definition ID"),
+      entity_definition_2_id: z.string().describe("Second object definition ID"),
+      entity_1_to_2_predicate: z.string().optional().describe("Label for 1→2 direction (e.g. 'works at')"),
+      entity_2_to_1_predicate: z.string().optional().describe("Label for 2→1 direction (e.g. 'employs')"),
+    },
+    { readOnlyHint: false },
+    async ({ type, entity_definition_1_id, entity_definition_2_id, entity_1_to_2_predicate, entity_2_to_1_predicate }) => {
+      const body: Record<string, unknown> = { type, entity_definition_1_id, entity_definition_2_id };
+      if (entity_1_to_2_predicate !== undefined) body.entity_1_to_2_predicate = entity_1_to_2_predicate;
+      if (entity_2_to_1_predicate !== undefined) body.entity_2_to_1_predicate = entity_2_to_1_predicate;
+      const result = await client.post("/v1/relationships", body);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "list_relationship_definitions",
+    "List all relationship type definitions in the workspace.",
+    {},
+    { readOnlyHint: true },
+    async () => {
+      const result = await client.get("/v1/relationships");
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "delete_relationship_definition",
+    "Delete a relationship type definition. This removes all instances of this relationship. Cannot be undone.",
+    { id: z.string().describe("Relationship definition ID to delete") },
+    { readOnlyHint: false, destructiveHint: true },
+    async ({ id }) => {
+      const result = await client.delete(`/v1/relationships/${encodeURIComponent(id)}`);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "create_relationship",
+    "Link two records using an existing relationship definition.",
+    {
+      record_id: z.string().describe("Record ID to create the relationship from (used in the URL path)"),
+      definition_id: z.string().describe("Relationship definition ID"),
+      entity_1_id: z.string().describe("First record ID"),
+      entity_2_id: z.string().describe("Second record ID"),
+    },
+    { readOnlyHint: false },
+    async ({ record_id, definition_id, entity_1_id, entity_2_id }) => {
+      const result = await client.post(`/v1/records/${encodeURIComponent(record_id)}/relationships`, {
+        definition_id,
+        entity_1_id,
+        entity_2_id,
+      });
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "delete_relationship",
+    "Remove a relationship between two records. Cannot be undone.",
+    {
+      record_id: z.string().describe("Record ID"),
+      relationship_id: z.string().describe("Relationship instance ID to delete"),
+    },
+    { readOnlyHint: false, destructiveHint: true },
+    async ({ record_id, relationship_id }) => {
+      const result = await client.delete(`/v1/records/${encodeURIComponent(record_id)}/relationships/${encodeURIComponent(relationship_id)}`);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}

--- a/mcp/src/tools/schema.ts
+++ b/mcp/src/tools/schema.ts
@@ -1,0 +1,153 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { NexApiClient } from "../client.js";
+
+export function registerSchemaTools(server: McpServer, client: NexApiClient) {
+  server.tool(
+    "create_object",
+    "Create a new custom object type definition (e.g. 'Project', 'Deal'). Defines the schema for a new entity type in your workspace.",
+    {
+      name: z.string().describe("Display name for the object type"),
+      slug: z.string().describe("URL-safe identifier (lowercase, hyphens)"),
+      name_plural: z.string().optional().describe("Plural display name"),
+      description: z.string().optional().describe("Description of the object type"),
+      type: z.enum(["person", "company", "custom", "deal"]).optional().describe("Object category (default: custom)"),
+    },
+    { readOnlyHint: false },
+    async ({ name, slug, name_plural, description, type }) => {
+      const body: Record<string, unknown> = { name, slug };
+      if (name_plural !== undefined) body.name_plural = name_plural;
+      if (description !== undefined) body.description = description;
+      if (type !== undefined) body.type = type;
+      const result = await client.post("/v1/objects", body);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "get_object",
+    "Get a single object type definition with its attributes. Use this to discover available fields before creating or querying records.",
+    { slug: z.string().describe("Object type slug (e.g. 'person', 'company', 'deal')") },
+    { readOnlyHint: true },
+    async ({ slug }) => {
+      const result = await client.get(`/v1/objects/${encodeURIComponent(slug)}`);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "list_objects",
+    "List all object type definitions in the workspace. Call this first to discover available object types and their schemas before creating or querying records.",
+    {
+      include_attributes: z.boolean().optional().describe("Include attribute definitions in the response"),
+    },
+    { readOnlyHint: true },
+    async ({ include_attributes }) => {
+      const params = new URLSearchParams();
+      if (include_attributes) params.set("include_attributes", "true");
+      const qs = params.toString();
+      const path = `/v1/objects${qs ? `?${qs}` : ""}`;
+      const result = await client.get(path);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "update_object",
+    "Update an existing object type definition (name, description, plural name).",
+    {
+      slug: z.string().describe("Object type slug to update"),
+      name: z.string().optional().describe("New display name"),
+      name_plural: z.string().optional().describe("New plural display name"),
+      description: z.string().optional().describe("New description"),
+    },
+    { readOnlyHint: false },
+    async ({ slug, name, name_plural, description }) => {
+      const body: Record<string, unknown> = {};
+      if (name !== undefined) body.name = name;
+      if (name_plural !== undefined) body.name_plural = name_plural;
+      if (description !== undefined) body.description = description;
+      const result = await client.patch(`/v1/objects/${encodeURIComponent(slug)}`, body);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "delete_object",
+    "Delete an object type definition and ALL its records. This is destructive and cannot be undone.",
+    { slug: z.string().describe("Object type slug to delete") },
+    { readOnlyHint: false, destructiveHint: true },
+    async ({ slug }) => {
+      const result = await client.delete(`/v1/objects/${encodeURIComponent(slug)}`);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "create_attribute",
+    "Add a new attribute (field) to an object type. Supports types: text, number, email, phone, url, date, boolean, currency, location, select, social_profile, domain, full_name.",
+    {
+      object_slug: z.string().describe("Object type slug to add the attribute to"),
+      name: z.string().describe("Display name for the attribute"),
+      slug: z.string().describe("URL-safe identifier for the attribute"),
+      type: z.enum(["text", "number", "email", "phone", "url", "date", "boolean", "currency", "location", "select", "social_profile", "domain", "full_name"]).describe("Attribute data type"),
+      description: z.string().optional().describe("Description of the attribute"),
+      options: z.object({
+        is_required: z.boolean().optional(),
+        is_unique: z.boolean().optional(),
+        is_multi_value: z.boolean().optional(),
+        use_raw_format: z.boolean().optional(),
+        is_whole_number: z.boolean().optional(),
+        select_options: z.array(z.object({ name: z.string() })).optional(),
+      }).optional().describe("Attribute options"),
+    },
+    { readOnlyHint: false },
+    async ({ object_slug, name, slug, type, description, options }) => {
+      const body: Record<string, unknown> = { name, slug, type };
+      if (description !== undefined) body.description = description;
+      if (options) body.options = options;
+      const result = await client.post(`/v1/objects/${encodeURIComponent(object_slug)}/attributes`, body);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "update_attribute",
+    "Update an existing attribute definition on an object type.",
+    {
+      object_slug: z.string().describe("Object type slug"),
+      attribute_id: z.string().describe("Attribute ID to update"),
+      name: z.string().optional().describe("New display name"),
+      description: z.string().optional().describe("New description"),
+      options: z.object({
+        is_required: z.boolean().optional(),
+        select_options: z.array(z.object({ name: z.string() })).optional(),
+        use_raw_format: z.boolean().optional(),
+        is_whole_number: z.boolean().optional(),
+      }).optional().describe("Updated options"),
+    },
+    { readOnlyHint: false },
+    async ({ object_slug, attribute_id, name, description, options }) => {
+      const body: Record<string, unknown> = {};
+      if (name !== undefined) body.name = name;
+      if (description !== undefined) body.description = description;
+      if (options) body.options = options;
+      const result = await client.patch(`/v1/objects/${encodeURIComponent(object_slug)}/attributes/${encodeURIComponent(attribute_id)}`, body);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "delete_attribute",
+    "Delete an attribute from an object type. This removes the field and its data from all records. Cannot be undone.",
+    {
+      object_slug: z.string().describe("Object type slug"),
+      attribute_id: z.string().describe("Attribute ID to delete"),
+    },
+    { readOnlyHint: false, destructiveHint: true },
+    async ({ object_slug, attribute_id }) => {
+      const result = await client.delete(`/v1/objects/${encodeURIComponent(object_slug)}/attributes/${encodeURIComponent(attribute_id)}`);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}

--- a/mcp/src/tools/search.ts
+++ b/mcp/src/tools/search.ts
@@ -1,0 +1,16 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { NexApiClient } from "../client.js";
+
+export function registerSearchTools(server: McpServer, client: NexApiClient) {
+  server.tool(
+    "search_records",
+    "Search records by name across all object types (person, company, deal, etc.). Returns matches grouped by object type with relevance scores.",
+    { query: z.string().min(1).max(500).describe("Search query (1-500 characters)") },
+    { readOnlyHint: true },
+    async ({ query }) => {
+      const result = await client.post("/v1/search", { query });
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}

--- a/mcp/src/tools/tasks.ts
+++ b/mcp/src/tools/tasks.ts
@@ -1,0 +1,106 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { NexApiClient } from "../client.js";
+
+export function registerTaskTools(server: McpServer, client: NexApiClient) {
+  server.tool(
+    "create_task",
+    "Create a new task, optionally linked to records and assigned to users.",
+    {
+      title: z.string().min(1).describe("Task title"),
+      description: z.string().optional().describe("Task description"),
+      priority: z.enum(["low", "medium", "high", "urgent"]).optional().describe("Task priority (default: unspecified)"),
+      due_date: z.string().optional().describe("Due date in RFC3339 format"),
+      entity_ids: z.array(z.string()).optional().describe("Associated record IDs"),
+      assignee_ids: z.array(z.string()).optional().describe("Assigned user IDs"),
+    },
+    { readOnlyHint: false },
+    async ({ title, description, priority, due_date, entity_ids, assignee_ids }) => {
+      const body: Record<string, unknown> = { title };
+      if (description !== undefined) body.description = description;
+      if (priority !== undefined) body.priority = priority;
+      if (due_date !== undefined) body.due_date = due_date;
+      if (entity_ids) body.entity_ids = entity_ids;
+      if (assignee_ids) body.assignee_ids = assignee_ids;
+      const result = await client.post("/v1/tasks", body);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "list_tasks",
+    "List tasks with optional filtering by record, assignee, completion status, or search query.",
+    {
+      entity_id: z.string().optional().describe("Filter by associated record ID"),
+      assignee_id: z.string().optional().describe("Filter by assignee user ID"),
+      search: z.string().optional().describe("Search task titles"),
+      is_completed: z.boolean().optional().describe("Filter by completion status"),
+      limit: z.number().optional().describe("Max results (1-500, default: 100)"),
+      offset: z.number().optional().describe("Pagination offset"),
+    },
+    { readOnlyHint: true },
+    async ({ entity_id, assignee_id, search, is_completed, limit, offset }) => {
+      const params = new URLSearchParams();
+      if (entity_id) params.set("entity_id", entity_id);
+      if (assignee_id) params.set("assignee_id", assignee_id);
+      if (search) params.set("search", search);
+      if (is_completed !== undefined) params.set("is_completed", String(is_completed));
+      if (limit !== undefined) params.set("limit", String(limit));
+      if (offset !== undefined) params.set("offset", String(offset));
+      const qs = params.toString();
+      const path = `/v1/tasks${qs ? `?${qs}` : ""}`;
+      const result = await client.get(path);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "get_task",
+    "Get a single task by ID.",
+    { task_id: z.string().describe("Task ID") },
+    { readOnlyHint: true },
+    async ({ task_id }) => {
+      const result = await client.get(`/v1/tasks/${encodeURIComponent(task_id)}`);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "update_task",
+    "Update a task's fields. All fields are optional — only provided fields are changed.",
+    {
+      task_id: z.string().describe("Task ID to update"),
+      title: z.string().optional().describe("New title"),
+      description: z.string().optional().describe("New description (empty string clears it)"),
+      priority: z.string().optional().describe("New priority (empty string clears it)"),
+      due_date: z.string().optional().describe("New due date in RFC3339 format"),
+      is_completed: z.boolean().optional().describe("Mark complete/incomplete"),
+      entity_ids: z.array(z.string()).optional().describe("Replace associated record IDs"),
+      assignee_ids: z.array(z.string()).optional().describe("Replace assignee user IDs"),
+    },
+    { readOnlyHint: false },
+    async ({ task_id, title, description, priority, due_date, is_completed, entity_ids, assignee_ids }) => {
+      const body: Record<string, unknown> = {};
+      if (title !== undefined) body.title = title;
+      if (description !== undefined) body.description = description;
+      if (priority !== undefined) body.priority = priority;
+      if (due_date !== undefined) body.due_date = due_date;
+      if (is_completed !== undefined) body.is_completed = is_completed;
+      if (entity_ids !== undefined) body.entity_ids = entity_ids;
+      if (assignee_ids !== undefined) body.assignee_ids = assignee_ids;
+      const result = await client.patch(`/v1/tasks/${encodeURIComponent(task_id)}`, body);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "delete_task",
+    "Archive a task (soft delete). Cannot be undone via API.",
+    { task_id: z.string().describe("Task ID to delete") },
+    { readOnlyHint: false, destructiveHint: true },
+    async ({ task_id }) => {
+      const result = await client.delete(`/v1/tasks/${encodeURIComponent(task_id)}`);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}

--- a/mcp/tsconfig.json
+++ b/mcp/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/scripts/nex-api.sh
+++ b/scripts/nex-api.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 # Nex API wrapper — safe HTTP client for OpenClaw skills
 # ENV: NEX_API_KEY (required)
-# ENDPOINTS: https://app.nex.ai/api/developers/v1/*
+# ENDPOINTS: http://localhost:3000/api/developers/v1/*
 # WRITES: Depends on method (POST/PUT/PATCH/DELETE modify data)
 set -euo pipefail
 
-BASE_URL="http://localhost:3000/api/v1/developers"
+BASE_URL="http://localhost:3000/api/developers/v1"
 TIMEOUT=120
 
 # --- Validate environment ---

--- a/scripts/nex-api.sh
+++ b/scripts/nex-api.sh
@@ -5,7 +5,7 @@
 # WRITES: Depends on method (POST/PUT/PATCH/DELETE modify data)
 set -euo pipefail
 
-BASE_URL="https://app.nex.ai/api/developers"
+BASE_URL="http://localhost:3000/api/v1/developers"
 TIMEOUT=120
 
 # --- Validate environment ---

--- a/scripts/nex-api.sh
+++ b/scripts/nex-api.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 # Nex API wrapper — safe HTTP client for OpenClaw skills
 # ENV: NEX_API_KEY (required)
-# ENDPOINTS: http://localhost:3000/api/developers/v1/*
+# ENDPOINTS: http://localhost:30000/api/developers/v1/*
 # WRITES: Depends on method (POST/PUT/PATCH/DELETE modify data)
 set -euo pipefail
 
-BASE_URL="http://localhost:3000/api/developers/v1"
+BASE_URL="http://localhost:30000/api/developers/v1"
 TIMEOUT=120
 
 # --- Validate environment ---

--- a/scripts/nex-api.sh
+++ b/scripts/nex-api.sh
@@ -5,7 +5,7 @@
 # WRITES: Depends on method (POST/PUT/PATCH/DELETE modify data)
 set -euo pipefail
 
-BASE_URL="http://localhost:30000/api/developers/v1"
+BASE_URL="http://localhost:30000/api/developers"
 TIMEOUT=120
 
 # --- Validate environment ---

--- a/scripts/nex-openclaw-register.sh
+++ b/scripts/nex-openclaw-register.sh
@@ -3,7 +3,7 @@
 # Usage: nex-openclaw-register.sh <email> [name] [company_name] [jq-filter]
 set -euo pipefail
 
-BASE_URL="http://localhost:300000/api/v1/openclaw/register"
+BASE_URL="http://localhost:30000/api/v1/agents/register"
 TIMEOUT="${NEX_API_TIMEOUT:-120}"
 
 EMAIL="${1:-}"

--- a/scripts/nex-openclaw-register.sh
+++ b/scripts/nex-openclaw-register.sh
@@ -3,7 +3,7 @@
 # Usage: nex-openclaw-register.sh <email> [name] [company_name] [jq-filter]
 set -euo pipefail
 
-BASE_URL="http://localhost:30000/api/v1/openclaw/register"
+BASE_URL="http://localhost:300000/api/v1/openclaw/register"
 TIMEOUT="${NEX_API_TIMEOUT:-120}"
 
 EMAIL="${1:-}"

--- a/scripts/nex-openclaw-register.sh
+++ b/scripts/nex-openclaw-register.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 
 BASE_URL="http://localhost:30000/api/v1/agents/register"
 TIMEOUT="${NEX_API_TIMEOUT:-120}"
+SOURCE="${NEX_AGENT_SOURCE:-openclaw}"
 
 EMAIL="${1:-}"
 NAME="${2:-}"
@@ -16,7 +17,12 @@ if [[ -z "$EMAIL" ]]; then
   exit 2
 fi
 
-PAYLOAD=$(jq -cn   --arg email "$EMAIL"   --arg name "$NAME"   --arg company_name "$COMPANY_NAME"   '{email: $email}
+PAYLOAD=$(jq -cn \
+  --arg email "$EMAIL" \
+  --arg source "$SOURCE" \
+  --arg name "$NAME" \
+  --arg company_name "$COMPANY_NAME" \
+  '{email: $email, source: $source}
    + (if $name != "" then {name: $name} else {} end)
    + (if $company_name != "" then {company_name: $company_name} else {} end)')
 


### PR DESCRIPTION
## Summary

- Adds a TypeScript MCP server (`mcp/`) exposing the full Nex Developer API as 47 MCP tools
- Supports auto-registration: no API key needed on first run — the `register` tool gets one and persists it to `~/.nex-mcp.json`
- Dual transport: stdio (Claude Desktop, Cursor) and Streamable HTTP (ChatGPT agent mode)
- 9 tool categories: context, search, schema, records, relationships, lists, tasks, notes, insights
- Security hardened: `encodeURIComponent` on all path params, `URLSearchParams` for query strings, 120s fetch timeout, Content-Type only on request bodies
- Updated root README to cover both MCP and OpenClaw integration paths

## Test plan

- [x] `npx tsc` — clean build, zero errors
- [x] Stdio transport: initialize handshake returns 47 tools
- [x] HTTP transport: `/health` responds, `/mcp` accepts MCP requests
- [x] Full E2E flow (no API key → register → use all tool categories) verified against live local API
- [x] Config persistence: key saved to `~/.nex-mcp.json`, loaded on restart in new session
- [x] Devil's advocate review: all CRITICAL and IMPORTANT findings fixed (URL injection, path traversal, fetch timeout, falsy-value bugs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)