### PR TITLE
feat: Claude Code memory plugin — hooks, smart recall, SessionStart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,43 @@
-# Nex — AI Agent Integrations
+# Nex — Cross-Agent Context Layer
 
-Give any AI agent a Context Graph. Three integration paths: **MCP Server** (Claude Desktop, ChatGPT, Cursor, Windsurf), **OpenClaw Plugin** (native memory), and **Claude Code Plugin** (hooks + commands).
+Give any AI agent persistent memory. One knowledge graph, every agent.
 
-## What is Nex?
+Tell something to OpenClaw. Ask about it in Claude Code. Reference it from Cursor. Context follows you across tools — no copy-pasting, no re-explaining, no lost context.
 
-Nex is a real-time context layer for AI agents. It builds a Context Graph from your conversations and shares organizational context with your agents — query contacts, companies, relationships, tasks, notes, and insights.
+## How It Works
+
+```
+You → OpenClaw: "Maria Rodriguez, CTO of TechFlow, wants to expand to Europe in Q3. Budget is $2M."
+
+You → Claude Code: "What do you know about Maria Rodriguez?"
+Claude Code: "Maria Rodriguez is the CTO of TechFlow. They're planning European expansion
+              in Q3 with a $2M budget."
+
+You → Cursor: "Which companies are planning European expansion?"
+Cursor: "TechFlow — Maria Rodriguez (CTO) confirmed Q3 timeline, $2M budget."
+```
+
+One fact entered once. Available everywhere, instantly.
 
 ## Integration Options
 
 | | MCP Server | OpenClaw Plugin | Claude Code Plugin |
 |---|---|---|---|
-| **Format** | TypeScript MCP server | Native OpenClaw plugin | Hooks + slash commands |
 | **Platforms** | Claude Desktop, ChatGPT, Cursor, Windsurf | OpenClaw | Claude Code CLI |
-| **Auto-recall** | No (explicit tool calls) | Yes (`onAssistantTurn` hook) | Yes (`UserPromptSubmit` hook) |
-| **Auto-capture** | No | Yes (`onConversationTurn` hook) | Yes (`Stop` hook) |
-| **Tools** | 47 typed tools with Zod schemas | `memory_search`, `memory_store`, `memory_forget` | Via MCP server |
-| **Auth** | Auto-registration or API key | Config-based | `NEX_API_KEY` env var |
-| **Setup** | `npm install` + add to client config | Copy plugin to OpenClaw | Build + configure hooks |
+| **Auto-recall** | No (explicit tool calls) | Yes | Yes |
+| **Auto-capture** | No | Yes | Yes |
+| **Tools** | 47 typed tools | 3 memory tools | Via MCP server |
+| **Setup** | `npm install` + config | Copy plugin | Build + hooks |
 
-## MCP Server (recommended for explicit tool use)
+## Quick Start
 
-Works with Claude Desktop, ChatGPT (agent mode), Cursor, Windsurf, and any MCP-compatible client.
-
-### Quick Start
+### MCP Server (Claude Desktop, Cursor, Windsurf)
 
 ```bash
 cd mcp && npm install && npm run build
 ```
 
-#### Claude Desktop
-
-Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
+Add to your client config:
 
 ```json
 {
@@ -38,189 +45,121 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
     "nex": {
       "command": "npx",
       "args": ["tsx", "/path/to/nex-as-a-skill/mcp/src/index.ts"],
-      "env": {
-        "NEX_API_KEY": "sk-your_key_here"
-      }
+      "env": { "NEX_API_KEY": "sk-your_key_here" }
     }
   }
 }
 ```
 
-#### Claude Code
+No API key? The server starts in registration mode — call the `register` tool with your email.
+
+See [`mcp/README.md`](mcp/README.md) for all 47 tools.
+
+### OpenClaw Plugin (auto-recall + auto-capture)
 
 ```bash
-claude mcp add nex -- node /path/to/nex-as-a-skill/mcp/dist/index.js
+cp -r openclaw-plugin /path/to/openclaw/plugins/nex
+cd /path/to/openclaw/plugins/nex && npm install && npm run build
 ```
 
-Set `NEX_API_KEY` in your environment.
-
-#### Cursor
-
-Add to `.cursor/mcp.json`:
+Add to `openclaw.json`:
 
 ```json
 {
-  "mcpServers": {
-    "nex": {
-      "command": "npx",
-      "args": ["tsx", "/path/to/nex-as-a-skill/mcp/src/index.ts"],
-      "env": {
-        "NEX_API_KEY": "sk-your_key_here"
+  "plugins": {
+    "load": { "paths": ["/path/to/plugins/nex"] },
+    "slots": { "memory": "nex" },
+    "entries": {
+      "nex": {
+        "enabled": true,
+        "config": {
+          "apiKey": "sk-your_key_here",
+          "baseUrl": "https://api.nex-crm.com"
+        }
       }
     }
   }
 }
 ```
-
-#### No API Key? Auto-register
-
-If you don't set `NEX_API_KEY`, the server starts in registration mode. Call the `register` tool with your email — it gets an API key and saves it to `~/.nex-mcp.json`.
-
-See [`mcp/README.md`](mcp/README.md) for the full tool reference.
-
-## OpenClaw Plugin (auto-recall + auto-capture)
-
-Native OpenClaw plugin that gives agents persistent long-term memory. Automatically recalls relevant context before each response and captures facts from conversations.
-
-### Setup
-
-1. Copy the plugin:
-   ```bash
-   cp -r openclaw-plugin /path/to/openclaw/plugins/nex
-   cd /path/to/openclaw/plugins/nex && npm install && npm run build
-   ```
-
-2. Add to your `openclaw.json`:
-   ```json
-   {
-     "plugins": {
-       "load": { "paths": ["/path/to/plugins/nex"] },
-       "slots": { "memory": "nex" },
-       "entries": {
-         "nex": {
-           "enabled": true,
-           "config": {
-             "apiKey": "sk-your_key_here",
-             "baseUrl": "https://api.nex-crm.com"
-           }
-         }
-       }
-     }
-   }
-   ```
-
-3. Restart OpenClaw. The plugin registers as the memory provider.
-
-### Features
-
-- **Auto-recall**: Queries Nex before each agent turn, injects relevant context
-- **Auto-capture**: Extracts facts from conversations after each turn
-- **Tools**: `memory_search`, `memory_store`, `memory_forget`
-- **Commands**: `/memory-status`, `/memory-search <query>`
 
 See [`openclaw-plugin/README.md`](openclaw-plugin/README.md) for details.
 
-## Claude Code Plugin (auto-recall + auto-capture)
+### Claude Code Plugin (auto-recall + auto-capture)
 
-Full-featured plugin for Claude Code CLI with the same behavior as the OpenClaw plugin: automatic context recall before each turn and fact capture after each turn.
+```bash
+cd claude-code-plugin && npm install && npm run build
+```
 
-### Setup
+Add hooks to `~/.claude/settings.json`:
 
