### PR TITLE
feat: OpenClaw plugin feature parity

### DIFF
--- a/openclaw-plugin/src/config.ts
+++ b/openclaw-plugin/src/config.ts
@@ -3,8 +3,8 @@
  * Resolves API key from config, env var, ${VAR} interpolation,
  * or ~/.nex-mcp.json fallback (shared with MCP server).
  */
-import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
-import { join, dirname } from "node:path";
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { homedir } from "node:os";
 
 export interface NexPluginConfig {
@@ -83,13 +83,12 @@ export function persistRegistration(data: Record<string, unknown>): void {
     existing.workspace_id = String(data.workspace_id);
   }
   if (typeof data.workspace_slug === "string") existing.workspace_slug = data.workspace_slug;
-  mkdirSync(dirname(MCP_CONFIG_PATH), { recursive: true });
   writeFileSync(MCP_CONFIG_PATH, JSON.stringify(existing, null, 2) + "\n", "utf-8");
 }
 
 /** Load base URL without requiring an API key. Used for registration. */
 export function loadBaseUrl(): string {
-  let baseUrl = process.env.NEX_API_BASE_URL ?? "https://app.nex.ai";
+  let baseUrl = process.env.NEX_API_BASE_URL ?? DEFAULTS.baseUrl;
   return baseUrl.replace(/\/+$/, "");
 }
 

