### PR TITLE
feat: MCP server feature parity

### DIFF
--- a/mcp/src/client.ts
+++ b/mcp/src/client.ts
@@ -1,5 +1,16 @@
-const BASE_URL = "http://localhost:30000/api/developers";
-const REGISTER_URL = "http://localhost:30000/api/v1/agents/register";
+import { loadConfig } from "./config.js";
+
+function getBaseUrl(): string {
+  const config = loadConfig();
+  const base = process.env.NEX_API_BASE_URL || config.base_url || "https://app.nex.ai";
+  return `${base.replace(/\/+$/, "")}/api/developers`;
+}
+
+function getRegisterUrl(): string {
+  const config = loadConfig();
+  const base = process.env.NEX_API_BASE_URL || config.base_url || "https://app.nex.ai";
+  return `${base.replace(/\/+$/, "")}/api/v1/agents/register`;
+}
 
 export class NexApiError extends Error {
   constructor(
@@ -41,7 +52,7 @@ export class NexApiClient {
     body?: unknown,
   ): Promise<unknown> {
     this.requireAuth();
-    const url = `${BASE_URL}${path}`;
+    const url = `${getBaseUrl()}${path}`;
     const headers: Record<string, string> = {
       Authorization: `Bearer ${this.apiKey}`,
     };
@@ -83,7 +94,7 @@ export class NexApiClient {
     if (name !== undefined) body.name = name;
     if (companyName !== undefined) body.company_name = companyName;
 
-    const res = await fetch(REGISTER_URL, {
+    const res = await fetch(getRegisterUrl(), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),

--- a/mcp/src/config.ts
+++ b/mcp/src/config.ts
@@ -6,6 +6,7 @@ const CONFIG_PATH = join(homedir(), ".nex-mcp.json");
 
 interface NexMcpConfig {
   api_key?: string;
+  base_url?: string;
   workspace_id?: string;
   workspace_slug?: string;
   [key: string]: unknown;

--- a/mcp/src/context-files.ts
+++ b/mcp/src/context-files.ts
@@ -1,0 +1,107 @@
+/**
+ * Ingests Claude Code context files (CLAUDE.md + memory files) into Nex.
+ *
+ * Reads from both global and project-level locations:
+ * - ~/.claude/CLAUDE.md (global instructions)
+ * - {cwd}/CLAUDE.md (project instructions)
+ * - ~/.claude/projects/{project-key}/memory/*.md (memory files)
+ *
+ * Uses the file manifest for change detection — unchanged files are skipped.
+ */
+import { existsSync, readdirSync, statSync, readFileSync } from "node:fs";
+import { join, extname, basename } from "node:path";
+import { homedir } from "node:os";
+import { readManifest, writeManifest, isChanged, markIngested } from "./file-manifest.js";
+import type { NexApiClient } from "./client.js";
+import type { RateLimiter } from "./rate-limiter.js";
+
+const CLAUDE_DIR = join(homedir(), ".claude");
+const INGEST_TIMEOUT_MS = 10_000;
+const MAX_FILE_SIZE = 100_000;
+
+export interface ContextFilesResult {
+  ingested: number;
+  skipped: number;
+  errors: number;
+  files: string[];
+}
+
+function projectKey(cwd: string): string {
+  return cwd.replace(/\//g, "-");
+}
+
+function collectContextFiles(cwd: string): Array<{ path: string; contextTag: string }> {
+  const files: Array<{ path: string; contextTag: string }> = [];
+  const key = projectKey(cwd);
+
+  const globalClaude = join(CLAUDE_DIR, "CLAUDE.md");
+  if (existsSync(globalClaude)) {
+    files.push({ path: globalClaude, contextTag: "claude-md:global" });
+  }
+
+  const projectClaude = join(cwd, "CLAUDE.md");
+  if (existsSync(projectClaude)) {
+    files.push({ path: projectClaude, contextTag: "claude-md:project" });
+  }
+
+  const memoryDir = join(CLAUDE_DIR, "projects", key, "memory");
+  if (existsSync(memoryDir)) {
+    try {
+      const entries = readdirSync(memoryDir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isFile()) continue;
+        if (extname(entry.name).toLowerCase() !== ".md") continue;
+        const fullPath = join(memoryDir, entry.name);
+        const name = basename(entry.name, ".md");
+        files.push({ path: fullPath, contextTag: `claude-memory:${name}` });
+      }
+    } catch {
+      // memoryDir unreadable — skip
+    }
+  }
+
+  return files;
+}
+
+export async function ingestContextFiles(
+  client: NexApiClient,
+  rateLimiter: RateLimiter,
+  cwd: string,
+): Promise<ContextFilesResult> {
+  const result: ContextFilesResult = { ingested: 0, skipped: 0, errors: 0, files: [] };
+  const manifest = readManifest();
+  const candidates = collectContextFiles(cwd);
+  let dirty = false;
+
+  for (const { path, contextTag } of candidates) {
+    try {
+      const stat = statSync(path);
+      if (!isChanged(path, stat, manifest)) {
+        result.skipped++;
+        continue;
+      }
+      if (!rateLimiter.canProceed()) {
+        process.stderr.write("[nex-context-files] Rate limited — stopping context file ingest\n");
+        result.skipped += candidates.length - result.ingested - result.skipped - result.errors;
+        break;
+      }
+      let content = readFileSync(path, "utf-8");
+      if (content.length > MAX_FILE_SIZE) {
+        content = content.slice(0, MAX_FILE_SIZE) + "\n[...truncated]";
+      }
+      await client.post("/v1/context/text", { content, context: contextTag });
+      markIngested(path, stat, contextTag, manifest);
+      result.ingested++;
+      result.files.push(contextTag);
+      dirty = true;
+    } catch (err) {
+      process.stderr.write(`[nex-context-files] Failed to ingest ${contextTag}: ${err instanceof Error ? err.message : String(err)}\n`);
+      result.errors++;
+    }
+  }
+
+  if (dirty) {
+    writeManifest(manifest);
+  }
+  return result;
+}

--- a/mcp/src/context-files.ts
+++ b/mcp/src/context-files.ts
@@ -90,6 +90,7 @@ export async function ingestContextFiles(
         content = content.slice(0, MAX_FILE_SIZE) + "\n[...truncated]";
       }
       await client.post("/v1/context/text", { content, context: contextTag });
+      rateLimiter.recordRequest();
       markIngested(path, stat, contextTag, manifest);
       result.ingested++;
       result.files.push(contextTag);

--- a/mcp/src/file-manifest.ts
+++ b/mcp/src/file-manifest.ts
@@ -1,0 +1,61 @@
+/**
+ * Persistent file manifest — tracks which files have been ingested
+ * using mtime + size as change detection.
+ *
+ * Stored at ~/.nex/file-scan-manifest.json.
+ */
+import { readFileSync, writeFileSync, mkdirSync, type Stats } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const DATA_DIR = join(homedir(), ".nex");
+const MANIFEST_PATH = join(DATA_DIR, "file-scan-manifest.json");
+
+export interface FileManifestEntry {
+  mtime: number;
+  size: number;
+  ingestedAt: number;
+  context: string;
+}
+
+export interface FileManifest {
+  version: 1;
+  files: Record<string, FileManifestEntry>;
+}
+
+export function readManifest(): FileManifest {
+  try {
+    const raw = readFileSync(MANIFEST_PATH, "utf-8");
+    const data = JSON.parse(raw);
+    if (data && data.version === 1 && data.files) {
+      return data;
+    }
+    return { version: 1, files: {} };
+  } catch {
+    return { version: 1, files: {} };
+  }
+}
+
+export function writeManifest(manifest: FileManifest): void {
+  try {
+    mkdirSync(DATA_DIR, { recursive: true });
+    writeFileSync(MANIFEST_PATH, JSON.stringify(manifest, null, 2), "utf-8");
+  } catch {
+    // Best-effort — if we can't write, next scan re-ingests
+  }
+}
+
+export function isChanged(path: string, stat: Stats, manifest: FileManifest): boolean {
+  const entry = manifest.files[path];
+  if (!entry) return true;
+  return entry.mtime !== stat.mtimeMs || entry.size !== stat.size;
+}
+
+export function markIngested(path: string, stat: Stats, context: string, manifest: FileManifest): void {
+  manifest.files[path] = {
+    mtime: stat.mtimeMs,
+    size: stat.size,
+    ingestedAt: Date.now(),
+    context,
+  };
+}

--- a/mcp/src/file-scanner.ts
+++ b/mcp/src/file-scanner.ts
@@ -90,6 +90,7 @@ export async function scanAndIngest(
       }
       const context = `file-scan:${file.relativePath}`;
       await client.post("/v1/context/text", { content, context });
+      rateLimiter.recordRequest();
       markIngested(file.absolutePath, file.stat, context, manifest);
       result.ingested++;
     } catch (err) {

--- a/mcp/src/file-scanner.ts
+++ b/mcp/src/file-scanner.ts
@@ -1,0 +1,103 @@
+/**
+ * Core file scanner — walks project directories, detects changed files,
+ * and ingests them into Nex via the developer API.
+ */
+import { readdirSync, statSync, readFileSync, type Stats } from "node:fs";
+import { join, relative, extname } from "node:path";
+import { readManifest, writeManifest, isChanged, markIngested } from "./file-manifest.js";
+import type { NexApiClient } from "./client.js";
+import type { RateLimiter } from "./rate-limiter.js";
+
+export interface ScanConfig {
+  enabled: boolean;
+  extensions: string[];
+  maxFileSize: number;
+  maxFilesPerScan: number;
+  scanDepth: number;
+  ignoreDirs: string[];
+}
+
+export interface ScanResult {
+  scanned: number;
+  ingested: number;
+  skipped: number;
+  errors: number;
+}
+
+interface CandidateFile {
+  absolutePath: string;
+  relativePath: string;
+  stat: Stats;
+}
+
+function walkDir(dir: string, cwd: string, config: ScanConfig, depth: number, results: CandidateFile[]): void {
+  if (depth > config.scanDepth) return;
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (config.ignoreDirs.includes(entry.name)) continue;
+      walkDir(fullPath, cwd, config, depth + 1, results);
+    } else if (entry.isFile()) {
+      const ext = extname(entry.name).toLowerCase();
+      if (!config.extensions.includes(ext)) continue;
+      try {
+        const stat = statSync(fullPath) as Stats;
+        results.push({ absolutePath: fullPath, relativePath: relative(cwd, fullPath), stat });
+      } catch {
+        // stat failed — skip
+      }
+    }
+  }
+}
+
+export async function scanAndIngest(
+  client: NexApiClient,
+  rateLimiter: RateLimiter,
+  cwd: string,
+  config: ScanConfig,
+): Promise<ScanResult> {
+  const result: ScanResult = { scanned: 0, ingested: 0, skipped: 0, errors: 0 };
+  if (!config.enabled) return result;
+
+  const manifest = readManifest();
+  const candidates: CandidateFile[] = [];
+  walkDir(cwd, cwd, config, 0, candidates);
+  result.scanned = candidates.length;
+
+  const changed = candidates
+    .filter((f) => isChanged(f.absolutePath, f.stat, manifest))
+    .sort((a, b) => b.stat.mtimeMs - a.stat.mtimeMs)
+    .slice(0, config.maxFilesPerScan);
+
+  result.skipped = candidates.length - changed.length;
+
+  for (const file of changed) {
+    if (!rateLimiter.canProceed()) {
+      process.stderr.write(`[nex-scan] Rate limited — stopping after ${result.ingested} files\n`);
+      result.skipped += changed.length - result.ingested - result.errors;
+      break;
+    }
+    try {
+      let content = readFileSync(file.absolutePath, "utf-8");
+      if (content.length > config.maxFileSize) {
+        content = content.slice(0, config.maxFileSize) + "\n[...truncated]";
+      }
+      const context = `file-scan:${file.relativePath}`;
+      await client.post("/v1/context/text", { content, context });
+      markIngested(file.absolutePath, file.stat, context, manifest);
+      result.ingested++;
+    } catch (err) {
+      process.stderr.write(`[nex-scan] Failed to ingest ${file.relativePath}: ${err instanceof Error ? err.message : String(err)}\n`);
+      result.errors++;
+    }
+  }
+
+  writeManifest(manifest);
+  return result;
+}

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -8,7 +8,7 @@ import { loadApiKey } from "./config.js";
 
 const apiKey = loadApiKey();
 if (!apiKey) {
-  console.error("No API key found (checked NEX_API_KEY env and ~/.nex-mcp.json). Starting in registration mode — use the 'register' tool to get an API key.");
+  console.error("No API key found (checked NEX_API_KEY env and ~/.nex-mcp.json). Starting in registration-only mode. Use the 'register' tool to create an account and get an API key. Once registered, all context, search, and scan tools become available.");
 }
 
 const transport = process.env.MCP_TRANSPORT ?? "stdio";

--- a/mcp/src/rate-limiter.ts
+++ b/mcp/src/rate-limiter.ts
@@ -1,0 +1,64 @@
+/**
+ * File-based sliding window rate limiter.
+ * Designed for Nex /text endpoint (10 req/min).
+ *
+ * Persists timestamps to a JSON file so rate limits are respected
+ * across invocations.
+ */
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+export interface RateLimiterConfig {
+  maxRequests: number;
+  windowMs: number;
+  dataDir: string;
+}
+
+const DEFAULTS: RateLimiterConfig = {
+  maxRequests: 10,
+  windowMs: 60_000,
+  dataDir: join(homedir(), ".nex"),
+};
+
+export class RateLimiter {
+  private config: RateLimiterConfig;
+  private filePath: string;
+
+  constructor(config?: Partial<RateLimiterConfig>) {
+    this.config = { ...DEFAULTS, ...config };
+    this.filePath = join(this.config.dataDir, "rate-limiter.json");
+    mkdirSync(this.config.dataDir, { recursive: true });
+  }
+
+  private readTimestamps(): number[] {
+    try {
+      const raw = readFileSync(this.filePath, "utf-8");
+      const data = JSON.parse(raw);
+      if (Array.isArray(data)) return data;
+      return [];
+    } catch {
+      return [];
+    }
+  }
+
+  private writeTimestamps(timestamps: number[]): void {
+    try {
+      writeFileSync(this.filePath, JSON.stringify(timestamps), "utf-8");
+    } catch {
+      // Best-effort
+    }
+  }
+
+  canProceed(): boolean {
+    const now = Date.now();
+    const timestamps = this.readTimestamps().filter((t) => now - t < this.config.windowMs);
+    if (timestamps.length >= this.config.maxRequests) {
+      this.writeTimestamps(timestamps);
+      return false;
+    }
+    timestamps.push(now);
+    this.writeTimestamps(timestamps);
+    return true;
+  }
+}

--- a/mcp/src/rate-limiter.ts
+++ b/mcp/src/rate-limiter.ts
@@ -57,8 +57,13 @@ export class RateLimiter {
       this.writeTimestamps(timestamps);
       return false;
     }
+    return true;
+  }
+
+  recordRequest(): void {
+    const now = Date.now();
+    const timestamps = this.readTimestamps().filter((t) => now - t < this.config.windowMs);
     timestamps.push(now);
     this.writeTimestamps(timestamps);
-    return true;
   }
 }

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -10,6 +10,7 @@ import { registerTaskTools } from "./tools/tasks.js";
 import { registerNoteTools } from "./tools/notes.js";
 import { registerInsightTools } from "./tools/insights.js";
 import { registerRegistrationTools } from "./tools/register.js";
+import { registerScanTools } from "./tools/scan.js";
 
 export function createServer(apiKey?: string): McpServer {
   const server = new McpServer({
@@ -29,6 +30,7 @@ export function createServer(apiKey?: string): McpServer {
   registerTaskTools(server, client);
   registerNoteTools(server, client);
   registerInsightTools(server, client);
+  registerScanTools(server, client);
 
   return server;
 }

--- a/mcp/src/session-store.ts
+++ b/mcp/src/session-store.ts
@@ -1,0 +1,82 @@
+/**
+ * File-based session store for MCP session ID mapping.
+ * Persists session mappings to ~/.nex/mcp-sessions.json.
+ */
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+export interface SessionStoreConfig {
+  maxSize: number;
+  dataDir: string;
+}
+
+const DEFAULT_MAX = 100;
+const DEFAULT_DATA_DIR = join(homedir(), ".nex");
+
+export class SessionStore {
+  private filePath: string;
+  private maxSize: number;
+
+  constructor(config?: Partial<SessionStoreConfig>) {
+    const dataDir = config?.dataDir ?? DEFAULT_DATA_DIR;
+    this.maxSize = config?.maxSize ?? DEFAULT_MAX;
+    this.filePath = join(dataDir, "mcp-sessions.json");
+    mkdirSync(dataDir, { recursive: true });
+  }
+
+  private readStore(): Record<string, string> {
+    try {
+      const raw = readFileSync(this.filePath, "utf-8");
+      const data = JSON.parse(raw);
+      if (data && typeof data === "object" && !Array.isArray(data)) {
+        return data;
+      }
+      return {};
+    } catch {
+      return {};
+    }
+  }
+
+  private writeStore(store: Record<string, string>): void {
+    try {
+      writeFileSync(this.filePath, JSON.stringify(store), "utf-8");
+    } catch {
+      // Best-effort
+    }
+  }
+
+  get(sessionKey: string): string | undefined {
+    const store = this.readStore();
+    return store[sessionKey];
+  }
+
+  set(sessionKey: string, nexSessionId: string): void {
+    const store = this.readStore();
+    store[sessionKey] = nexSessionId;
+    const keys = Object.keys(store);
+    while (keys.length > this.maxSize) {
+      const oldest = keys.shift()!;
+      delete store[oldest];
+    }
+    this.writeStore(store);
+  }
+
+  delete(sessionKey: string): boolean {
+    const store = this.readStore();
+    if (sessionKey in store) {
+      delete store[sessionKey];
+      this.writeStore(store);
+      return true;
+    }
+    return false;
+  }
+
+  get size(): number {
+    return Object.keys(this.readStore()).length;
+  }
+
+  clear(): void {
+    this.writeStore({});
+  }
+}

--- a/mcp/src/tools/context.ts
+++ b/mcp/src/tools/context.ts
@@ -6,10 +6,15 @@ export function registerContextTools(server: McpServer, client: NexApiClient) {
   server.tool(
     "query_context",
     "Query the Nex context graph with a natural language question. Returns an AI-generated answer with supporting entities and evidence. Use for open-ended questions about contacts, companies, relationships, or history.",
-    { query: z.string().describe("Natural language question about your contacts, companies, or relationships") },
+    {
+      query: z.string().describe("Natural language question about your contacts, companies, or relationships"),
+      session_id: z.string().optional().describe("Session ID for multi-turn conversational continuity"),
+    },
     { readOnlyHint: true, openWorldHint: true },
-    async ({ query }) => {
-      const result = await client.post("/v1/context/ask", { query });
+    async ({ query, session_id }) => {
+      const body: Record<string, unknown> = { query };
+      if (session_id) body.session_id = session_id;
+      const result = await client.post("/v1/context/ask", body);
       return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
     },
   );
@@ -76,6 +81,22 @@ export function registerContextTools(server: McpServer, client: NexApiClient) {
       const path = `/v1/context/list/jobs/${encodeURIComponent(job_id)}${qs ? `?${qs}` : ""}`;
       const result = await client.get(path);
       return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "search_entities",
+    "Search for entities (people, companies, topics) in the Nex knowledge base. Returns a structured list with names, types, and mention counts.",
+    { query: z.string().describe("Search query to find entities") },
+    { readOnlyHint: true },
+    async ({ query }) => {
+      const result = await client.post("/v1/context/ask", { query }) as { entity_references?: Array<{ name: string; type: string; count?: number }> };
+      const entities = result.entity_references ?? [];
+      if (entities.length === 0) {
+        return { content: [{ type: "text", text: "No matching entities found." }] };
+      }
+      const lines = entities.map(e => `- ${e.name} (${e.type})${e.count ? ` — ${e.count} mentions` : ""}`);
+      return { content: [{ type: "text", text: `Found ${entities.length} entities:\n${lines.join("\n")}` }] };
     },
   );
 }

--- a/mcp/src/tools/scan.ts
+++ b/mcp/src/tools/scan.ts
@@ -1,0 +1,48 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { NexApiClient } from "../client.js";
+import { RateLimiter } from "../rate-limiter.js";
+import { scanAndIngest } from "../file-scanner.js";
+import { ingestContextFiles } from "../context-files.js";
+
+const rateLimiter = new RateLimiter();
+
+export function registerScanTools(server: McpServer, client: NexApiClient) {
+  server.tool(
+    "scan_files",
+    "Scan a directory for text files and ingest changed ones into the Nex knowledge base. Uses manifest-based change detection — unchanged files are skipped automatically.",
+    {
+      directory: z.string().optional().describe("Directory to scan (default: current working directory)"),
+      max_files: z.number().optional().describe("Maximum files to ingest per scan (default: 5)"),
+      max_depth: z.number().optional().describe("Maximum directory depth (default: 2)"),
+    },
+    { readOnlyHint: false },
+    async ({ directory, max_files, max_depth }) => {
+      const scanConfig = {
+        enabled: true,
+        extensions: [".md", ".txt", ".csv", ".json", ".yaml", ".yml"],
+        maxFileSize: 100_000,
+        maxFilesPerScan: max_files ?? 5,
+        scanDepth: max_depth ?? 2,
+        ignoreDirs: ["node_modules", ".git", "dist", "build", ".next", "__pycache__", "vendor", ".venv", ".claude", "coverage", ".turbo", ".cache"],
+      };
+      const cwd = directory || process.cwd();
+      const result = await scanAndIngest(client, rateLimiter, cwd, scanConfig);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "ingest_context_files",
+    "Ingest CLAUDE.md and memory files from the current project into Nex. Uses manifest-based change detection.",
+    {
+      directory: z.string().optional().describe("Project directory (default: current working directory)"),
+    },
+    { readOnlyHint: false },
+    async ({ directory }) => {
+      const cwd = directory || process.cwd();
+      const result = await ingestContextFiles(client, rateLimiter, cwd);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Add `scan_files` and `ingest_context_files` tools (manifest-based change detection)
- Add `search_entities` tool (extracts entity_references from /ask)
- Add file-based rate limiter (10 req/min, persisted to `~/.nex/rate-limiter.json`)
- Add session tracking (`~/.nex/mcp-sessions.json`, LRU)
- Make base URL configurable via `NEX_API_BASE_URL` env or `~/.nex-mcp.json`

## Review fixes applied
- C2: Replaced hardcoded `localhost:30000` with configurable base URL
- C3: Rate limiter `canProceed()` is check-only; `recordRequest()` records after success

## Test plan
- [ ] TypeScript compiles clean (`tsc --noEmit`)
- [ ] `scan_files` tool ingests changed files, manifest prevents re-ingestion
- [ ] `search_entities` returns formatted entity list
- [ ] `query_context` accepts optional `session_id` param
- [ ] Rate limiter blocks after 10 req/min
- [ ] Base URL reads from env/config (not hardcoded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)