-1. Build the plugin:
-   ```bash
-   cd claude-code-plugin && npm install && npm run build
-   ```
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [{
+      "matcher": "",
+      "hooks": [{
+        "type": "command",
+        "command": "NEX_API_KEY=sk-your_key node /path/to/claude-code-plugin/dist/auto-recall.js",
+        "timeout": 10000
+      }]
+    }],
+    "Stop": [{
+      "matcher": "",
+      "hooks": [{
+        "type": "command",
+        "command": "NEX_API_KEY=sk-your_key node /path/to/claude-code-plugin/dist/auto-capture.js",
+        "timeout": 5000,
+        "async": true
+      }]
+    }]
+  }
+}
+```
 
-2. Add hooks to your `.claude/settings.json` (or `.claude/settings.local.json`):
-   ```json
-   {
-     "hooks": {
-       "UserPromptSubmit": [{
-         "matcher": "",
-         "hooks": [{
-           "type": "command",
-           "command": "node /absolute/path/to/claude-code-plugin/dist/auto-recall.js",
-           "timeout": 10000,
-           "statusMessage": "Recalling relevant context..."
-         }]
-       }],
-       "Stop": [{
-         "matcher": "",
-         "hooks": [{
-           "type": "command",
-           "command": "node /absolute/path/to/claude-code-plugin/dist/auto-capture.js",
-           "timeout": 5000,
-           "async": true
-         }]
-       }]
-     }
-   }
-   ```
+Optional slash commands and MCP server:
 
-3. Set your API key:
-   ```bash
-   export NEX_API_KEY="sk-your_key_here"
-   ```
+```bash
+cp claude-code-plugin/commands/*.md ~/.claude/commands/    # /recall, /remember
+claude mcp add nex -- node /path/to/mcp/dist/index.js      # 47 tools
+```
 
-4. (Optional) Add slash commands — copy `claude-code-plugin/commands/` to `.claude/commands/`:
-   ```bash
-   cp claude-code-plugin/commands/*.md /path/to/project/.claude/commands/
-   ```
+See [`claude-code-plugin/README.md`](claude-code-plugin/README.md) for details.
 
-5. (Optional) Add MCP server for explicit tool access:
-   ```bash
-   claude mcp add nex -- node /path/to/nex-as-a-skill/mcp/dist/index.js
-   ```
+## Architecture
 
-### Features
+```
+                    ┌─────────────────────┐
+                    │   Nex Context Graph  │
+                    │  (people, companies, │
+                    │  insights, tasks...) │
+                    └──────────┬──────────┘
+                               │
+              ┌────────────────┼────────────────┐
+              │                │                │
+     ┌────────▼───────┐ ┌─────▼──────┐ ┌───────▼──────┐
+     │  MCP Server    │ │  OpenClaw  │ │  Claude Code │
+     │  (47 tools)    │ │  Plugin    │ │  Plugin      │
+     └────────┬───────┘ └─────┬──────┘ └───────┬──────┘
+              │               │                │
+     Claude Desktop    OpenClaw agents    Claude Code CLI
+     ChatGPT           Clawgent          Any project
+     Cursor
+     Windsurf
+```
 
-- **Auto-recall** (`UserPromptSubmit` hook): Queries Nex with your prompt, injects `<nex-context>` before Claude processes it
-- **Auto-capture** (`Stop` hook): Extracts text from Claude's response, sends to Nex for fact extraction (fire-and-forget)
-- **Session persistence**: Tracks session IDs across turns via `~/.nex/claude-sessions.json`
-- **Rate limiting**: File-based rate tracking at `~/.nex/rate-limiter.json`
-- **Commands**: `/recall <query>`, `/remember <text>` (requires MCP server)
-
-### Environment Variables
+## Environment Variables
 
 | Variable | Required | Default |
 |----------|----------|---------|
 | `NEX_API_KEY` | Yes | — |
 | `NEX_API_BASE_URL` | No | `https://api.nex-crm.com` |
 
-See [`claude-code-plugin/README.md`](claude-code-plugin/README.md) for details.
+## Testing
 
-## OpenClaw Skill (legacy)
-
-For OpenClaw agents using the SKILL.md approach (simpler but no auto-recall/capture).
-
-### Setup
-
-1. Copy `SKILL.md` to your OpenClaw skills directory:
-   ```bash
-   mkdir -p ~/.openclaw/workspace/skills/nex
-   cp SKILL.md ~/.openclaw/workspace/skills/nex/
-   ```
-
-2. Add your API key to `~/.openclaw/openclaw.json`:
-   ```json
-   {
-     "skills": {
-       "entries": {
-         "nex": {
-           "enabled": true,
-           "env": {
-             "NEX_API_KEY": "sk-your_key_here"
-           }
-         }
-       }
-     }
-   }
-   ```
-
-## API Documentation
-
-See [docs.nex.ai](https://docs.nex.ai) for full API documentation.
+- **OpenClaw plugin**: 38/38 unit tests pass (`cd openclaw-plugin && npx vitest run`)
+- **Claude Code plugin**: 14/14 manual E2E tests pass (see [`docs/nex-plugin-test-results.md`](../docs/nex-plugin-test-results.md))
+- **MCP server**: Builds clean, all tools typed with Zod schemas
 
 ## License
 
-MIT License - see [LICENSE](LICENSE)
+MIT

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nex — AI Agent Integrations
 
-Give any AI agent a Context Graph. Two integration paths: **MCP Server** (Claude Desktop, ChatGPT, Cursor, Windsurf) and **OpenClaw Skill**.
+Give any AI agent a Context Graph. Three integration paths: **MCP Server** (Claude Desktop, ChatGPT, Cursor, Windsurf), **OpenClaw Plugin** (native memory), and **Claude Code Plugin** (hooks + commands).
 
 ## What is Nex?
 
@@ -8,23 +8,24 @@ Nex is a real-time context layer for AI agents. It builds a Context Graph from y
 
 ## Integration Options
 
-| | MCP Server | OpenClaw Skill |
-|---|---|---|
-| **Format** | TypeScript MCP server | SKILL.md + bash scripts |
-| **Platforms** | Claude Desktop, ChatGPT, Cursor, Windsurf, any MCP client | OpenClaw |
-| **Transport** | stdio (local) or Streamable HTTP (remote) | Shell exec |
-| **Tools** | 47 typed tools with Zod schemas | Bash wrapper around curl |
-| **Auth** | Auto-registration or manual API key | Auto-registration or manual |
-| **Setup** | `npm install` + add to client config | Copy SKILL.md to skills dir |
+| | MCP Server | OpenClaw Plugin | Claude Code Plugin |
+|---|---|---|---|
+| **Format** | TypeScript MCP server | Native OpenClaw plugin | Hooks + slash commands |
+| **Platforms** | Claude Desktop, ChatGPT, Cursor, Windsurf | OpenClaw | Claude Code CLI |
+| **Auto-recall** | No (explicit tool calls) | Yes (`onAssistantTurn` hook) | Yes (`UserPromptSubmit` hook) |
+| **Auto-capture** | No | Yes (`onConversationTurn` hook) | Yes (`Stop` hook) |
+| **Tools** | 47 typed tools with Zod schemas | `memory_search`, `memory_store`, `memory_forget` | Via MCP server |
+| **Auth** | Auto-registration or API key | Config-based | `NEX_API_KEY` env var |
+| **Setup** | `npm install` + add to client config | Copy plugin to OpenClaw | Build + configure hooks |
 
-## MCP Server (recommended)
+## MCP Server (recommended for explicit tool use)
 
 Works with Claude Desktop, ChatGPT (agent mode), Cursor, Windsurf, and any MCP-compatible client.
 
 ### Quick Start
 
 ```bash
-cd mcp && npm install
+cd mcp && npm install && npm run build
 ```
 
 #### Claude Desktop
@@ -44,6 +45,14 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
   }
 }
 ```
+
+#### Claude Code
+
+```bash
+claude mcp add nex -- node /path/to/nex-as-a-skill/mcp/dist/index.js
+```
+
+Set `NEX_API_KEY` in your environment.
 
 #### Cursor
 
@@ -65,13 +74,124 @@ Add to `.cursor/mcp.json`:
 
 #### No API Key? Auto-register
 
-If you don't set `NEX_API_KEY`, the server starts in registration mode. Just call the `register` tool with your email — it gets an API key and saves it to `~/.nex-mcp.json` for all future sessions.
+If you don't set `NEX_API_KEY`, the server starts in registration mode. Call the `register` tool with your email — it gets an API key and saves it to `~/.nex-mcp.json`.
 
-See [`mcp/README.md`](mcp/README.md) for the full tool reference and setup guide.
+See [`mcp/README.md`](mcp/README.md) for the full tool reference.
 
-## OpenClaw Skill
+## OpenClaw Plugin (auto-recall + auto-capture)
 
-For OpenClaw agents specifically.
+Native OpenClaw plugin that gives agents persistent long-term memory. Automatically recalls relevant context before each response and captures facts from conversations.
+
+### Setup
+
+1. Copy the plugin:
+   ```bash
+   cp -r openclaw-plugin /path/to/openclaw/plugins/nex
+   cd /path/to/openclaw/plugins/nex && npm install && npm run build
+   ```
+
+2. Add to your `openclaw.json`:
+   ```json
+   {
+     "plugins": {
+       "load": { "paths": ["/path/to/plugins/nex"] },
+       "slots": { "memory": "nex" },
+       "entries": {
+         "nex": {
+           "enabled": true,
+           "config": {
+             "apiKey": "sk-your_key_here",
+             "baseUrl": "https://api.nex-crm.com"
+           }
+         }
+       }
+     }
+   }
+   ```
+
+3. Restart OpenClaw. The plugin registers as the memory provider.
+
+### Features
+
+- **Auto-recall**: Queries Nex before each agent turn, injects relevant context
+- **Auto-capture**: Extracts facts from conversations after each turn
+- **Tools**: `memory_search`, `memory_store`, `memory_forget`
+- **Commands**: `/memory-status`, `/memory-search <query>`
+
+See [`openclaw-plugin/README.md`](openclaw-plugin/README.md) for details.
+
+## Claude Code Plugin (auto-recall + auto-capture)
+
+Full-featured plugin for Claude Code CLI with the same behavior as the OpenClaw plugin: automatic context recall before each turn and fact capture after each turn.
+
+### Setup
+
+1. Build the plugin:
+   ```bash
+   cd claude-code-plugin && npm install && npm run build
+   ```
+
+2. Add hooks to your `.claude/settings.json` (or `.claude/settings.local.json`):
+   ```json
+   {
+     "hooks": {
+       "UserPromptSubmit": [{
+         "matcher": "",
+         "hooks": [{
+           "type": "command",
+           "command": "node /absolute/path/to/claude-code-plugin/dist/auto-recall.js",
+           "timeout": 10000,
+           "statusMessage": "Recalling relevant context..."
+         }]
+       }],
+       "Stop": [{
+         "matcher": "",
+         "hooks": [{
+           "type": "command",
+           "command": "node /absolute/path/to/claude-code-plugin/dist/auto-capture.js",
+           "timeout": 5000,
+           "async": true
+         }]
+       }]
+     }
+   }
+   ```
+
+3. Set your API key:
+   ```bash
+   export NEX_API_KEY="sk-your_key_here"
+   ```
+
+4. (Optional) Add slash commands — copy `claude-code-plugin/commands/` to `.claude/commands/`:
+   ```bash
+   cp claude-code-plugin/commands/*.md /path/to/project/.claude/commands/
+   ```
+
+5. (Optional) Add MCP server for explicit tool access:
+   ```bash
+   claude mcp add nex -- node /path/to/nex-as-a-skill/mcp/dist/index.js
+   ```
+
+### Features
+
+- **Auto-recall** (`UserPromptSubmit` hook): Queries Nex with your prompt, injects `<nex-context>` before Claude processes it
+- **Auto-capture** (`Stop` hook): Extracts text from Claude's response, sends to Nex for fact extraction (fire-and-forget)
+- **Session persistence**: Tracks session IDs across turns via `~/.nex/claude-sessions.json`
+- **Rate limiting**: File-based rate tracking at `~/.nex/rate-limiter.json`
+- **Commands**: `/recall <query>`, `/remember <text>` (requires MCP server)
+
+### Environment Variables
+
+| Variable | Required | Default |
+|----------|----------|---------|
+| `NEX_API_KEY` | Yes | — |
+| `NEX_API_BASE_URL` | No | `https://api.nex-crm.com` |
+
+See [`claude-code-plugin/README.md`](claude-code-plugin/README.md) for details.
+
+## OpenClaw Skill (legacy)
+
+For OpenClaw agents using the SKILL.md approach (simpler but no auto-recall/capture).
 
 ### Setup
 
@@ -96,10 +216,6 @@ For OpenClaw agents specifically.
      }
    }
    ```
-
-3. Verify: `openclaw agent --message "What skills do you have?"`
-
-Or skip the API key — the skill can auto-register on first use.
 
 ## API Documentation
 

--- a/claude-code-plugin/.gitignore
+++ b/claude-code-plugin/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/claude-code-plugin/README.md
+++ b/claude-code-plugin/README.md
@@ -12,7 +12,7 @@ Persistent context intelligence for Claude Code, powered by Nex. Automatically r
 ## Prerequisites
 
 - Node.js 18+
-- A Nex API key (get one at [nex-crm.com](https://nex-crm.com))
+- A Nex API key (get one at [app.nex.ai](https://app.nex.ai)) — [API docs](https://docs.nex.ai)
 - Claude Code CLI
 
 ## Installation
@@ -29,7 +29,7 @@ npm run build
 
 ```bash
 export NEX_API_KEY="your-api-key-here"
-export NEX_API_BASE_URL="https://api.nex-crm.com"  # optional, defaults to api.nex-crm.com
+export NEX_API_BASE_URL="https://api.nex.ai"  # optional, defaults to api.nex.ai
 ```
 
 ### 2. MCP Server Registration
@@ -47,6 +47,19 @@ Copy the hook entries from `settings.json` into your Claude Code settings at `~/
 ```json
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node /absolute/path/to/claude-code-plugin/dist/auto-session-start.js",
+            "timeout": 10000,
+            "statusMessage": "Loading knowledge context..."
+          }
+        ]
+      }
+    ],
     "UserPromptSubmit": [
       {
         "matcher": "",
@@ -91,12 +104,20 @@ Then use:
 
 ## How It Works
 
+### Session Start (SessionStart Hook)
+
+1. Fires once when a new Claude Code session begins
+2. Queries Nex for a baseline context summary ("key active context, recent interactions, important updates")
+3. Injects as system context so the agent "already knows" relevant business context from the first message
+4. On any error: returns `{}`, logs to stderr (graceful degradation)
+
 ### Auto-Recall (UserPromptSubmit Hook)
 
 1. Reads the user's prompt from stdin (`{ "prompt": "...", "session_id": "..." }`)
-2. Queries Nex `/ask` endpoint for relevant context
-3. Returns `{ "additionalContext": "<nex-context>...</nex-context>" }` to inject into the conversation
-4. On any error: returns `{}` (graceful degradation, never blocks Claude Code)
+2. Runs prompt through `recall-filter.ts` — skips short directives, tool commands, code-heavy prompts; always recalls on questions and first prompt
+3. If recall needed, queries Nex `/ask` endpoint for relevant context
+4. Returns `{ "additionalContext": "<nex-context>...</nex-context>" }` to inject into the conversation
+5. On any error: returns `{}`, logs to stderr (graceful degradation)
 
 ### Auto-Capture (Stop Hook)
 
@@ -111,17 +132,19 @@ Then use:
 ```
 claude-code-plugin/
 ├── src/
-│   ├── auto-recall.ts      # UserPromptSubmit hook handler
-│   ├── auto-capture.ts     # Stop hook handler
-│   ├── nex-client.ts       # HTTP client for Nex API
-│   ├── config.ts           # Environment variable config
-│   ├── context-format.ts   # XML context formatting
-│   ├── capture-filter.ts   # Smart capture filtering
-│   ├── rate-limiter.ts     # Sliding window rate limiter
-│   └── session-store.ts    # LRU session ID mapping
+│   ├── auto-session-start.ts  # SessionStart hook — baseline context load
+│   ├── auto-recall.ts         # UserPromptSubmit hook — selective recall
+│   ├── auto-capture.ts        # Stop hook — conversation capture
+│   ├── recall-filter.ts       # Smart prompt classifier + debounce
+│   ├── nex-client.ts          # HTTP client for Nex API
+│   ├── config.ts              # Environment variable config
+│   ├── context-format.ts      # XML context formatting
+│   ├── capture-filter.ts      # Smart capture filtering
+│   ├── rate-limiter.ts        # Sliding window rate limiter
+│   └── session-store.ts       # LRU session ID mapping
 ├── commands/
-│   ├── recall.md           # /recall slash command
-│   └── remember.md         # /remember slash command
-├── settings.json           # Hook configuration template
+│   ├── recall.md              # /recall slash command
+│   └── remember.md            # /remember slash command
+├── settings.json              # Hook configuration template
 └── README.md
 ```

--- a/claude-code-plugin/README.md
+++ b/claude-code-plugin/README.md
@@ -5,7 +5,7 @@ Persistent context intelligence for Claude Code, powered by Nex. Automatically r
 ## Features
 
 - **Auto-recall** — `UserPromptSubmit` hook queries Nex and injects relevant context
-- **Auto-capture** — `Stop` hook captures conversation exchanges to build your knowledge base
+- **Auto-capture** — `Stop` hook captures assistant responses to build your knowledge base
 - **Slash commands** — `/recall <query>` and `/remember <text>` for manual control
 - **MCP tools** — Full Nex API access via the MCP server
 
@@ -29,7 +29,7 @@ npm run build
 
 ```bash
 export NEX_API_KEY="your-api-key-here"
-export NEX_BASE_URL="http://localhost:30000"  # optional, defaults to localhost
+export NEX_API_BASE_URL="https://api.nex-crm.com"  # optional, defaults to api.nex-crm.com
 ```
 
 ### 2. MCP Server Registration
@@ -67,7 +67,8 @@ Copy the hook entries from `settings.json` into your Claude Code settings at `~/
           {
             "type": "command",
             "command": "node /absolute/path/to/claude-code-plugin/dist/auto-capture.js",
-            "timeout": 5000
+            "timeout": 5000,
+            "async": true
           }
         ]
       }
@@ -92,19 +93,18 @@ Then use:
 
 ### Auto-Recall (UserPromptSubmit Hook)
 
-1. Reads the user's prompt from stdin
+1. Reads the user's prompt from stdin (`{ "prompt": "...", "session_id": "..." }`)
 2. Queries Nex `/ask` endpoint for relevant context
-3. Returns `{ additionalContext: "<nex-context>...</nex-context>" }` to inject into the conversation
+3. Returns `{ "additionalContext": "<nex-context>...</nex-context>" }` to inject into the conversation
 4. On any error: returns `{}` (graceful degradation, never blocks Claude Code)
 
 ### Auto-Capture (Stop Hook)
 
-1. Reads the transcript JSONL file path from stdin
-2. Extracts the last user + assistant exchange
-3. Strips any `<nex-context>` blocks (prevents feedback loops)
-4. Filters out short, duplicate, or command messages
-5. Sends to Nex `/text` endpoint via rate limiter (fire-and-forget)
-6. On any error: returns `{}` (graceful degradation)
+1. Reads `{ "last_assistant_message": "...", "session_id": "..." }` from stdin
+2. Strips any `<nex-context>` blocks (prevents feedback loops)
+3. Filters out short, duplicate, or command messages
+4. Sends to Nex `/text` endpoint (fire-and-forget, `async: true`)
+5. On any error: returns `{}` (graceful degradation)
 
 ## Architecture
 

--- a/claude-code-plugin/README.md
+++ b/claude-code-plugin/README.md
@@ -29,7 +29,7 @@ npm run build
 
 ```bash
 export NEX_API_KEY="your-api-key-here"
-export NEX_API_BASE_URL="https://api.nex.ai"  # optional, defaults to api.nex.ai
+export NEX_API_BASE_URL="https://app.nex.ai"  # optional, defaults to app.nex.ai
 ```
 
 ### 2. MCP Server Registration

--- a/claude-code-plugin/README.md
+++ b/claude-code-plugin/README.md
@@ -1,0 +1,127 @@
+# Nex Memory Plugin for Claude Code
+
+Persistent context intelligence for Claude Code, powered by Nex. Automatically recalls relevant knowledge before each prompt and captures conversation facts after each response.
+
+## Features
+
+- **Auto-recall** — `UserPromptSubmit` hook queries Nex and injects relevant context
+- **Auto-capture** — `Stop` hook captures conversation exchanges to build your knowledge base
+- **Slash commands** — `/recall <query>` and `/remember <text>` for manual control
+- **MCP tools** — Full Nex API access via the MCP server
+
+## Prerequisites
+
+- Node.js 18+
+- A Nex API key (get one at [nex-crm.com](https://nex-crm.com))
+- Claude Code CLI
+
+## Installation
+
+```bash
+cd claude-code-plugin
+npm install
+npm run build
+```
+
+## Setup
+
+### 1. Environment Variables
+
+```bash
+export NEX_API_KEY="your-api-key-here"
+export NEX_BASE_URL="http://localhost:30000"  # optional, defaults to localhost
+```
+
+### 2. MCP Server Registration
+
+Register the Nex MCP server so Claude Code can use `/recall` and `/remember`:
+
+```bash
+claude mcp add nex -- node /path/to/mcp/dist/index.js
+```
+
+### 3. Hook Configuration
+
+Copy the hook entries from `settings.json` into your Claude Code settings at `~/.claude/settings.json`. Update the `<path-to>` placeholder with the actual path:
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node /absolute/path/to/claude-code-plugin/dist/auto-recall.js",
+            "timeout": 10000,
+            "statusMessage": "Recalling relevant memories..."
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node /absolute/path/to/claude-code-plugin/dist/auto-capture.js",
+            "timeout": 5000
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### 4. Slash Commands
+
+Copy the `commands/` directory to your project's `.claude/commands/` or global `~/.claude/commands/`:
+
+```bash
+cp -r commands/ ~/.claude/commands/
+```
+
+Then use:
+- `/recall <query>` — Search your Nex knowledge base
+- `/remember <text>` — Store information in Nex
+
+## How It Works
+
+### Auto-Recall (UserPromptSubmit Hook)
+
+1. Reads the user's prompt from stdin
+2. Queries Nex `/ask` endpoint for relevant context
+3. Returns `{ additionalContext: "<nex-context>...</nex-context>" }` to inject into the conversation
+4. On any error: returns `{}` (graceful degradation, never blocks Claude Code)
+
+### Auto-Capture (Stop Hook)
+
+1. Reads the transcript JSONL file path from stdin
+2. Extracts the last user + assistant exchange
+3. Strips any `<nex-context>` blocks (prevents feedback loops)
+4. Filters out short, duplicate, or command messages
+5. Sends to Nex `/text` endpoint via rate limiter (fire-and-forget)
+6. On any error: returns `{}` (graceful degradation)
+
+## Architecture
+
+```
+claude-code-plugin/
+├── src/
+│   ├── auto-recall.ts      # UserPromptSubmit hook handler
+│   ├── auto-capture.ts     # Stop hook handler
+│   ├── nex-client.ts       # HTTP client for Nex API
+│   ├── config.ts           # Environment variable config
+│   ├── context-format.ts   # XML context formatting
+│   ├── capture-filter.ts   # Smart capture filtering
+│   ├── rate-limiter.ts     # Sliding window rate limiter
+│   └── session-store.ts    # LRU session ID mapping
+├── commands/
+│   ├── recall.md           # /recall slash command
+│   └── remember.md         # /remember slash command
+├── settings.json           # Hook configuration template
+└── README.md
+```

--- a/claude-code-plugin/commands/recall.md
+++ b/claude-code-plugin/commands/recall.md
@@ -1,0 +1,5 @@
+---
+description: Recall relevant memories from Nex
+---
+Search the Nex knowledge base for: $ARGUMENTS
+Use the mcp__nex__context_ask tool to query and return formatted results.

--- a/claude-code-plugin/commands/recall.md
+++ b/claude-code-plugin/commands/recall.md
@@ -1,5 +1,5 @@
 ---
-description: Recall relevant memories from Nex
+description: Recall relevant memories from Nex knowledge base
 ---
-Search the Nex knowledge base for: $ARGUMENTS
-Use the mcp__nex__context_ask tool to query and return formatted results.
+Search the nex knowledge base for: $ARGUMENTS
+Use the mcp__nex__context_ask tool to query and return formatted results with sources.

--- a/claude-code-plugin/commands/remember.md
+++ b/claude-code-plugin/commands/remember.md
@@ -1,0 +1,4 @@
+---
+description: Store information in Nex knowledge base
+---
+Use the mcp__nex__context_add_text tool to store: $ARGUMENTS

--- a/claude-code-plugin/commands/remember.md
+++ b/claude-code-plugin/commands/remember.md
@@ -1,4 +1,5 @@
 ---
 description: Store information in Nex knowledge base
 ---
-Use the mcp__nex__context_add_text tool to store: $ARGUMENTS
+Use the mcp__nex__context_add_text tool to store the following text: $ARGUMENTS
+Confirm what was stored.

--- a/claude-code-plugin/package-lock.json
+++ b/claude-code-plugin/package-lock.json
@@ -1,0 +1,51 @@
+{
+  "name": "@nex-crm/claude-code-memory-plugin",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@nex-crm/claude-code-memory-plugin",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "typescript": "^5.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.35",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.35.tgz",
+      "integrity": "sha512-Uarfe6J91b9HAUXxjvSOdiO2UPOKLm07Q1oh0JHxoZ1y8HoqxDAu3gVrsrOHeiio0kSsoVBt4wFrKOm0dKxVPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/claude-code-plugin/package.json
+++ b/claude-code-plugin/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@nex-crm/claude-code-memory-plugin",
+  "version": "1.0.0",
+  "description": "Claude Code plugin for Nex persistent memory — auto-recall, auto-capture, commands",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "@types/node": "^20.0.0"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "license": "MIT"
+}

--- a/claude-code-plugin/package.json
+++ b/claude-code-plugin/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@nex-crm/claude-code-memory-plugin",
+  "name": "@nex-crm/claude-code-nex-plugin",
   "version": "1.0.0",
   "description": "Claude Code plugin for Nex persistent memory — auto-recall, auto-capture, commands",
   "type": "module",

--- a/claude-code-plugin/settings.json
+++ b/claude-code-plugin/settings.json
@@ -1,5 +1,18 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node <path-to>/claude-code-plugin/dist/auto-session-start.js",
+            "timeout": 10000,
+            "statusMessage": "Loading knowledge context..."
+          }
+        ]
+      }
+    ],
     "UserPromptSubmit": [
       {
         "matcher": "",

--- a/claude-code-plugin/settings.json
+++ b/claude-code-plugin/settings.json
@@ -20,7 +20,8 @@
           {
             "type": "command",
             "command": "node <path-to>/claude-code-plugin/dist/auto-capture.js",
-            "timeout": 5000
+            "timeout": 5000,
+            "async": true
           }
         ]
       }

--- a/claude-code-plugin/settings.json
+++ b/claude-code-plugin/settings.json
@@ -1,0 +1,29 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node <path-to>/claude-code-plugin/dist/auto-recall.js",
+            "timeout": 10000,
+            "statusMessage": "Recalling relevant memories..."
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node <path-to>/claude-code-plugin/dist/auto-capture.js",
+            "timeout": 5000
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/claude-code-plugin/src/auto-capture.ts
+++ b/claude-code-plugin/src/auto-capture.ts
@@ -2,57 +2,25 @@
 /**
  * Claude Code Stop hook — auto-capture conversation to Nex.
  *
- * Reads the transcript JSONL file, extracts the last user+assistant exchange,
+ * Reads { last_assistant_message, session_id } from stdin,
  * filters and sends to Nex for ingestion.
  *
  * On ANY error: outputs {} and exits 0 (graceful degradation).
  */
 