--- a/openclaw-plugin/src/config.ts
+++ b/openclaw-plugin/src/config.ts
@@ -1,7 +1,11 @@
 /**
  * Plugin configuration parsing and validation.
- * Resolves API key from config, env var, or ${VAR} interpolation.
+ * Resolves API key from config, env var, ${VAR} interpolation,
+ * or ~/.nex-mcp.json fallback (shared with MCP server).
  */
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { homedir } from "node:os";
 
 export interface NexPluginConfig {
   apiKey: string;
@@ -13,6 +17,15 @@ export interface NexPluginConfig {
   sessionTracking: boolean;
   recallTimeoutMs: number;
   debug: boolean;
+}
+
+export interface ScanConfig {
+  extensions: string[];
+  maxFileSize: number;
+  maxFilesPerScan: number;
+  scanDepth: number;
+  ignoreDirs: string[];
+  enabled: boolean;
 }
 
 const DEFAULTS: Omit<NexPluginConfig, "apiKey"> = {
@@ -40,21 +53,65 @@ export class ConfigError extends Error {
   }
 }
 
+// --- Shared MCP config (registration data) ---
+
+/** Shared config file with MCP server — stores registration data. */
+export const MCP_CONFIG_PATH = join(homedir(), ".nex-mcp.json");
+
+interface McpConfig {
+  api_key?: string;
+  base_url?: string;
+  workspace_id?: string;
+  workspace_slug?: string;
+}
+
+/** Read ~/.nex-mcp.json (shared with MCP server registration). */
+export function loadMcpConfig(): McpConfig {
+  try {
+    const raw = readFileSync(MCP_CONFIG_PATH, "utf-8");
+    return JSON.parse(raw);
+  } catch {
+    return {};
+  }
+}
+
+/** Write registration data to ~/.nex-mcp.json. */
+export function persistRegistration(data: Record<string, unknown>): void {
+  const existing = loadMcpConfig();
+  if (typeof data.api_key === "string") existing.api_key = data.api_key;
+  if (typeof data.workspace_id === "string" || typeof data.workspace_id === "number") {
+    existing.workspace_id = String(data.workspace_id);
+  }
+  if (typeof data.workspace_slug === "string") existing.workspace_slug = data.workspace_slug;
+  mkdirSync(dirname(MCP_CONFIG_PATH), { recursive: true });
+  writeFileSync(MCP_CONFIG_PATH, JSON.stringify(existing, null, 2) + "\n", "utf-8");
+}
+
+/** Load base URL without requiring an API key. Used for registration. */
+export function loadBaseUrl(): string {
+  let baseUrl = process.env.NEX_API_BASE_URL ?? "https://app.nex.ai";
+  return baseUrl.replace(/\/+$/, "");
+}
+
 /**
  * Parse raw plugin config into a validated NexPluginConfig.
- * Falls back to process.env.NEX_API_KEY if no apiKey in config.
+ * Falls back to process.env.NEX_API_KEY, then ~/.nex-mcp.json.
  */
 export function parseConfig(raw?: Record<string, unknown>): NexPluginConfig {
   const cfg = raw ?? {};
 
-  // Resolve API key: config → env var interpolation → NEX_API_KEY env
+  // Resolve API key: config → env var interpolation → NEX_API_KEY env → ~/.nex-mcp.json
   let apiKey = typeof cfg.apiKey === "string" ? resolveEnvVars(cfg.apiKey) : undefined;
   if (!apiKey) {
     apiKey = process.env.NEX_API_KEY;
   }
   if (!apiKey) {
+    const mcpConfig = loadMcpConfig();
+    apiKey = mcpConfig.api_key;
+  }
+  if (!apiKey) {
     throw new ConfigError(
-      "No API key configured. Set 'apiKey' in plugin config or export NEX_API_KEY environment variable."
+      "No API key configured. Set 'apiKey' in plugin config, export NEX_API_KEY, or run /register to create an account."
     );
   }
 
@@ -88,4 +145,42 @@ export function parseConfig(raw?: Record<string, unknown>): NexPluginConfig {
     recallTimeoutMs,
     debug: typeof cfg.debug === "boolean" ? cfg.debug : DEFAULTS.debug,
   };
+}
+
+// --- Scan config ---
+
+const DEFAULT_SCAN_EXTENSIONS = [".md", ".txt", ".csv", ".json", ".yaml", ".yml"];
+const DEFAULT_IGNORE_DIRS = [
+  "node_modules", ".git", "dist", "build", ".next", "__pycache__",
+  "vendor", ".venv", ".claude", ".openclaw", "coverage", ".turbo", ".cache",
+];
+
+/**
+ * Parse scan config from plugin config or environment variables.
+ * All fields have sensible defaults; enabled=false is the kill switch.
+ */
+export function parseScanConfig(pluginCfg?: NexPluginConfig | Record<string, unknown>): ScanConfig {
+  const enabled = (process.env.NEX_SCAN_ENABLED ?? "true").toLowerCase() !== "false";
+
+  const extensions = process.env.NEX_SCAN_EXTENSIONS
+    ? process.env.NEX_SCAN_EXTENSIONS.split(",").map((e) => e.trim())
+    : DEFAULT_SCAN_EXTENSIONS;
+
+  const maxFileSize = process.env.NEX_SCAN_MAX_FILE_SIZE
+    ? parseInt(process.env.NEX_SCAN_MAX_FILE_SIZE, 10)
+    : 100_000;
+
+  const maxFilesPerScan = process.env.NEX_SCAN_MAX_FILES
+    ? parseInt(process.env.NEX_SCAN_MAX_FILES, 10)
+    : 5;
+
+  const scanDepth = process.env.NEX_SCAN_DEPTH
+    ? parseInt(process.env.NEX_SCAN_DEPTH, 10)
+    : 2;
+
+  const ignoreDirs = process.env.NEX_SCAN_IGNORE_DIRS
+    ? process.env.NEX_SCAN_IGNORE_DIRS.split(",").map((d) => d.trim())
+    : DEFAULT_IGNORE_DIRS;
+
+  return { extensions, maxFileSize, maxFilesPerScan, scanDepth, ignoreDirs, enabled };
 }

--- a/openclaw-plugin/src/config.ts
+++ b/openclaw-plugin/src/config.ts
@@ -29,7 +29,7 @@ export interface ScanConfig {
 }
 
 const DEFAULTS: Omit<NexPluginConfig, "apiKey"> = {
-  baseUrl: "https://api.nex-crm.com",
+  baseUrl: "https://app.nex.ai",
   autoRecall: true,
   autoCapture: true,
   captureMode: "last_turn",

--- a/openclaw-plugin/src/context-files.ts
+++ b/openclaw-plugin/src/context-files.ts
@@ -94,6 +94,7 @@ export async function ingestContextFiles(
       }
 
       await client.ingest(content, contextTag);
+      if (rateLimiter) rateLimiter.recordRequest();
       markIngested(path, stat, contextTag, manifest);
       result.ingested++;
       result.files.push(contextTag);

--- a/openclaw-plugin/src/context-files.ts
+++ b/openclaw-plugin/src/context-files.ts
@@ -1,0 +1,113 @@
+/**
+ * Ingests OpenClaw context files into Nex.
+ *
+ * Reads from project-level locations:
+ * - {cwd}/CLAUDE.md (project instructions, if exists)
+ * - {cwd}/.openclaw/ config directory (any .md/.yaml/.json files)
+ *
+ * Uses the file manifest for change detection — unchanged files are skipped.
+ */
+import { existsSync, readdirSync, statSync, readFileSync } from "node:fs";
+import { join, extname, basename } from "node:path";
+import { readManifest, writeManifest, isChanged, markIngested } from "./file-manifest.js";
+import type { NexClient } from "./nex-client.js";
+import type { RateLimiter } from "./rate-limiter.js";
+
+const MAX_FILE_SIZE = 100_000;
+const CONTEXT_EXTENSIONS = new Set([".md", ".yaml", ".yml", ".json", ".txt"]);
+
+interface ContextFileCandidate {
+  path: string;
+  contextTag: string;
+}
+
+/**
+ * Collect all context file paths to check.
+ */
+function collectContextFiles(cwd: string): ContextFileCandidate[] {
+  const files: ContextFileCandidate[] = [];
+
+  // 1. Project CLAUDE.md
+  const projectClaude = join(cwd, "CLAUDE.md");
+  if (existsSync(projectClaude)) {
+    files.push({ path: projectClaude, contextTag: "claude-md:project" });
+  }
+
+  // 2. .openclaw/ config directory
+  const openclawDir = join(cwd, ".openclaw");
+  if (existsSync(openclawDir)) {
+    try {
+      const entries = readdirSync(openclawDir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isFile()) continue;
+        const ext = extname(entry.name).toLowerCase();
+        if (!CONTEXT_EXTENSIONS.has(ext)) continue;
+        const fullPath = join(openclawDir, entry.name);
+        const name = basename(entry.name, ext);
+        files.push({ path: fullPath, contextTag: `openclaw-config:${name}` });
+      }
+    } catch {
+      // openclawDir unreadable — skip silently
+    }
+  }
+
+  return files;
+}
+
+export interface ContextFilesResult {
+  ingested: number;
+  skipped: number;
+  errors: number;
+  files: string[];
+}
+
+/**
+ * Ingest changed context files into Nex.
+ */
+export async function ingestContextFiles(
+  client: NexClient,
+  cwd: string,
+  rateLimiter?: RateLimiter,
+): Promise<ContextFilesResult> {
+  const result: ContextFilesResult = { ingested: 0, skipped: 0, errors: 0, files: [] };
+  const manifest = readManifest();
+  const candidates = collectContextFiles(cwd);
+  let dirty = false;
+
+  for (const { path, contextTag } of candidates) {
+    try {
+      const stat = statSync(path);
+      if (!isChanged(path, stat, manifest)) {
+        result.skipped++;
+        continue;
+      }
+
+      if (rateLimiter && !rateLimiter.canProceed()) {
+        process.stderr.write("[nex-context-files] Rate limited — stopping context file ingest\n");
+        result.skipped += candidates.length - result.ingested - result.skipped - result.errors;
+        break;
+      }
+
+      let content = readFileSync(path, "utf-8");
+      if (content.length > MAX_FILE_SIZE) {
+        content = content.slice(0, MAX_FILE_SIZE) + "\n[...truncated]";
+      }
+
+      await client.ingest(content, contextTag);
+      markIngested(path, stat, contextTag, manifest);
+      result.ingested++;
+      result.files.push(contextTag);
+      dirty = true;
+    } catch (err) {
+      process.stderr.write(
+        `[nex-context-files] Failed to ingest ${contextTag}: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      result.errors++;
+    }
+  }
+
+  if (dirty) {
+    writeManifest(manifest);
+  }
+  return result;
+}

--- a/openclaw-plugin/src/file-manifest.ts
+++ b/openclaw-plugin/src/file-manifest.ts
@@ -1,0 +1,61 @@
+/**
+ * Persistent file manifest — tracks which files have been ingested
+ * using mtime + size as change detection.
+ *
+ * Stored at ~/.nex/file-scan-manifest.json. Follows session-store.ts pattern.
+ */
+import { readFileSync, writeFileSync, mkdirSync, type Stats } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const DATA_DIR = join(homedir(), ".nex");
+const MANIFEST_PATH = join(DATA_DIR, "file-scan-manifest.json");
+
+export interface FileManifestEntry {
+  mtime: number;
+  size: number;
+  ingestedAt: number;
+  context: string;
+}
+
+export interface FileManifest {
+  version: 1;
+  files: Record<string, FileManifestEntry>;
+}
+
+export function readManifest(): FileManifest {
+  try {
+    const raw = readFileSync(MANIFEST_PATH, "utf-8");
+    const data = JSON.parse(raw);
+    if (data && data.version === 1 && data.files) {
+      return data;
+    }
+    return { version: 1, files: {} };
+  } catch {
+    return { version: 1, files: {} };
+  }
+}
+
+export function writeManifest(manifest: FileManifest): void {
+  try {
+    mkdirSync(DATA_DIR, { recursive: true });
+    writeFileSync(MANIFEST_PATH, JSON.stringify(manifest, null, 2), "utf-8");
+  } catch {
+    // Best-effort — if we can't write, next scan re-ingests
+  }
+}
+
+export function isChanged(path: string, stat: Stats, manifest: FileManifest): boolean {
+  const entry = manifest.files[path];
+  if (!entry) return true;
+  return entry.mtime !== stat.mtimeMs || entry.size !== stat.size;
+}
+
+export function markIngested(path: string, stat: Stats, context: string, manifest: FileManifest): void {
+  manifest.files[path] = {
+    mtime: stat.mtimeMs,
+    size: stat.size,
+    ingestedAt: Date.now(),
+    context,
+  };
+}

--- a/openclaw-plugin/src/file-scanner.ts
+++ b/openclaw-plugin/src/file-scanner.ts
@@ -1,0 +1,116 @@
+/**
+ * Core file scanner — walks project directories, detects changed files,
+ * and ingests them into Nex via the developer API.
+ *
+ * Adapted for OpenClaw plugin. Uses NexClient.ingest(content, context?)
+ * without timeout parameter. Rate limiting uses canProceed() check.
+ */
+import { readdirSync, statSync, readFileSync, type Stats } from "node:fs";
+import { join, relative, extname } from "node:path";
+import { readManifest, writeManifest, isChanged, markIngested } from "./file-manifest.js";
+import type { NexClient } from "./nex-client.js";
+import type { ScanConfig } from "./config.js";
+import type { RateLimiter } from "./rate-limiter.js";
+
+interface FileCandidate {
+  absolutePath: string;
+  relativePath: string;
+  stat: Stats;
+}
+
+/**
+ * Recursively collect candidate files up to scanDepth levels.
+ */
+function walkDir(dir: string, cwd: string, config: ScanConfig, depth: number, results: FileCandidate[]): void {
+  if (depth > config.scanDepth) return;
+
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return; // Permission denied or missing — skip silently
+  }
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (config.ignoreDirs.includes(entry.name)) continue;
+      walkDir(fullPath, cwd, config, depth + 1, results);
+    } else if (entry.isFile()) {
+      const ext = extname(entry.name).toLowerCase();
+      if (!config.extensions.includes(ext)) continue;
+      try {
+        const stat = statSync(fullPath);
+        results.push({
+          absolutePath: fullPath,
+          relativePath: relative(cwd, fullPath),
+          stat,
+        });
+      } catch {
+        // stat failed — skip
+      }
+    }
+  }
+}
+
+export interface ScanResult {
+  scanned: number;
+  ingested: number;
+  skipped: number;
+  errors: number;
+}
+
+/**
+ * Scan project directory for text files and ingest changed ones into Nex.
+ */
+export async function scanAndIngest(
+  client: NexClient,
+  cwd: string,
+  config: ScanConfig,
+  rateLimiter?: RateLimiter,
+): Promise<ScanResult> {
+  const result: ScanResult = { scanned: 0, ingested: 0, skipped: 0, errors: 0 };
+  if (!config.enabled) return result;
+
+  const manifest = readManifest();
+  const candidates: FileCandidate[] = [];
+  walkDir(cwd, cwd, config, 0, candidates);
+  result.scanned = candidates.length;
+
+  // Filter to changed files, sort by mtime descending (newest first)
+  const changed = candidates
+    .filter((f) => isChanged(f.absolutePath, f.stat, manifest))
+    .sort((a, b) => b.stat.mtimeMs - a.stat.mtimeMs)
+    .slice(0, config.maxFilesPerScan);
+
+  result.skipped = candidates.length - changed.length;
+
+  for (const file of changed) {
+    if (rateLimiter && !rateLimiter.canProceed()) {
+      process.stderr.write(`[nex-scan] Rate limited — stopping after ${result.ingested} files\n`);
+      result.skipped += changed.length - result.ingested - result.errors;
+      break;
+    }
+
+    try {
+      let content = readFileSync(file.absolutePath, "utf-8");
+      // Truncate large files
+      if (content.length > config.maxFileSize) {
+        content = content.slice(0, config.maxFileSize) + "\n[...truncated]";
+      }
+
+      const context = `file-scan:${file.relativePath}`;
+      await client.ingest(content, context);
+      markIngested(file.absolutePath, file.stat, context, manifest);
+      result.ingested++;
+    } catch (err) {
+      process.stderr.write(
+        `[nex-scan] Failed to ingest ${file.relativePath}: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      result.errors++;
+    }
+  }
+
+  writeManifest(manifest);
+  return result;
+}

--- a/openclaw-plugin/src/file-scanner.ts
+++ b/openclaw-plugin/src/file-scanner.ts
@@ -101,6 +101,7 @@ export async function scanAndIngest(
 
       const context = `file-scan:${file.relativePath}`;
       await client.ingest(content, context);
+      if (rateLimiter) rateLimiter.recordRequest();
       markIngested(file.absolutePath, file.stat, context, manifest);
       result.ingested++;
     } catch (err) {

--- a/openclaw-plugin/src/index.ts
+++ b/openclaw-plugin/src/index.ts
@@ -4,15 +4,32 @@
  * Gives OpenClaw agents persistent long-term memory powered by the Nex
  * context intelligence layer. Auto-recalls relevant context before each
  * agent turn and auto-captures conversation facts after each turn.
+ *
+ * Features: auto-recall, auto-capture, file scanning, plan ingestion,
+ * smart recall filtering, registration, and slash commands.
  */
 
 import { Type, type Static } from "@sinclair/typebox";
-import { parseConfig, type NexPluginConfig } from "./config.js";
+import { existsSync, readdirSync, statSync, readFileSync } from "node:fs";
+import { join, extname } from "node:path";
+import {
+  parseConfig,
+  parseScanConfig,
+  loadMcpConfig,
+  persistRegistration,
+  loadBaseUrl,
+  MCP_CONFIG_PATH,
+  type NexPluginConfig,
+} from "./config.js";
 import { NexClient, NexAuthError } from "./nex-client.js";
 import { RateLimiter } from "./rate-limiter.js";
 import { SessionStore } from "./session-store.js";
 import { formatNexContext, stripNexContext } from "./context-format.js";
 import { captureFilter, type AgentMessage } from "./capture-filter.js";
+import { scanAndIngest } from "./file-scanner.js";
+import { ingestContextFiles } from "./context-files.js";
+import { readManifest, writeManifest, isChanged, markIngested } from "./file-manifest.js";
+import { RecallFilter } from "./recall-filter.js";
 
 // --- TypeBox schemas for tool parameters ---
 
@@ -27,6 +44,16 @@ const RememberParams = Type.Object({
 
 const EntitiesParams = Type.Object({
   query: Type.String({ description: "Search query to find related entities" }),
+});
+
+const ScanParams = Type.Object({
+  directory: Type.Optional(Type.String({ description: "Directory to scan (default: current working directory)" })),
+});
+
+const RegisterParams = Type.Object({
+  email: Type.String({ description: "Your email address for registration" }),
+  name: Type.Optional(Type.String({ description: "Your name" })),
+  company: Type.Optional(Type.String({ description: "Your company name" })),
 });
 
 // --- Plugin Logger interface (matches OpenClaw's PluginLogger) ---
@@ -117,13 +144,70 @@ interface OpenClawPluginApi {
   }): void;
 }
 
+// --- Plan file ingestion helper ---
+
+const PLAN_DIRS = [".claude/plans", ".openclaw/plans"];
+const MAX_PLANS_PER_TURN = 2;
+
+async function ingestPlanFiles(
+  client: NexClient,
+  cwd: string,
+  debug: (...args: unknown[]) => void,
+): Promise<{ ingested: number; errors: number }> {
+  const result = { ingested: 0, errors: 0 };
+  const manifest = readManifest();
+  let dirty = false;
+
+  for (const planDir of PLAN_DIRS) {
+    const fullDir = join(cwd, planDir);
+    if (!existsSync(fullDir)) continue;
+
+    let entries;
+    try {
+      entries = readdirSync(fullDir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (result.ingested >= MAX_PLANS_PER_TURN) break;
+      if (!entry.isFile()) continue;
+      if (extname(entry.name).toLowerCase() !== ".md") continue;
+
+      const filePath = join(fullDir, entry.name);
+      try {
+        const stat = statSync(filePath);
+        if (!isChanged(filePath, stat, manifest)) continue;
+
+        const content = readFileSync(filePath, "utf-8");
+        if (content.length < 10) continue;
+
+        const contextTag = `plan:${planDir}/${entry.name}`;
+        await client.ingest(content.slice(0, 100_000), contextTag);
+        markIngested(filePath, stat, contextTag, manifest);
+        result.ingested++;
+        dirty = true;
+        debug("Plan file ingested:", contextTag);
+      } catch (err) {
+        process.stderr.write(
+          `[nex-plans] Failed to ingest ${entry.name}: ${err instanceof Error ? err.message : String(err)}\n`,
+        );
+        result.errors++;
+      }
+    }
+  }
+
+  if (dirty) writeManifest(manifest);
+  return result;
+}
+
 // --- Plugin definition ---
 
 const plugin = {
   id: "memory-nex",
   name: "Nex Memory",
   description: "Persistent context intelligence for OpenClaw agents, powered by Nex",
-  version: "0.1.0",
+  version: "0.2.0",
   kind: "memory" as const,
 
   register(api: OpenClawPluginApi) {
@@ -141,6 +225,7 @@ const plugin = {
     const client = new NexClient(cfg.apiKey, cfg.baseUrl);
     const rateLimiter = new RateLimiter();
     const sessions = new SessionStore();
+    const recallFilter = new RecallFilter();
 
     const debug = (...args: unknown[]) => {
       if (cfg.debug && log.debug) log.debug("[nex]", ...args);
@@ -148,7 +233,7 @@ const plugin = {
 
     debug("Plugin config loaded", { baseUrl: cfg.baseUrl, autoRecall: cfg.autoRecall, autoCapture: cfg.autoCapture });
 
-    // --- Service (health check on start, cleanup on stop) ---
+    // --- Service (health check + file scanning on start, cleanup on stop) ---
 
     api.registerService({
       id: "memory-nex",
@@ -168,6 +253,19 @@ const plugin = {
             logger.warn("Could not reach Nex API:", err);
           }
         }
+
+        // File scanning on startup
+        try {
+          const scanConfig = parseScanConfig(cfg);
+          const cwd = process.cwd();
+          const scanResult = await scanAndIngest(client, cwd, scanConfig, rateLimiter);
+          logger.info(`File scan: ${scanResult.ingested} ingested, ${scanResult.skipped} skipped`);
+
+          const ctxResult = await ingestContextFiles(client, cwd, rateLimiter);
+          logger.info(`Context files: ${ctxResult.ingested} ingested`);
+        } catch (err) {
+          logger.warn("Startup file scan failed:", err);
+        }
       },
       async stop({ logger }) {
         logger.info("Nex memory plugin stopping — flushing capture queue...");
@@ -184,7 +282,7 @@ const plugin = {
       },
     });
 
-    // --- Hook: before_agent_start (auto-recall) ---
+    // --- Hook: before_agent_start (auto-recall with smart filter) ---
 
     if (cfg.autoRecall) {
       api.on(
@@ -192,7 +290,16 @@ const plugin = {
         async (event, ctx) => {
           if (!event.prompt) return;
 
-          debug("Auto-recall triggered", { sessionKey: ctx.sessionKey, promptLength: event.prompt.length });
+          // Smart recall filter
+          const isFirst = recallFilter.isFirstPrompt(ctx.sessionKey);
+          const decision = recallFilter.shouldRecall(event.prompt, isFirst);
+
+          if (!decision.shouldRecall) {
+            debug("Recall skipped:", decision.reason);
+            return;
+          }
+
+          debug("Auto-recall triggered", { sessionKey: ctx.sessionKey, promptLength: event.prompt.length, reason: decision.reason });
 
           try {
             // Resolve session ID for multi-turn continuity
@@ -211,6 +318,8 @@ const plugin = {
             if (result.session_id && ctx.sessionKey && cfg.sessionTracking) {
               sessions.set(ctx.sessionKey, result.session_id);
             }
+
+            recallFilter.recordRecall();
 
             const entityCount = result.entity_references?.length ?? 0;
             const context = formatNexContext({
@@ -236,7 +345,7 @@ const plugin = {
       );
     }
 
-    // --- Hook: agent_end (auto-capture) ---
+    // --- Hook: agent_end (auto-capture + plan ingestion) ---
 
     if (cfg.autoCapture) {
       api.on("agent_end", async (event, ctx) => {
@@ -248,22 +357,32 @@ const plugin = {
 
         if (result.skipped) {
           debug("Capture skipped:", result.reason);
-          return;
+        } else {
+          debug("Capture enqueued", { textLength: result.text.length });
+
+          // Fire-and-forget via rate limiter
+          rateLimiter.enqueue(async () => {
+            try {
+              const res = await client.ingest(result.text, "openclaw-conversation");
+              debug("Capture complete", { artifactId: res.artifact_id });
+            } catch (err) {
+              log.warn("Nex capture failed:", err);
+            }
+          }).catch(() => {
+            // Queue full / dropped — already logged by rate limiter
+          });
         }
 
-        debug("Capture enqueued", { textLength: result.text.length });
-
-        // Fire-and-forget via rate limiter
-        rateLimiter.enqueue(async () => {
-          try {
-            const res = await client.ingest(result.text, "openclaw-conversation");
-            debug("Capture complete", { artifactId: res.artifact_id });
-          } catch (err) {
-            log.warn("Nex capture failed:", err);
+        // Plan file ingestion (up to 2 per turn)
+        try {
+          const cwd = ctx.workspaceDir || process.cwd();
+          const planResult = await ingestPlanFiles(client, cwd, debug);
+          if (planResult.ingested > 0) {
+            debug("Plan files ingested:", planResult.ingested);
           }
-        }).catch(() => {
-          // Queue full / dropped — already logged by rate limiter
-        });
+        } catch (err) {
+          debug("Plan file ingestion failed:", err);
+        }
       });
     }
 
@@ -348,6 +467,23 @@ const plugin = {
       },
     });
 
+    api.registerTool({
+      name: "nex_scan",
+      label: "Scan Project Files",
+      description:
+        "Scan the project directory for text files and ingest changed ones into Nex knowledge base.",
+      parameters: ScanParams,
+      async execute(_toolCallId, params) {
+        const dir = (params as { directory?: string }).directory || process.cwd();
+        const scanConfig = parseScanConfig(cfg);
+        const result = await scanAndIngest(client, dir, scanConfig, rateLimiter);
+        return {
+          content: [{ type: "text", text: `Scanned ${result.scanned} files: ${result.ingested} ingested, ${result.skipped} unchanged, ${result.errors} errors` }],
+          details: result,
+        };
+      },
+    });
+
     // --- Commands ---
 
     api.registerCommand({
@@ -410,6 +546,60 @@ const plugin = {
           return { text: "Remembered." };
         } catch (err) {
           return { text: `Remember failed: ${err instanceof Error ? err.message : String(err)}` };
+        }
+      },
+    });
+
+    api.registerCommand({
+      name: "scan",
+      description: "Scan project files and ingest changes into Nex. Usage: /scan [directory]",
+      acceptsArgs: true,
+      async handler(ctx) {
+        const dir = ctx.args?.trim() || process.cwd();
+        const scanConfig = parseScanConfig(cfg);
+        const result = await scanAndIngest(client, dir, scanConfig, rateLimiter);
+        return { text: `Scanned ${result.scanned} files: ${result.ingested} ingested, ${result.skipped} unchanged, ${result.errors} errors` };
+      },
+    });
+
+    api.registerCommand({
+      name: "register",
+      description: "Register for a Nex account and save API key. Usage: /register <email> [name] [company]",
+      acceptsArgs: true,
+      async handler(ctx) {
+        const args = ctx.args?.trim().split(/\s+/) ?? [];
+        const email = args[0];
+        const name = args[1];
+        const company = args[2];
+
+        if (!email) {
+          return { text: "Usage: /register <email> [name] [company]" };
+        }
+
+        // Check if already registered
+        const existing = loadMcpConfig();
+        if (existing.api_key) {
+          return {
+            text: `Already registered.\n  API key: ${existing.api_key.slice(0, 12)}...\n  Config: ${MCP_CONFIG_PATH}\n\nTo re-register, delete ~/.nex-mcp.json first.`,
+          };
+        }
+
+        try {
+          const baseUrl = loadBaseUrl();
+          const result = await NexClient.register(baseUrl, email, name, company);
+
+          if (!result.api_key || typeof result.api_key !== "string") {
+            return { text: "Registration succeeded but no API key returned." };
+          }
+
+          // Persist to shared config
+          persistRegistration(result);
+
+          return {
+            text: `Registration successful!\n  API key: ${(result.api_key as string).slice(0, 12)}...\n${result.workspace_slug ? `  Workspace: ${result.workspace_slug}\n` : ""}  Saved to: ${MCP_CONFIG_PATH}\n\nRestart the plugin for the new key to take effect.`,
+          };
+        } catch (err) {
+          return { text: `Registration failed: ${err instanceof Error ? err.message : String(err)}` };
         }
       },
     });

--- a/openclaw-plugin/src/nex-client.ts
+++ b/openclaw-plugin/src/nex-client.ts
@@ -115,6 +115,48 @@ export class NexClient {
     }
   }
 
+  /**
+   * Register a new account and get an API key.
+   * Does NOT require an existing API key — uses the public registration endpoint.
+   */
+  static async register(
+    baseUrl: string,
+    email: string,
+    name?: string,
+    companyName?: string,
+  ): Promise<Record<string, unknown>> {
+    const url = `${baseUrl}/api/v1/agents/register`;
+    const body: Record<string, string> = { email, source: "openclaw" };
+    if (name) body.name = name;
+    if (companyName) body.company_name = companyName;
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 30_000);
+
+    try {
+      const res = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+
+      if (!res.ok) {
+        let errorBody: string | undefined;
+        try {
+          errorBody = await res.text();
+        } catch {
+          /* ignore */
+        }
+        throw new NexServerError(res.status, errorBody);
+      }
+
+      return (await res.json()) as Record<string, unknown>;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
   /** Ingest text content into the Nex knowledge graph. */
   async ingest(content: string, context?: string): Promise<IngestResponse> {
     const body: Record<string, string> = { content };

--- a/openclaw-plugin/src/rate-limiter.ts
+++ b/openclaw-plugin/src/rate-limiter.ts
@@ -1,7 +1,13 @@
 /**
- * Sliding window rate limiter with async queue.
+ * Sliding window rate limiter with async queue and file persistence.
  * Designed for Nex /text endpoint (10 req/min).
+ *
+ * Timestamps are persisted to ~/.nex/rate-limiter.json so rate limits
+ * are respected across plugin restarts.
  */
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
 
 export interface RateLimiterConfig {
   maxRequests: number;
@@ -14,6 +20,9 @@ const DEFAULTS: RateLimiterConfig = {
   windowMs: 60_000,
   maxQueueDepth: 5,
 };
+
+const DATA_DIR = join(homedir(), ".nex");
+const PERSIST_PATH = join(DATA_DIR, "rate-limiter.json");
 
 interface QueuedRequest {
   fn: () => Promise<void>;
@@ -30,6 +39,31 @@ export class RateLimiter {
 
   constructor(config?: Partial<RateLimiterConfig>) {
     this.config = { ...DEFAULTS, ...config };
+    this.loadTimestamps();
+  }
+
+  /** Load persisted timestamps from disk. */
+  private loadTimestamps(): void {
+    try {
+      const raw = readFileSync(PERSIST_PATH, "utf-8");
+      const data = JSON.parse(raw);
+      if (Array.isArray(data)) {
+        const now = Date.now();
+        this.timestamps = data.filter((t: number) => now - t < this.config.windowMs);
+      }
+    } catch {
+      // No file or invalid — start fresh
+    }
+  }
+
+  /** Persist timestamps to disk. */
+  private saveTimestamps(): void {
+    try {
+      mkdirSync(DATA_DIR, { recursive: true });
+      writeFileSync(PERSIST_PATH, JSON.stringify(this.timestamps), "utf-8");
+    } catch {
+      // Best-effort
+    }
   }
 
   /** Enqueue a function to be executed within rate limits. Fire-and-forget. */
@@ -47,7 +81,11 @@ export class RateLimiter {
     });
   }
 
-  private canProceed(): boolean {
+  /**
+   * Check if a request can proceed without queuing.
+   * Prunes expired timestamps but does NOT record a new one.
+   */
+  canProceed(): boolean {
     const now = Date.now();
     // Remove timestamps outside the window
     this.timestamps = this.timestamps.filter((t) => now - t < this.config.windowMs);
@@ -75,6 +113,7 @@ export class RateLimiter {
           } catch (err) {
             item.reject(err instanceof Error ? err : new Error(String(err)));
           }
+          this.saveTimestamps();
         } else {
           // Wait until a slot opens
           const wait = this.msUntilSlot();

--- a/openclaw-plugin/src/rate-limiter.ts
+++ b/openclaw-plugin/src/rate-limiter.ts
@@ -145,6 +145,12 @@ export class RateLimiter {
     this.timestamps.length = 0;
   }
 
+  /** Record a successful request timestamp. Call after API call succeeds. */
+  recordRequest(): void {
+    this.timestamps.push(Date.now());
+    this.saveTimestamps();
+  }
+
   /** Current queue depth (for debugging). */
   get pending(): number {
     return this.queue.length;

--- a/openclaw-plugin/src/recall-filter.ts
+++ b/openclaw-plugin/src/recall-filter.ts
@@ -1,0 +1,110 @@
+/**
+ * Smart prompt classifier for selective recall.
+ *
+ * Determines whether a prompt is likely knowledge-seeking (needs recall)
+ * or a pure coding directive (skip recall). Also handles debounce —
+ * skips recall if a successful recall happened within the debounce window,
+ * unless the current prompt contains question words.
+ *
+ * OpenClaw adaptation: uses in-memory state (long-lived process)
+ * instead of file-based persistence (CC hooks are ephemeral).
+ */
+
+const DEBOUNCE_MS = 30_000; // 30 seconds
+
+// --- Question words that signal knowledge-seeking intent ---
+const QUESTION_WORDS =
+  /\b(who|what|when|where|why|how|which|tell|explain|describe|summarize|summarise|list|find|show|get|any|does|did|is|are|was|were|have|has|do|can|could|should|would|will)\b/i;
+
+// --- Tool/action commands that are pure coding directives ---
+const TOOL_COMMANDS =
+  /^\s*(run|build|test|lint|format|deploy|install|uninstall|start|stop|restart|commit|push|pull|merge|rebase|checkout|fetch|init|fix|refactor|rename|move|delete|remove|add|create|update|upgrade|downgrade|migrate|generate|scaffold|compile|bundle|watch|serve|debug|profile|bench|clean|reset|undo|redo|revert|squash|cherry-pick|tag|release|publish|npm|npx|yarn|pnpm|bun|pip|cargo|go|make|docker|kubectl|terraform|git|gh|cd|ls|cat|grep|find|mkdir|rm|cp|mv|touch|echo|export|source|chmod|chown|curl|wget|ssh|scp)\b/i;
+
+// --- File reference pattern (paths, extensions) ---
+const FILE_REF = /(?:[\w./\\-]+\.\w{1,10}|src\/|lib\/|dist\/|node_modules\/|\.\/|\.\.\/)/;
+
+// --- Code-heavy: >50% non-alpha characters (brackets, operators, etc.) ---
+function isCodeHeavy(text: string): boolean {
+  const alpha = text.replace(/[^a-zA-Z]/g, "").length;
+  return alpha < text.length * 0.5;
+}
+
+export interface RecallDecision {
+  shouldRecall: boolean;
+  reason: string;
+}
+
+/**
+ * In-memory recall filter for long-lived OpenClaw plugin process.
+ * Tracks debounce state and first-prompt detection per session.
+ */
+export class RecallFilter {
+  private lastRecallAt = 0;
+  private seenSessions = new Set<string>();
+
+  /** Check if this is the first prompt for a given session key. */
+  isFirstPrompt(sessionKey?: string): boolean {
+    if (!sessionKey) return true;
+    if (this.seenSessions.has(sessionKey)) return false;
+    this.seenSessions.add(sessionKey);
+    // Limit set size to prevent unbounded growth
+    if (this.seenSessions.size > 1000) {
+      const iter = this.seenSessions.values();
+      this.seenSessions.delete(iter.next().value!);
+    }
+    return true;
+  }
+
+  /** Record that a successful recall just happened. */
+  recordRecall(): void {
+    this.lastRecallAt = Date.now();
+  }
+
+  /** Determine whether this prompt should trigger a Nex /ask recall. */
+  shouldRecall(prompt: string, isFirstPrompt: boolean): RecallDecision {
+    const trimmed = prompt.trim();
+
+    // Always recall on first prompt of session
+    if (isFirstPrompt) {
+      return { shouldRecall: true, reason: "first-prompt" };
+    }
+
+    // Explicit opt-out: prompt starts with !
+    if (trimmed.startsWith("!")) {
+      return { shouldRecall: false, reason: "opt-out" };
+    }
+
+    // Too short — likely a directive like "yes", "ok", "done"
+    if (trimmed.length < 15) {
+      return { shouldRecall: false, reason: "too-short" };
+    }
+
+    // Has question words — likely knowledge-seeking
+    const hasQuestion = QUESTION_WORDS.test(trimmed);
+
+    // Check debounce: skip if recent successful recall, unless question
+    if (!hasQuestion) {
+      if (this.lastRecallAt > 0 && Date.now() - this.lastRecallAt < DEBOUNCE_MS) {
+        return { shouldRecall: false, reason: "debounce" };
+      }
+    }
+
+    // Tool/action commands — pure coding directives
+    if (TOOL_COMMANDS.test(trimmed) && !hasQuestion) {
+      return { shouldRecall: false, reason: "tool-command" };
+    }
+
+    // Code-heavy with file references and no question words
+    if (isCodeHeavy(trimmed) && FILE_REF.test(trimmed) && !hasQuestion) {
+      return { shouldRecall: false, reason: "code-prompt" };
+    }
+
+    // Has question words — always recall
+    if (hasQuestion) {
+      return { shouldRecall: true, reason: "question" };
+    }
+
+    // Default: recall (err on the side of providing context)
+    return { shouldRecall: true, reason: "default" };
+  }
+}


### PR DESCRIPTION
## Summary
- Port file scanning (manifest-based change detection) from Claude Code plugin
- Add smart recall filter (question detection, debounce, opt-out)
- Add `/scan` tool and command
- Add plan file ingestion in agent_end hook
- Add `/register` command with shared `~/.nex-mcp.json` config
- Add file-based rate limiter persistence across restarts
- Unify default base URL to `app.nex.ai`

## Review fixes applied
- H1/H2: Rate limiter `recordRequest()` called after successful ingest
- H5: `loadBaseUrl()` uses unified default
- L6: Removed unnecessary `mkdirSync` on `$HOME`

## Test plan
- [ ] TypeScript compiles clean (`tsc --noEmit`)
- [ ] File scan on startup ingests changed files
- [ ] Smart recall filter skips directives, debounces repeats
- [ ] `/scan` command returns scan results
- [ ] `/register` persists key to both OpenClaw config and `~/.nex-mcp.json`
- [ ] Rate limiter state persists across plugin restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)