-import { readFile } from "node:fs/promises";
 import { loadConfig } from "./config.js";
 import { NexClient } from "./nex-client.js";
 import { captureFilter } from "./capture-filter.js";
 import { RateLimiter } from "./rate-limiter.js";
 
+/** Ingest timeout — 3s leaves buffer within 5s hook timeout */
+const INGEST_TIMEOUT_MS = 3_000;
+
 const rateLimiter = new RateLimiter();
 
 interface HookInput {
-  stop_hook_active?: boolean;
-  transcript_path?: string;
+  last_assistant_message?: string;
   session_id?: string;
-}
-
-interface TranscriptMessage {
-  role?: string;
-  type?: string;
-  message?: {
-    role?: string;
-    content?: string | Array<{ type: string; text?: string }>;
-  };
-  content?: string | Array<{ type: string; text?: string }>;
-}
-
-/**
- * Extract text content from a transcript message.
- */
-function extractText(msg: TranscriptMessage): string {
-  // Try message.content first (nested format)
-  const content = msg.message?.content ?? msg.content;
-  if (typeof content === "string") return content;
-  if (Array.isArray(content)) {
-    return content
-      .filter((p) => p.type === "text" && p.text)
-      .map((p) => p.text!)
-      .join("\n");
-  }
-  return "";
-}
-
-/**
- * Get the role from a transcript message (handles nested format).
- */
-function getRole(msg: TranscriptMessage): string | undefined {
-  return msg.role ?? msg.message?.role ?? msg.type;
 }
 
 async function main(): Promise<void> {
@@ -72,9 +40,8 @@ async function main(): Promise<void> {
       return;
     }
 
-    const transcriptPath = input.transcript_path;
-    if (!transcriptPath) {
-      // No transcript path — can't capture
+    const message = input.last_assistant_message?.trim();
+    if (!message) {
       process.stdout.write("{}");
       return;
     }
@@ -87,80 +54,35 @@ async function main(): Promise<void> {
       return;
     }
 
-    // Read the transcript JSONL file
-    let transcriptRaw: string;
-    try {
-      transcriptRaw = await readFile(transcriptPath, "utf-8");
-    } catch {
-      // Can't read transcript — skip
-      process.stdout.write("{}");
-      return;
-    }
-
-    const lines = transcriptRaw.trim().split("\n").filter(Boolean);
-    if (lines.length === 0) {
-      process.stdout.write("{}");
-      return;
-    }
-
-    // Parse messages from JSONL — get last few lines
-    const recentLines = lines.slice(-20);
-    const messages: TranscriptMessage[] = [];
-    for (const line of recentLines) {
-      try {
-        messages.push(JSON.parse(line) as TranscriptMessage);
-      } catch {
-        // Skip unparseable lines
-      }
-    }
-
-    // Extract last user + last assistant message
-    const parts: string[] = [];
-    const reversed = [...messages].reverse();
-
-    const lastAssistant = reversed.find((m) => {
-      const role = getRole(m);
-      return role === "assistant";
-    });
-    const lastUser = reversed.find((m) => {
-      const role = getRole(m);
-      return role === "user" || role === "human";
-    });
-
-    if (lastUser) {
-      const text = extractText(lastUser);
-      if (text) parts.push(`User: ${text}`);
-    }
-    if (lastAssistant) {
-      const text = extractText(lastAssistant);
-      if (text) parts.push(`Assistant: ${text}`);
-    }
-
-    if (parts.length === 0) {
-      process.stdout.write("{}");
-      return;
-    }
-
-    const captureText = parts.join("\n\n");
-    const filterResult = captureFilter(captureText);
+    const filterResult = captureFilter(message);
 
     if (filterResult.skipped) {
       process.stdout.write("{}");
       return;
     }
 
-    // Fire-and-forget via rate limiter
+    // Check rate limit before making API call
+    if (!rateLimiter.canProceed()) {
+      process.stderr.write("[nex-capture] Rate limited — skipping ingest\n");
+      process.stdout.write("{}");
+      return;
+    }
+
+    // Fire-and-forget ingest with tight timeout
     const client = new NexClient(cfg.apiKey, cfg.baseUrl);
-    rateLimiter
-      .enqueue(async () => {
-        await client.ingest(filterResult.text, "claude-code-conversation");
-      })
-      .catch(() => {
-        // Silently drop — rate limited or queue full
-      });
+    try {
+      await client.ingest(filterResult.text, "claude-code-conversation", INGEST_TIMEOUT_MS);
+    } catch (err) {
+      process.stderr.write(
+        `[nex-capture] Ingest failed: ${err instanceof Error ? err.message : String(err)}\n`
+      );
+    }
 
     process.stdout.write("{}");
-  } catch {
+  } catch (err) {
+    process.stderr.write(
+      `[nex-capture] Unexpected error: ${err instanceof Error ? err.message : String(err)}\n`
+    );
     process.stdout.write("{}");
   }
 }

--- a/claude-code-plugin/src/auto-capture.ts
+++ b/claude-code-plugin/src/auto-capture.ts
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+/**
+ * Claude Code Stop hook — auto-capture conversation to Nex.
+ *
+ * Reads the transcript JSONL file, extracts the last user+assistant exchange,
+ * filters and sends to Nex for ingestion.
+ *
+ * On ANY error: outputs {} and exits 0 (graceful degradation).
+ */
+
+import { readFile } from "node:fs/promises";
+import { loadConfig } from "./config.js";
+import { NexClient } from "./nex-client.js";
+import { captureFilter } from "./capture-filter.js";
+import { RateLimiter } from "./rate-limiter.js";
+
+const rateLimiter = new RateLimiter();
+
+interface HookInput {
+  stop_hook_active?: boolean;
+  transcript_path?: string;
+  session_id?: string;
+}
+
+interface TranscriptMessage {
+  role?: string;
+  type?: string;
+  message?: {
+    role?: string;
+    content?: string | Array<{ type: string; text?: string }>;
+  };
+  content?: string | Array<{ type: string; text?: string }>;
+}
+
+/**
+ * Extract text content from a transcript message.
+ */
+function extractText(msg: TranscriptMessage): string {
+  // Try message.content first (nested format)
+  const content = msg.message?.content ?? msg.content;
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .filter((p) => p.type === "text" && p.text)
+      .map((p) => p.text!)
+      .join("\n");
+  }
+  return "";
+}
+
+/**
+ * Get the role from a transcript message (handles nested format).
+ */
+function getRole(msg: TranscriptMessage): string | undefined {
+  return msg.role ?? msg.message?.role ?? msg.type;
+}
+
+async function main(): Promise<void> {
+  try {
+    // Read stdin
+    const chunks: Buffer[] = [];
+    for await (const chunk of process.stdin) {
+      chunks.push(chunk as Buffer);
+    }
+    const raw = Buffer.concat(chunks).toString("utf-8");
+
+    let input: HookInput;
+    try {
+      input = JSON.parse(raw) as HookInput;
+    } catch {
+      process.stdout.write("{}");
+      return;
+    }
+
+    const transcriptPath = input.transcript_path;
+    if (!transcriptPath) {
+      // No transcript path — can't capture
+      process.stdout.write("{}");
+      return;
+    }
+
+    let cfg;
+    try {
+      cfg = loadConfig();
+    } catch {
+      process.stdout.write("{}");
+      return;
+    }
+
+    // Read the transcript JSONL file
+    let transcriptRaw: string;
+    try {
+      transcriptRaw = await readFile(transcriptPath, "utf-8");
+    } catch {
+      // Can't read transcript — skip
+      process.stdout.write("{}");
+      return;
+    }
+
+    const lines = transcriptRaw.trim().split("\n").filter(Boolean);
+    if (lines.length === 0) {
+      process.stdout.write("{}");
+      return;
+    }
+
+    // Parse messages from JSONL — get last few lines
+    const recentLines = lines.slice(-20);
+    const messages: TranscriptMessage[] = [];
+    for (const line of recentLines) {
+      try {
+        messages.push(JSON.parse(line) as TranscriptMessage);
+      } catch {
+        // Skip unparseable lines
+      }
+    }
+
+    // Extract last user + last assistant message
+    const parts: string[] = [];
+    const reversed = [...messages].reverse();
+
+    const lastAssistant = reversed.find((m) => {
+      const role = getRole(m);
+      return role === "assistant";
+    });
+    const lastUser = reversed.find((m) => {
+      const role = getRole(m);
+      return role === "user" || role === "human";
+    });
+
+    if (lastUser) {
+      const text = extractText(lastUser);
+      if (text) parts.push(`User: ${text}`);
+    }
+    if (lastAssistant) {
+      const text = extractText(lastAssistant);
+      if (text) parts.push(`Assistant: ${text}`);
+    }
+
+    if (parts.length === 0) {
+      process.stdout.write("{}");
+      return;
+    }
+
+    const captureText = parts.join("\n\n");
+    const filterResult = captureFilter(captureText);
+
+    if (filterResult.skipped) {
+      process.stdout.write("{}");
+      return;
+    }
+
+    // Fire-and-forget via rate limiter
+    const client = new NexClient(cfg.apiKey, cfg.baseUrl);
+    rateLimiter
+      .enqueue(async () => {
+        await client.ingest(filterResult.text, "claude-code-conversation");
+      })
+      .catch(() => {
+        // Silently drop — rate limited or queue full
+      });
+
+    process.stdout.write("{}");
+  } catch {
+    process.stdout.write("{}");
+  }
+}
+
+main().then(() => process.exit(0)).catch(() => process.exit(0));

--- a/claude-code-plugin/src/auto-recall.ts
+++ b/claude-code-plugin/src/auto-recall.ts
@@ -86,8 +86,8 @@ async function main(): Promise<void> {
       sessionId: result.session_id,
     });
 
-    const output = JSON.stringify({ additionalContext: context });
-    process.stdout.write(output);
+    // Output as plain text — Claude Code adds stdout text as context on exit 0
+    process.stdout.write(context);
   } catch {
     // Graceful degradation — never block Claude Code on recall failure
     process.stdout.write("{}");

--- a/claude-code-plugin/src/auto-recall.ts
+++ b/claude-code-plugin/src/auto-recall.ts
@@ -2,7 +2,8 @@
 /**
  * Claude Code UserPromptSubmit hook — auto-recall from Nex.
  *
- * Reads the user's prompt from stdin, queries Nex for relevant context,
+ * Reads the user's prompt from stdin, runs it through the recall filter
+ * to decide if recall is needed, queries Nex for relevant context,
  * and outputs { additionalContext: "..." } to inject into the conversation.
  *
  * On ANY error: outputs {} and exits 0 (graceful degradation).
@@ -12,14 +13,24 @@ import { loadConfig } from "./config.js";
 import { NexClient } from "./nex-client.js";
 import { formatNexContext } from "./context-format.js";
 import { SessionStore } from "./session-store.js";
+import { shouldRecall, recordRecall } from "./recall-filter.js";
 
-// Single shared session store (per process — hooks are short-lived so this
-// is effectively per-invocation, but it's here for structural consistency)
 const sessions = new SessionStore();
 
 interface HookInput {
   prompt?: string;
   session_id?: string;
+}
+
+/**
+ * Check if this is the first prompt for this session.
+ * A session with no stored Nex session ID is considered "first prompt"
+ * (SessionStart may have already set one, but that's fine — it means
+ * baseline context was loaded, and first user prompt still gets recall).
+ */
+function isFirstPrompt(sessionKey: string | undefined): boolean {
+  if (!sessionKey) return true;
+  return !sessions.get(sessionKey);
 }
 
 async function main(): Promise<void> {
@@ -35,7 +46,6 @@ async function main(): Promise<void> {
     try {
       input = JSON.parse(raw) as HookInput;
     } catch {
-      // Unparseable stdin — skip silently
       process.stdout.write("{}");
       return;
     }
@@ -52,11 +62,17 @@ async function main(): Promise<void> {
       return;
     }
 
+    // --- Recall filter: decide if this prompt needs memory recall ---
+    const decision = shouldRecall(prompt, isFirstPrompt(input.session_id));
+    if (!decision.shouldRecall) {
+      process.stdout.write("{}");
+      return;
+    }
+
     let cfg;
     try {
       cfg = loadConfig();
     } catch {
-      // No API key configured — skip silently
       process.stdout.write("{}");
       return;
     }
@@ -78,6 +94,9 @@ async function main(): Promise<void> {
     if (result.session_id && sessionKey) {
       sessions.set(sessionKey, result.session_id);
     }
+
+    // Record successful recall for debounce
+    recordRecall(result.session_id);
 
     const entityCount = result.entity_references?.length ?? 0;
     const context = formatNexContext({

--- a/claude-code-plugin/src/auto-recall.ts
+++ b/claude-code-plugin/src/auto-recall.ts
@@ -46,6 +46,7 @@ async function main(): Promise<void> {
     try {
       input = JSON.parse(raw) as HookInput;
     } catch {
+      process.stderr.write("[nex-recall] Failed to parse stdin JSON\n");
       process.stdout.write("{}");
       return;
     }
@@ -72,7 +73,10 @@ async function main(): Promise<void> {
     let cfg;
     try {
       cfg = loadConfig();
-    } catch {
+    } catch (err) {
+      process.stderr.write(
+        `[nex-recall] Config error: ${err instanceof Error ? err.message : String(err)}\n`
+      );
       process.stdout.write("{}");
       return;
     }
@@ -113,8 +117,10 @@ async function main(): Promise<void> {
       },
     });
     process.stdout.write(output);
-  } catch {
-    // Graceful degradation — never block Claude Code on recall failure
+  } catch (err) {
+    process.stderr.write(
+      `[nex-recall] Unexpected error: ${err instanceof Error ? err.message : String(err)}\n`
+    );
     process.stdout.write("{}");
   }
 }

--- a/claude-code-plugin/src/auto-recall.ts
+++ b/claude-code-plugin/src/auto-recall.ts
@@ -86,8 +86,14 @@ async function main(): Promise<void> {
       sessionId: result.session_id,
     });
 
-    // Output as plain text — Claude Code adds stdout text as context on exit 0
-    process.stdout.write(context);
+    // Use hookSpecificOutput for discrete context injection (not shown in transcript)
+    const output = JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "UserPromptSubmit",
+        additionalContext: context,
+      },
+    });
+    process.stdout.write(output);
   } catch {
     // Graceful degradation — never block Claude Code on recall failure
     process.stdout.write("{}");

--- a/claude-code-plugin/src/auto-recall.ts
+++ b/claude-code-plugin/src/auto-recall.ts
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/**
+ * Claude Code UserPromptSubmit hook — auto-recall from Nex.
+ *
+ * Reads the user's prompt from stdin, queries Nex for relevant context,
+ * and outputs { additionalContext: "..." } to inject into the conversation.
+ *
+ * On ANY error: outputs {} and exits 0 (graceful degradation).
+ */
+
+import { loadConfig } from "./config.js";
+import { NexClient } from "./nex-client.js";
+import { formatNexContext } from "./context-format.js";
+import { SessionStore } from "./session-store.js";
+
+// Single shared session store (per process — hooks are short-lived so this
+// is effectively per-invocation, but it's here for structural consistency)
+const sessions = new SessionStore();
+
+interface HookInput {
+  prompt?: string;
+  session_id?: string;
+}
+
+async function main(): Promise<void> {
+  try {
+    // Read stdin
+    const chunks: Buffer[] = [];
+    for await (const chunk of process.stdin) {
+      chunks.push(chunk as Buffer);
+    }
+    const raw = Buffer.concat(chunks).toString("utf-8");
+
+    let input: HookInput;
+    try {
+      input = JSON.parse(raw) as HookInput;
+    } catch {
+      // Unparseable stdin — skip silently
+      process.stdout.write("{}");
+      return;
+    }
+
+    const prompt = input.prompt?.trim();
+    if (!prompt || prompt.length < 5) {
+      process.stdout.write("{}");
+      return;
+    }
+
+    // Skip slash commands
+    if (prompt.startsWith("/")) {
+      process.stdout.write("{}");
+      return;
+    }
+
+    let cfg;
+    try {
+      cfg = loadConfig();
+    } catch {
+      // No API key configured — skip silently
+      process.stdout.write("{}");
+      return;
+    }
+
+    const client = new NexClient(cfg.apiKey, cfg.baseUrl);
+
+    // Resolve session ID for multi-turn continuity
+    const sessionKey = input.session_id;
+    const nexSessionId = sessionKey ? sessions.get(sessionKey) : undefined;
+
+    const result = await client.ask(prompt, nexSessionId, 10_000);
+
+    if (!result.answer) {
+      process.stdout.write("{}");
+      return;
+    }
+
+    // Store session ID for future turns
+    if (result.session_id && sessionKey) {
+      sessions.set(sessionKey, result.session_id);
+    }
+
+    const entityCount = result.entity_references?.length ?? 0;
+    const context = formatNexContext({
+      answer: result.answer,
+      entityCount,
+      sessionId: result.session_id,
+    });
+
+    const output = JSON.stringify({ additionalContext: context });
+    process.stdout.write(output);
+  } catch {
+    // Graceful degradation — never block Claude Code on recall failure
+    process.stdout.write("{}");
+  }
+}
+
+main().then(() => process.exit(0)).catch(() => process.exit(0));

--- a/claude-code-plugin/src/auto-session-start.ts
+++ b/claude-code-plugin/src/auto-session-start.ts
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+/**
+ * Claude Code SessionStart hook — bulk context load from Nex.
+ *
+ * Fires once when a new Claude Code session begins. Queries Nex for
+ * a baseline context summary and injects it so the agent "already knows"
+ * relevant business context from the first message.
+ *
+ * On ANY error: outputs {} and exits 0 (graceful degradation).
+ */
+
+import { loadConfig } from "./config.js";
+import { NexClient } from "./nex-client.js";
+import { formatNexContext } from "./context-format.js";
+import { SessionStore } from "./session-store.js";
+import { recordRecall } from "./recall-filter.js";
+
+const sessions = new SessionStore();
+
+interface HookInput {
+  session_id?: string;
+}
+
+const SESSION_START_QUERY = "Summarize the key active context, recent interactions, and important updates for this user.";
+
+async function main(): Promise<void> {
+  try {
+    // Read stdin
+    const chunks: Buffer[] = [];
+    for await (const chunk of process.stdin) {
+      chunks.push(chunk as Buffer);
+    }
+    const raw = Buffer.concat(chunks).toString("utf-8");
+
+    let input: HookInput = {};
+    try {
+      input = JSON.parse(raw) as HookInput;
+    } catch {
+      // Unparseable stdin — continue with empty input
+    }
+
+    let cfg;
+    try {
+      cfg = loadConfig();
+    } catch {
+      process.stdout.write("{}");
+      return;
+    }
+
+    const client = new NexClient(cfg.apiKey, cfg.baseUrl);
+
+    const result = await client.ask(SESSION_START_QUERY, undefined, 10_000);
+
+    if (!result.answer) {
+      process.stdout.write("{}");
+      return;
+    }
+
+    // Store session mapping
+    if (result.session_id && input.session_id) {
+      sessions.set(input.session_id, result.session_id);
+    }
+
+    // Record this as a successful recall for debounce
+    recordRecall(result.session_id);
+
+    const entityCount = result.entity_references?.length ?? 0;
+    const context = formatNexContext({
+      answer: result.answer,
+      entityCount,
+      sessionId: result.session_id,
+    });
+
+    const output = JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "SessionStart",
+        additionalContext: context,
+      },
+    });
+    process.stdout.write(output);
+  } catch {
+    process.stdout.write("{}");
+  }
+}
+
+main().then(() => process.exit(0)).catch(() => process.exit(0));

--- a/claude-code-plugin/src/auto-session-start.ts
+++ b/claude-code-plugin/src/auto-session-start.ts
@@ -36,13 +36,16 @@ async function main(): Promise<void> {
     try {
       input = JSON.parse(raw) as HookInput;
     } catch {
-      // Unparseable stdin — continue with empty input
+      process.stderr.write("[nex-session-start] Failed to parse stdin JSON, continuing with defaults\n");
     }
 
     let cfg;
     try {
       cfg = loadConfig();
-    } catch {
+    } catch (err) {
+      process.stderr.write(
+        `[nex-session-start] Config error: ${err instanceof Error ? err.message : String(err)}\n`
+      );
       process.stdout.write("{}");
       return;
     }
@@ -78,7 +81,10 @@ async function main(): Promise<void> {
       },
     });
     process.stdout.write(output);
-  } catch {
+  } catch (err) {
+    process.stderr.write(
+      `[nex-session-start] Unexpected error: ${err instanceof Error ? err.message : String(err)}\n`
+    );
     process.stdout.write("{}");
   }
 }

--- a/claude-code-plugin/src/capture-filter.ts
+++ b/claude-code-plugin/src/capture-filter.ts
@@ -8,44 +8,6 @@ import { stripNexContext } from "./context-format.js";
 const MIN_LENGTH = 20;
 const MAX_LENGTH = 50_000;
 
-/**
- * Simple content hash for deduplication.
- */
-function hashContent(text: string): string {
-  let hash = 0;
-  for (let i = 0; i < text.length; i++) {
-    const ch = text.charCodeAt(i);
-    hash = ((hash << 5) - hash + ch) | 0;
-  }
-  return hash.toString(36);
-}
-
-interface CacheEntry {
-  hash: string;
-  timestamp: number;
-}
-
-const DEDUP_MAX = 50;
-const DEDUP_TTL_MS = 60 * 60 * 1000; // 1 hour
-
-const dedupCache: CacheEntry[] = [];
-
-function isDuplicate(hash: string): boolean {
-  const now = Date.now();
-  // Evict expired entries
-  while (dedupCache.length > 0 && now - dedupCache[0].timestamp > DEDUP_TTL_MS) {
-    dedupCache.shift();
-  }
-  if (dedupCache.some((e) => e.hash === hash)) {
-    return true;
-  }
-  dedupCache.push({ hash, timestamp: now });
-  if (dedupCache.length > DEDUP_MAX) {
-    dedupCache.shift();
-  }
-  return false;
-}
-
 export interface CaptureResult {
   text: string;
   skipped: false;
@@ -59,6 +21,10 @@ export interface CaptureSkip {
 /**
  * Filter text for capture eligibility.
  * Works with plain strings (Claude Code messages).
+ *
+ * Note: Deduplication is handled server-side by the Nex extraction pipeline.
+ * Since hooks are short-lived processes (new process per invocation), in-memory
+ * dedup caches would be empty on each run and provide no value.
  */
 export function captureFilter(text: string): CaptureResult | CaptureSkip {
   if (!text || text.trim().length === 0) {
@@ -66,7 +32,7 @@ export function captureFilter(text: string): CaptureResult | CaptureSkip {
   }
 
   // Strip injected context blocks (prevent feedback loop)
-  let cleaned = stripNexContext(text);
+  const cleaned = stripNexContext(text);
 
   // Skip too short
   if (cleaned.length < MIN_LENGTH) {
@@ -76,12 +42,6 @@ export function captureFilter(text: string): CaptureResult | CaptureSkip {
   // Skip too long
   if (cleaned.length > MAX_LENGTH) {
     return { skipped: true, reason: `too long (${cleaned.length} chars)` };
-  }
-
-  // Dedup check
-  const hash = hashContent(cleaned);
-  if (isDuplicate(hash)) {
-    return { skipped: true, reason: "duplicate content" };
   }
 
   return { skipped: false, text: cleaned };

--- a/claude-code-plugin/src/capture-filter.ts
+++ b/claude-code-plugin/src/capture-filter.ts
@@ -68,11 +68,6 @@ export function captureFilter(text: string): CaptureResult | CaptureSkip {
   // Strip injected context blocks (prevent feedback loop)
   let cleaned = stripNexContext(text);
 
-  // Skip slash commands
-  if (cleaned.startsWith("/")) {
-    return { skipped: true, reason: "slash command" };
-  }
-
   // Skip too short
   if (cleaned.length < MIN_LENGTH) {
     return { skipped: true, reason: `too short (${cleaned.length} chars)` };

--- a/claude-code-plugin/src/capture-filter.ts
+++ b/claude-code-plugin/src/capture-filter.ts
@@ -1,0 +1,93 @@
+/**
+ * Capture filtering for Claude Code — decides what content to send to Nex.
+ * Adapted from openclaw-plugin for plain string input.
+ */
+
+import { stripNexContext } from "./context-format.js";
+
+const MIN_LENGTH = 20;
+const MAX_LENGTH = 50_000;
+
+/**
+ * Simple content hash for deduplication.
+ */
+function hashContent(text: string): string {
+  let hash = 0;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text.charCodeAt(i);
+    hash = ((hash << 5) - hash + ch) | 0;
+  }
+  return hash.toString(36);
+}
+
+interface CacheEntry {
+  hash: string;
+  timestamp: number;
+}
+
+const DEDUP_MAX = 50;
+const DEDUP_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+const dedupCache: CacheEntry[] = [];
+
+function isDuplicate(hash: string): boolean {
+  const now = Date.now();
+  // Evict expired entries
+  while (dedupCache.length > 0 && now - dedupCache[0].timestamp > DEDUP_TTL_MS) {
+    dedupCache.shift();
+  }
+  if (dedupCache.some((e) => e.hash === hash)) {
+    return true;
+  }
+  dedupCache.push({ hash, timestamp: now });
+  if (dedupCache.length > DEDUP_MAX) {
+    dedupCache.shift();
+  }
+  return false;
+}
+
+export interface CaptureResult {
+  text: string;
+  skipped: false;
+}
+
+export interface CaptureSkip {
+  reason: string;
+  skipped: true;
+}
+
+/**
+ * Filter text for capture eligibility.
+ * Works with plain strings (Claude Code messages).
+ */
+export function captureFilter(text: string): CaptureResult | CaptureSkip {
+  if (!text || text.trim().length === 0) {
+    return { skipped: true, reason: "empty text" };
+  }
+
+  // Strip injected context blocks (prevent feedback loop)
+  let cleaned = stripNexContext(text);
+
+  // Skip slash commands
+  if (cleaned.startsWith("/")) {
+    return { skipped: true, reason: "slash command" };
+  }
+
+  // Skip too short
+  if (cleaned.length < MIN_LENGTH) {
+    return { skipped: true, reason: `too short (${cleaned.length} chars)` };
+  }
+
+  // Skip too long
+  if (cleaned.length > MAX_LENGTH) {
+    return { skipped: true, reason: `too long (${cleaned.length} chars)` };
+  }
+
+  // Dedup check
+  const hash = hashContent(cleaned);
+  if (isDuplicate(hash)) {
+    return { skipped: true, reason: "duplicate content" };
+  }
+
+  return { skipped: false, text: cleaned };
+}

--- a/claude-code-plugin/src/config.ts
+++ b/claude-code-plugin/src/config.ts
@@ -27,7 +27,7 @@ export function loadConfig(): NexConfig {
     );
   }
 
-  let baseUrl = process.env.NEX_API_BASE_URL ?? "https://api.nex-crm.com";
+  let baseUrl = process.env.NEX_API_BASE_URL ?? "https://api.nex.ai";
   // Strip trailing slash
   baseUrl = baseUrl.replace(/\/+$/, "");
 

--- a/claude-code-plugin/src/config.ts
+++ b/claude-code-plugin/src/config.ts
@@ -17,7 +17,7 @@ export class ConfigError extends Error {
 /**
  * Load config from environment variables.
  * - NEX_API_KEY: required
- * - NEX_BASE_URL: optional (default: http://localhost:30000)
+ * - NEX_API_BASE_URL: optional (default: https://api.nex-crm.com)
  */
 export function loadConfig(): NexConfig {
   const apiKey = process.env.NEX_API_KEY;
@@ -27,7 +27,7 @@ export function loadConfig(): NexConfig {
     );
   }
 
-  let baseUrl = process.env.NEX_BASE_URL ?? "http://localhost:30000";
+  let baseUrl = process.env.NEX_API_BASE_URL ?? "https://api.nex-crm.com";
   // Strip trailing slash
   baseUrl = baseUrl.replace(/\/+$/, "");
 

--- a/claude-code-plugin/src/config.ts
+++ b/claude-code-plugin/src/config.ts
@@ -27,7 +27,7 @@ export function loadConfig(): NexConfig {
     );
   }
 
-  let baseUrl = process.env.NEX_API_BASE_URL ?? "https://api.nex.ai";
+  let baseUrl = process.env.NEX_API_BASE_URL ?? "https://app.nex.ai";
   // Strip trailing slash
   baseUrl = baseUrl.replace(/\/+$/, "");
 

--- a/claude-code-plugin/src/config.ts
+++ b/claude-code-plugin/src/config.ts
@@ -1,0 +1,35 @@
+/**
+ * Plugin configuration — reads from environment variables.
+ */
+
+export interface NexConfig {
+  apiKey: string;
+  baseUrl: string;
+}
+
+export class ConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ConfigError";
+  }
+}
+
+/**
+ * Load config from environment variables.
+ * - NEX_API_KEY: required
+ * - NEX_BASE_URL: optional (default: http://localhost:30000)
+ */
+export function loadConfig(): NexConfig {
+  const apiKey = process.env.NEX_API_KEY;
+  if (!apiKey) {
+    throw new ConfigError(
+      "NEX_API_KEY environment variable is required. Export it before using the Nex memory plugin."
+    );
+  }
+
+  let baseUrl = process.env.NEX_BASE_URL ?? "http://localhost:30000";
+  // Strip trailing slash
+  baseUrl = baseUrl.replace(/\/+$/, "");
+
+  return { apiKey, baseUrl };
+}

--- a/claude-code-plugin/src/context-format.ts
+++ b/claude-code-plugin/src/context-format.ts
@@ -1,0 +1,52 @@
+/**
+ * XML context formatting and stripping for recall injection.
+ * Wraps Nex answers in <nex-context> tags and strips them before capture.
+ */
+
+const OPEN_TAG = "<nex-context>";
+const CLOSE_TAG = "</nex-context>";
+
+export interface NexRecallResult {
+  answer: string;
+  entityCount: number;
+  sessionId?: string;
+}
+
+/**
+ * Format a Nex /ask response as an XML block for context injection.
+ */
+export function formatNexContext(result: NexRecallResult): string {
+  const parts: string[] = [
+    OPEN_TAG,
+    "The following is relevant context from the user's knowledge base. Use it to inform your response, but do not mention this block directly.",
+  ];
+
+  if (result.entityCount > 0) {
+    parts.push(`[${result.entityCount} related entities found]`);
+  }
+
+  parts.push("");
+  parts.push(result.answer);
+  parts.push(CLOSE_TAG);
+
+  return parts.join("\n");
+}
+
+/**
+ * Strip all <nex-context>...</nex-context> blocks from text.
+ * Also handles unclosed tags (strips from open tag to end of text).
+ */
+export function stripNexContext(text: string): string {
+  // First: strip complete blocks
+  let result = text.replace(/<nex-context>[\s\S]*?<\/nex-context>/g, "");
+  // Then: strip unclosed tags (open tag without matching close)
+  result = result.replace(/<nex-context>[\s\S]*/g, "");
+  return result.trim();
+}
+
+/**
+ * Check if text contains a nex-context block.
+ */
+export function hasNexContext(text: string): boolean {
+  return text.includes(OPEN_TAG);
+}

--- a/claude-code-plugin/src/context-format.ts
+++ b/claude-code-plugin/src/context-format.ts
@@ -43,10 +43,3 @@ export function stripNexContext(text: string): string {
   result = result.replace(/<nex-context>[\s\S]*/g, "");
   return result.trim();
 }
-
-/**
- * Check if text contains a nex-context block.
- */
-export function hasNexContext(text: string): boolean {
-  return text.includes(OPEN_TAG);
-}

--- a/claude-code-plugin/src/nex-client.ts
+++ b/claude-code-plugin/src/nex-client.ts
@@ -1,0 +1,131 @@
+/**
+ * HTTP client for the Nex Developer API.
+ * Adapted from openclaw-plugin — uses native fetch with timeout.
+ */
+
+// --- Error types ---
+
+export class NexAuthError extends Error {
+  constructor(message = "Invalid or missing API key") {
+    super(message);
+    this.name = "NexAuthError";
+  }
+}
+
+export class NexRateLimitError extends Error {
+  public retryAfterMs: number;
+
+  constructor(retryAfterMs = 60_000) {
+    super(`Rate limited — retry after ${retryAfterMs}ms`);
+    this.name = "NexRateLimitError";
+    this.retryAfterMs = retryAfterMs;
+  }
+}
+
+export class NexServerError extends Error {
+  public status: number;
+
+  constructor(status: number, body?: string) {
+    super(`Nex API error ${status}${body ? `: ${body}` : ""}`);
+    this.name = "NexServerError";
+    this.status = status;
+  }
+}
+
+// --- Response types ---
+
+export interface IngestResponse {
+  artifact_id: string;
+}
+
+export interface EntityReference {
+  id?: number;
+  name: string;
+  type: string;
+  count?: number;
+}
+
+export interface AskResponse {
+  answer: string;
+  session_id?: string;
+  entity_references?: EntityReference[];
+}
+
+// --- Client ---
+
+export class NexClient {
+  private apiKey: string;
+  private baseUrl: string;
+
+  constructor(apiKey: string, baseUrl: string) {
+    this.apiKey = apiKey;
+    this.baseUrl = baseUrl;
+  }
+
+  private async request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+    timeoutMs = 10_000
+  ): Promise<T> {
+    const url = `${this.baseUrl}/api/developers${path}`;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      const headers: Record<string, string> = {
+        Authorization: `Bearer ${this.apiKey}`,
+      };
+      if (body !== undefined) {
+        headers["Content-Type"] = "application/json";
+      }
+
+      const res = await fetch(url, {
+        method,
+        headers,
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+        signal: controller.signal,
+      });
+
+      if (res.status === 401 || res.status === 403) {
+        throw new NexAuthError();
+      }
+
+      if (res.status === 429) {
+        const retryAfter = res.headers.get("retry-after");
+        const ms = retryAfter ? parseInt(retryAfter, 10) * 1000 : 60_000;
+        throw new NexRateLimitError(ms);
+      }
+
+      if (!res.ok) {
+        let errorBody: string | undefined;
+        try {
+          errorBody = await res.text();
+        } catch {
+          // ignore
+        }
+        throw new NexServerError(res.status, errorBody);
+      }
+
+      const text = await res.text();
+      if (!text) return {} as T;
+      return JSON.parse(text) as T;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /** Ingest text content into the Nex knowledge graph. */
+  async ingest(content: string, context?: string): Promise<IngestResponse> {
+    const body: Record<string, string> = { content };
+    if (context) body.context = context;
+    return this.request<IngestResponse>("POST", "/v1/context/text", body, 60_000);
+  }
+
+  /** Ask a question against the Nex knowledge graph. */
+  async ask(query: string, sessionId?: string, timeoutMs?: number): Promise<AskResponse> {
+    const body: Record<string, unknown> = { query };
+    if (sessionId) body.session_id = sessionId;
+    return this.request<AskResponse>("POST", "/v1/context/ask", body, timeoutMs);
+  }
+}

--- a/claude-code-plugin/src/nex-client.ts
+++ b/claude-code-plugin/src/nex-client.ts
@@ -108,7 +108,7 @@ export class NexClient {
       }
 
       const text = await res.text();
-      if (!text) return {} as T;
+      if (!text || !text.trim()) return {} as T;
       return JSON.parse(text) as T;
     } finally {
       clearTimeout(timer);
@@ -116,10 +116,10 @@ export class NexClient {
   }
 
   /** Ingest text content into the Nex knowledge graph. */
-  async ingest(content: string, context?: string): Promise<IngestResponse> {
+  async ingest(content: string, context?: string, timeoutMs?: number): Promise<IngestResponse> {
     const body: Record<string, string> = { content };
     if (context) body.context = context;
-    return this.request<IngestResponse>("POST", "/v1/context/text", body, 60_000);
+    return this.request<IngestResponse>("POST", "/v1/context/text", body, timeoutMs ?? 60_000);
   }
 
   /** Ask a question against the Nex knowledge graph. */

--- a/claude-code-plugin/src/rate-limiter.ts
+++ b/claude-code-plugin/src/rate-limiter.ts
@@ -1,0 +1,108 @@
+/**
+ * Sliding window rate limiter with async queue.
+ * Designed for Nex /text endpoint (10 req/min).
+ */
+
+export interface RateLimiterConfig {
+  maxRequests: number;
+  windowMs: number;
+  maxQueueDepth: number;
+}
+
+const DEFAULTS: RateLimiterConfig = {
+  maxRequests: 10,
+  windowMs: 60_000,
+  maxQueueDepth: 5,
+};
+
+interface QueuedRequest {
+  fn: () => Promise<void>;
+  resolve: () => void;
+  reject: (err: Error) => void;
+}
+
+export class RateLimiter {
+  private timestamps: number[] = [];
+  private queue: QueuedRequest[] = [];
+  private draining = false;
+  private config: RateLimiterConfig;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(config?: Partial<RateLimiterConfig>) {
+    this.config = { ...DEFAULTS, ...config };
+  }
+
+  /** Enqueue a function to be executed within rate limits. */
+  enqueue(fn: () => Promise<void>): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      this.queue.push({ fn, resolve, reject });
+
+      while (this.queue.length > this.config.maxQueueDepth) {
+        const dropped = this.queue.shift()!;
+        dropped.reject(new Error("Rate limiter queue full — request dropped"));
+      }
+
+      this.drain();
+    });
+  }
+
+  private canProceed(): boolean {
+    const now = Date.now();
+    this.timestamps = this.timestamps.filter((t) => now - t < this.config.windowMs);
+    return this.timestamps.length < this.config.maxRequests;
+  }
+
+  private msUntilSlot(): number {
+    if (this.timestamps.length === 0) return 0;
+    const oldest = this.timestamps[0];
+    return Math.max(0, this.config.windowMs - (Date.now() - oldest));
+  }
+
+  private async drain(): Promise<void> {
+    if (this.draining) return;
+    this.draining = true;
+
+    try {
+      while (this.queue.length > 0) {
+        if (this.canProceed()) {
+          const item = this.queue.shift()!;
+          this.timestamps.push(Date.now());
+          try {
+            await item.fn();
+            item.resolve();
+          } catch (err) {
+            item.reject(err instanceof Error ? err : new Error(String(err)));
+          }
+        } else {
+          const wait = this.msUntilSlot();
+          await new Promise<void>((r) => {
+            this.timer = setTimeout(r, wait);
+          });
+        }
+      }
+    } finally {
+      this.draining = false;
+    }
+  }
+
+  /** Flush pending queue (called on shutdown). */
+  async flush(): Promise<void> {
+    while (this.draining || this.queue.length > 0) {
+      await new Promise((r) => setTimeout(r, 50));
+    }
+  }
+
+  /** Cancel all pending and stop timers. */
+  destroy(): void {
+    if (this.timer) clearTimeout(this.timer);
+    for (const item of this.queue) {
+      item.reject(new Error("Rate limiter destroyed"));
+    }
+    this.queue.length = 0;
+    this.timestamps.length = 0;
+  }
+
+  get pending(): number {
+    return this.queue.length;
+  }
+}

--- a/claude-code-plugin/src/rate-limiter.ts
+++ b/claude-code-plugin/src/rate-limiter.ts
@@ -1,108 +1,79 @@
 /**
- * Sliding window rate limiter with async queue.
+ * File-based sliding window rate limiter.
  * Designed for Nex /text endpoint (10 req/min).
+ *
+ * Since Claude Code hooks are short-lived processes (start, run, exit),
+ * in-memory state is lost between invocations. This implementation persists
+ * timestamps to a JSON file so rate limits are respected across invocations.
  */
+
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
 
 export interface RateLimiterConfig {
   maxRequests: number;
   windowMs: number;
-  maxQueueDepth: number;
+  dataDir: string;
 }
 
 const DEFAULTS: RateLimiterConfig = {
   maxRequests: 10,
   windowMs: 60_000,
-  maxQueueDepth: 5,
+  dataDir: join(homedir(), ".nex"),
 };
 
-interface QueuedRequest {
-  fn: () => Promise<void>;
-  resolve: () => void;
-  reject: (err: Error) => void;
-}
-
 export class RateLimiter {
-  private timestamps: number[] = [];
-  private queue: QueuedRequest[] = [];
-  private draining = false;
   private config: RateLimiterConfig;
-  private timer: ReturnType<typeof setTimeout> | null = null;
+  private filePath: string;
 
   constructor(config?: Partial<RateLimiterConfig>) {
     this.config = { ...DEFAULTS, ...config };
+    this.filePath = join(this.config.dataDir, "rate-limiter.json");
+    mkdirSync(this.config.dataDir, { recursive: true });
   }
 
-  /** Enqueue a function to be executed within rate limits. */
-  enqueue(fn: () => Promise<void>): Promise<void> {
-    return new Promise<void>((resolve, reject) => {
-      this.queue.push({ fn, resolve, reject });
-
-      while (this.queue.length > this.config.maxQueueDepth) {
-        const dropped = this.queue.shift()!;
-        dropped.reject(new Error("Rate limiter queue full — request dropped"));
-      }
-
-      this.drain();
-    });
-  }
-
-  private canProceed(): boolean {
-    const now = Date.now();
-    this.timestamps = this.timestamps.filter((t) => now - t < this.config.windowMs);
-    return this.timestamps.length < this.config.maxRequests;
-  }
-
-  private msUntilSlot(): number {
-    if (this.timestamps.length === 0) return 0;
-    const oldest = this.timestamps[0];
-    return Math.max(0, this.config.windowMs - (Date.now() - oldest));
-  }
-
-  private async drain(): Promise<void> {
-    if (this.draining) return;
-    this.draining = true;
-
+  private readTimestamps(): number[] {
     try {
-      while (this.queue.length > 0) {
-        if (this.canProceed()) {
-          const item = this.queue.shift()!;
-          this.timestamps.push(Date.now());
-          try {
-            await item.fn();
-            item.resolve();
-          } catch (err) {
-            item.reject(err instanceof Error ? err : new Error(String(err)));
-          }
-        } else {
-          const wait = this.msUntilSlot();
-          await new Promise<void>((r) => {
-            this.timer = setTimeout(r, wait);
-          });
-        }
-      }
-    } finally {
-      this.draining = false;
+      const raw = readFileSync(this.filePath, "utf-8");
+      const data = JSON.parse(raw);
+      if (Array.isArray(data)) return data;
+      return [];
+    } catch {
+      return [];
     }
   }
 
-  /** Flush pending queue (called on shutdown). */
-  async flush(): Promise<void> {
-    while (this.draining || this.queue.length > 0) {
-      await new Promise((r) => setTimeout(r, 50));
+  private writeTimestamps(timestamps: number[]): void {
+    try {
+      writeFileSync(this.filePath, JSON.stringify(timestamps), "utf-8");
+    } catch {
+      // Best-effort — if we can't write, proceed without rate limiting
     }
   }
 
-  /** Cancel all pending and stop timers. */
-  destroy(): void {
-    if (this.timer) clearTimeout(this.timer);
-    for (const item of this.queue) {
-      item.reject(new Error("Rate limiter destroyed"));
+  /**
+   * Check if a request can proceed, and if so, record the timestamp.
+   * Returns true if the request is allowed, false if rate limited.
+   */
+  canProceed(): boolean {
+    const now = Date.now();
+    const timestamps = this.readTimestamps().filter(
+      (t) => now - t < this.config.windowMs
+    );
+
+    if (timestamps.length >= this.config.maxRequests) {
+      // Write back pruned timestamps
+      this.writeTimestamps(timestamps);
+      return false;
     }
-    this.queue.length = 0;
-    this.timestamps.length = 0;
+
+    timestamps.push(now);
+    this.writeTimestamps(timestamps);
+    return true;
   }
 
   get pending(): number {
-    return this.queue.length;
+    return 0;
   }
 }

--- a/claude-code-plugin/src/recall-filter.ts
+++ b/claude-code-plugin/src/recall-filter.ts
@@ -1,0 +1,120 @@
+/**
+ * Smart prompt classifier for selective recall.
+ *
+ * Determines whether a prompt is likely knowledge-seeking (needs recall)
+ * or a pure coding directive (skip recall). Also handles debounce —
+ * skips recall if a successful recall happened within the debounce window,
+ * unless the current prompt contains question words.
+ *
+ * Persistence: last-recall timestamp stored in ~/.nex/recall-state.json
+ */
+
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const DATA_DIR = join(homedir(), ".nex");
+const STATE_FILE = join(DATA_DIR, "recall-state.json");
+const DEBOUNCE_MS = 30_000; // 30 seconds
+
+// --- Question words that signal knowledge-seeking intent ---
+const QUESTION_WORDS = /\b(who|what|when|where|why|how|which|tell|explain|describe|summarize|summarise|list|find|show|get|any|does|did|is|are|was|were|have|has|do|can|could|should|would|will)\b/i;
+
+// --- Tool/action commands that are pure coding directives ---
+const TOOL_COMMANDS = /^\s*(run|build|test|lint|format|deploy|install|uninstall|start|stop|restart|commit|push|pull|merge|rebase|checkout|fetch|init|fix|refactor|rename|move|delete|remove|add|create|update|upgrade|downgrade|migrate|generate|scaffold|compile|bundle|watch|serve|debug|profile|bench|clean|reset|undo|redo|revert|squash|cherry-pick|tag|release|publish|npm|npx|yarn|pnpm|bun|pip|cargo|go|make|docker|kubectl|terraform|git|gh|cd|ls|cat|grep|find|mkdir|rm|cp|mv|touch|echo|export|source|chmod|chown|curl|wget|ssh|scp)\b/i;
+
+// --- File reference pattern (paths, extensions) ---
+const FILE_REF = /(?:[\w./\\-]+\.\w{1,10}|src\/|lib\/|dist\/|node_modules\/|\.\/|\.\.\/)/;
+
+// --- Code-heavy: >50% non-alpha characters (brackets, operators, etc.) ---
+function isCodeHeavy(text: string): boolean {
+  const alpha = text.replace(/[^a-zA-Z]/g, "").length;
+  return alpha < text.length * 0.5;
+}
+
+export interface RecallDecision {
+  shouldRecall: boolean;
+  reason: string;
+}
+
+interface RecallState {
+  lastRecallAt: number; // epoch ms
+  lastRecallSessionId?: string;
+}
+
+function readState(): RecallState {
+  try {
+    const raw = readFileSync(STATE_FILE, "utf-8");
+    return JSON.parse(raw) as RecallState;
+  } catch {
+    return { lastRecallAt: 0 };
+  }
+}
+
+function writeState(state: RecallState): void {
+  try {
+    mkdirSync(DATA_DIR, { recursive: true });
+    writeFileSync(STATE_FILE, JSON.stringify(state), "utf-8");
+  } catch {
+    // best-effort
+  }
+}
+
+/**
+ * Record that a successful recall just happened.
+ * Call this after a non-empty /ask response.
+ */
+export function recordRecall(sessionId?: string): void {
+  writeState({ lastRecallAt: Date.now(), lastRecallSessionId: sessionId });
+}
+
+/**
+ * Determine whether this prompt should trigger a Nex /ask recall.
+ */
+export function shouldRecall(prompt: string, isFirstPrompt: boolean): RecallDecision {
+  const trimmed = prompt.trim();
+
+  // Always recall on first prompt of session
+  if (isFirstPrompt) {
+    return { shouldRecall: true, reason: "first-prompt" };
+  }
+
+  // Explicit opt-out: prompt starts with !
+  if (trimmed.startsWith("!")) {
+    return { shouldRecall: false, reason: "opt-out" };
+  }
+
+  // Too short — likely a directive like "yes", "ok", "done"
+  if (trimmed.length < 15) {
+    return { shouldRecall: false, reason: "too-short" };
+  }
+
+  // Has question words — likely knowledge-seeking
+  const hasQuestion = QUESTION_WORDS.test(trimmed);
+
+  // Check debounce: skip if recent successful recall, unless question
+  if (!hasQuestion) {
+    const state = readState();
+    if (state.lastRecallAt > 0 && Date.now() - state.lastRecallAt < DEBOUNCE_MS) {
+      return { shouldRecall: false, reason: "debounce" };
+    }
+  }
+
+  // Tool/action commands — pure coding directives
+  if (TOOL_COMMANDS.test(trimmed) && !hasQuestion) {
+    return { shouldRecall: false, reason: "tool-command" };
+  }
+
+  // Code-heavy with file references and no question words
+  if (isCodeHeavy(trimmed) && FILE_REF.test(trimmed) && !hasQuestion) {
+    return { shouldRecall: false, reason: "code-prompt" };
+  }
+
+  // Has question words — always recall
+  if (hasQuestion) {
+    return { shouldRecall: true, reason: "question" };
+  }
+
+  // Default: recall (err on the side of providing context)
+  return { shouldRecall: true, reason: "default" };
+}

--- a/claude-code-plugin/src/session-store.ts
+++ b/claude-code-plugin/src/session-store.ts
@@ -1,50 +1,89 @@
 /**
- * In-memory session store mapping Claude Code session IDs to Nex session IDs.
- * LRU eviction at configurable max size.
+ * File-based session store mapping Claude Code session IDs to Nex session IDs.
+ *
+ * Since Claude Code hooks are short-lived processes (start, run, exit),
+ * in-memory state is lost between invocations. This implementation persists
+ * session mappings to a JSON file so multi-turn continuity works.
  */
 
-const DEFAULT_MAX = 1000;
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const DEFAULT_MAX = 100;
+const DEFAULT_DATA_DIR = join(homedir(), ".nex");
+
+export interface SessionStoreConfig {
+  maxSize: number;
+  dataDir: string;
+}
 
 export class SessionStore {
-  private map = new Map<string, string>();
+  private filePath: string;
   private maxSize: number;
 
-  constructor(maxSize = DEFAULT_MAX) {
-    this.maxSize = maxSize;
+  constructor(config?: Partial<SessionStoreConfig>) {
+    const dataDir = config?.dataDir ?? DEFAULT_DATA_DIR;
+    this.maxSize = config?.maxSize ?? DEFAULT_MAX;
+    this.filePath = join(dataDir, "claude-sessions.json");
+    mkdirSync(dataDir, { recursive: true });
+  }
+
+  private readStore(): Record<string, string> {
+    try {
+      const raw = readFileSync(this.filePath, "utf-8");
+      const data = JSON.parse(raw);
+      if (data && typeof data === "object" && !Array.isArray(data)) {
+        return data as Record<string, string>;
+      }
+      return {};
+    } catch {
+      return {};
+    }
+  }
+
+  private writeStore(store: Record<string, string>): void {
+    try {
+      writeFileSync(this.filePath, JSON.stringify(store), "utf-8");
+    } catch {
+      // Best-effort — if we can't write, session continuity degrades gracefully
+    }
   }
 
   get(sessionKey: string): string | undefined {
-    const value = this.map.get(sessionKey);
-    if (value !== undefined) {
-      // Move to end (most recently used)
-      this.map.delete(sessionKey);
-      this.map.set(sessionKey, value);
-    }
-    return value;
+    const store = this.readStore();
+    return store[sessionKey];
   }
 
   set(sessionKey: string, nexSessionId: string): void {
-    if (this.map.has(sessionKey)) {
-      this.map.delete(sessionKey);
+    const store = this.readStore();
+    store[sessionKey] = nexSessionId;
+
+    // Evict oldest entries if over max size
+    const keys = Object.keys(store);
+    while (keys.length > this.maxSize) {
+      const oldest = keys.shift()!;
+      delete store[oldest];
     }
 
-    this.map.set(sessionKey, nexSessionId);
-
-    while (this.map.size > this.maxSize) {
-      const oldest = this.map.keys().next().value!;
-      this.map.delete(oldest);
-    }
+    this.writeStore(store);
   }
 
   delete(sessionKey: string): boolean {
-    return this.map.delete(sessionKey);
+    const store = this.readStore();
+    if (sessionKey in store) {
+      delete store[sessionKey];
+      this.writeStore(store);
+      return true;
+    }
+    return false;
   }
 
   get size(): number {
-    return this.map.size;
+    return Object.keys(this.readStore()).length;
   }
 
   clear(): void {
-    this.map.clear();
+    this.writeStore({});
   }
 }

--- a/claude-code-plugin/src/session-store.ts
+++ b/claude-code-plugin/src/session-store.ts
@@ -1,0 +1,50 @@
+/**
+ * In-memory session store mapping Claude Code session IDs to Nex session IDs.
+ * LRU eviction at configurable max size.
+ */
+
+const DEFAULT_MAX = 1000;
+
+export class SessionStore {
+  private map = new Map<string, string>();
+  private maxSize: number;
+
+  constructor(maxSize = DEFAULT_MAX) {
+    this.maxSize = maxSize;
+  }
+
+  get(sessionKey: string): string | undefined {
+    const value = this.map.get(sessionKey);
+    if (value !== undefined) {
+      // Move to end (most recently used)
+      this.map.delete(sessionKey);
+      this.map.set(sessionKey, value);
+    }
+    return value;
+  }
+
+  set(sessionKey: string, nexSessionId: string): void {
+    if (this.map.has(sessionKey)) {
+      this.map.delete(sessionKey);
+    }
+
+    this.map.set(sessionKey, nexSessionId);
+
+    while (this.map.size > this.maxSize) {
+      const oldest = this.map.keys().next().value!;
+      this.map.delete(oldest);
+    }
+  }
+
+  delete(sessionKey: string): boolean {
+    return this.map.delete(sessionKey);
+  }
+
+  get size(): number {
+    return this.map.size;
+  }
+
+  clear(): void {
+    this.map.clear();
+  }
+}

--- a/claude-code-plugin/tsconfig.json
+++ b/claude-code-plugin/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"]
+}

--- a/openclaw-plugin/openclaw.plugin.json
+++ b/openclaw-plugin/openclaw.plugin.json
@@ -1,5 +1,5 @@
 {
-  "id": "memory-nex",
+  "id": "nex",
   "kind": "memory",
   "configSchema": {
     "type": "object",

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@nex-crm/memory-nex",
+  "name": "@nex-crm/nex",
   "version": "0.1.0",
   "description": "Nex memory plugin for OpenClaw — persistent context intelligence for AI agents",
   "type": "module",

--- a/openclaw-plugin/src/index.ts
+++ b/openclaw-plugin/src/index.ts
@@ -120,7 +120,7 @@ interface OpenClawPluginApi {
 // --- Plugin definition ---
 
 const plugin = {
-  id: "memory-nex",
+  id: "nex",
   name: "Nex Memory",
   description: "Persistent context intelligence for OpenClaw agents, powered by Nex",
   version: "0.1.0",
@@ -151,7 +151,7 @@ const plugin = {
     // --- Service (health check on start, cleanup on stop) ---
 
     api.registerService({
-      id: "memory-nex",
+      id: "nex",
       async start({ logger }) {
         logger.info("Nex memory plugin starting...");
         try {

--- a/openclaw-plugin/tests/index.test.ts
+++ b/openclaw-plugin/tests/index.test.ts
@@ -395,7 +395,7 @@ describe("session-store", () => {
 
 describe("plugin", () => {
   it("has correct id and kind", () => {
-    expect(plugin.id).toBe("memory-nex");
+    expect(plugin.id).toBe("nex");
     expect(plugin.kind).toBe("memory");
   });
 


### PR DESCRIPTION
## Summary

Claude Code plugin for Nex persistent memory with three integration paths: hooks (automatic), MCP server (agent-controlled), slash commands (manual).

### Hooks Architecture
- **SessionStart hook** (`auto-session-start.ts`): Loads baseline context summary on session open — agent "already knows" business context from first message
- **UserPromptSubmit hook** (`auto-recall.ts`): Selective per-prompt recall with smart filtering — only fires for knowledge-seeking prompts
- **Stop hook** (`auto-capture.ts`): Captures assistant responses and sends to Nex for fact extraction (fire-and-forget)

### Token Optimization — Hybrid Recall Strategy
~60% reduction in `/ask` API calls per session via `recall-filter.ts`:

| Rule | Action |
|------|--------|
| First prompt of session | Always recall |
| `!` prefix | Skip (explicit opt-out) |
| < 15 chars | Skip (short directives) |
| Question words (who/what/how/tell/summarize...) | Always recall |
| Recent recall < 30s ago + no question words | Skip (debounce) |
| Tool commands (run/build/test/git/lint...) | Skip |
| Code-heavy + file refs + no question | Skip |
| Everything else | Recall |

### Supporting Infrastructure
- **Session persistence**: File-based LRU store at `~/.nex/claude-sessions.json` for multi-turn continuity
- **Debounce state**: `~/.nex/recall-state.json` tracks last successful recall timestamp
- **Rate limiting**: File-based sliding window at `~/.nex/rate-limiter.json` (10 req/min)
- **Capture filter**: Strips `<nex-context>` blocks to prevent feedback loops, enforces length bounds
- **Slash commands**: `/recall` and `/remember` for manual control
- **Graceful degradation**: All errors return `{}` with exit 0 — never blocks Claude Code

## Test plan

- [x] 17/17 recall filter unit tests pass (skip/recall classification + debounce + bypass)
- [x] SessionStart returns rich baseline context from live API
- [x] Code prompts ("run the tests", "build docker") correctly skip recall
- [x] Short directives ("yes do it") correctly skip
- [x] Opt-out prefix ("!query") correctly skips
- [x] Knowledge questions ("Who should I loop in...") correctly recall
- [x] Debounce: non-question within 30s skips, question within 30s still recalls
- [x] Graceful degradation: hooks output `{}` and exit 0 when no API key configured
- [x] R1-R6, C1-C3, E1-E4, S1 manual E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)