### PR TITLE
feat: SKILL.md and scripts feature parity

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nex
 description: Share real-time organizational context with your AI agent — query your context graph, manage records, and receive live insights
-metadata: {"clawdbot": {"emoji": "\U0001F4CA", "homepage": "https://github.com/nex-crm/nex-as-a-skill", "primaryEnv": "NEX_API_KEY", "requires": {"env": [], "bins": ["curl", "jq", "bash"]}, "files": ["scripts/nex-api.sh", "scripts/nex-openclaw-register.sh"]}}
+metadata: {"clawdbot": {"emoji": "\U0001F4CA", "homepage": "https://github.com/nex-crm/nex-as-a-skill", "primaryEnv": "NEX_API_KEY", "requires": {"env": [], "bins": ["curl", "jq", "bash"]}, "files": ["scripts/nex-api.sh", "scripts/nex-openclaw-register.sh", "scripts/nex-scan-files.sh"]}}
 ---
 
 # Nex - Real-time Organizational Context for AI Agents
@@ -62,6 +62,11 @@ jq --arg api_key "$API_KEY" '
 jq -e '.skills.entries.nex.env.NEX_API_KEY | type == "string" and length > 0' "$HOME/.openclaw/openclaw.json" >/dev/null
 ```
 
+**Shared Config**: Registration data is also saved to `~/.nex-mcp.json` for cross-tool compatibility. If `NEX_API_KEY` is not set, check this file as a fallback:
+```bash
+API_KEY="$(jq -r '.api_key // empty' "$HOME/.nex-mcp.json" 2>/dev/null || true)"
+```
+
 4. Continue:
 - Use `scripts/nex-api.sh` with `Authorization: Bearer <NEX_API_KEY>` for Developer API endpoints (including context/text).
 - Re-registration is allowed; key rotation behavior depends on backend policy.
@@ -80,6 +85,81 @@ jq -e '.skills.entries.nex.env.NEX_API_KEY | type == "string" and length > 0' "$
 - **ALWAYS** use `printf '%s' '{...}'` to pipe JSON via stdin — `printf '%s'` does not interpret escape sequences or variables in the format argument
 - If user input must appear in a JSON body, construct the JSON object using jq: `jq -n --arg q "user text" '{query: $q}'`
 - The examples below use hardcoded JSON for clarity — when building commands with dynamic values, always use the jq construction pattern above
+
+## File Scanning
+
+Scan project directories and ingest changed files into the Nex knowledge base. Uses manifest-based change detection — unchanged files are automatically skipped on subsequent scans.
+
+### When to Scan
+- First time working with a project (ingests docs, config, notes)
+- After adding new documentation or configuration files
+- Periodically during long sessions to capture changes
+
+### Usage
+
+```bash
+# Scan current directory (default settings)
+bash {baseDir}/scripts/nex-scan-files.sh --dir .
+
+# Scan with custom limits
+bash {baseDir}/scripts/nex-scan-files.sh --dir . --max-files 10 --max-depth 3
+
+# Scan specific extensions only
+bash {baseDir}/scripts/nex-scan-files.sh --dir . --extensions ".md,.txt"
+```
+
+**IMPORTANT**: Set `timeout: 120` on exec tool calls — file ingestion can be slow.
+
+### Flags
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--dir` | `.` | Directory to scan |
+| `--max-files` | `5` | Maximum files to ingest per scan |
+| `--max-depth` | `2` | Maximum directory depth |
+| `--extensions` | `.md,.txt,.csv,.json,.yaml,.yml` | Comma-separated file extensions |
+
+### How It Works
+1. Walks the directory tree (respecting depth + ignore rules)
+2. Checks each file against `~/.nex/file-scan-manifest.json` (mtime + size)
+3. Ingests changed files via `POST /v1/context/text` with context tag `file-scan:<relative-path>`
+4. Updates manifest to prevent re-ingestion
+
+### Ignored Directories
+`node_modules`, `.git`, `dist`, `build`, `.next`, `__pycache__`, `vendor`, `.venv`, `.claude`, `coverage`, `.turbo`, `.cache`
+
+Files larger than 100KB are automatically truncated.
+
+## Entity Search
+
+Search for entities (people, companies, topics) in the Nex knowledge base.
+
+### Usage
+Query the context graph and extract entity references from the response:
+
+```bash
+# Search for entities related to a query
+printf '%s' '{"query":"who are the key contacts at Acme Corp?"}' | bash {baseDir}/scripts/nex-api.sh POST /v1/context/ask
+```
+
+The response includes an `entity_references` array:
+```json
+{
+  "answer": "...",
+  "entity_references": [
+    {"name": "John Smith", "type": "14", "count": 12},
+    {"name": "Acme Corp", "type": "15", "count": 8}
+  ]
+}
+```
+
+**Type codes**: `14` = Person, `15` = Company
+
+### Formatting Entity Results
+When displaying entities to the user, format as:
+```
+- {name} ({type_label}) — {count} mentions
+```
+Example: `- John Smith (Person) — 12 mentions`
 
 ## External Endpoints
 

--- a/claude-code-plugin/commands/entities.md
+++ b/claude-code-plugin/commands/entities.md
@@ -1,0 +1,18 @@
+---
+description: Search for entities (people, companies, topics) in Nex knowledge base
+---
+Search for entities matching: $ARGUMENTS
+If no query provided, respond: "Usage: /entities <search query>"
+
+Use the `mcp__nex__query_context` tool with the query.
+From the response, extract the `entity_references` array.
+If no entities found, respond: "No matching entities found."
+
+Format each entity as a bullet list:
+```
+Found {count} entities:
+- {name} ({type_label}) — {mention_count} mentions
+```
+
+Type labels: type "14" → Person, type "15" → Company, all others → Entity.
+Only show mention count if available (count > 0).

--- a/scripts/nex-scan-files.sh
+++ b/scripts/nex-scan-files.sh
@@ -34,7 +34,11 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# Resolve to absolute path
+# Validate directory
+if [[ ! -d "$DIR" ]]; then
+  echo "Error: Directory '$DIR' does not exist" >&2
+  exit 1
+fi
 DIR="$(cd "$DIR" && pwd)"
 
 # --- Ensure manifest directory exists ---
@@ -43,29 +47,43 @@ if [[ ! -f "$MANIFEST_FILE" ]]; then
   echo '{"version":1,"files":{}}' > "$MANIFEST_FILE"
 fi
 
-# --- Build find command for extensions ---
-# Convert ".md,.txt" to -name "*.md" -o -name "*.txt"
+# --- Validate and parse extensions ---
 IFS=',' read -ra EXT_ARRAY <<< "$EXTENSIONS"
-FIND_NAMES=""
 for ext in "${EXT_ARRAY[@]}"; do
-  ext="$(echo "$ext" | xargs)"  # trim whitespace
-  if [[ -n "$FIND_NAMES" ]]; then
-    FIND_NAMES="$FIND_NAMES -o"
+  ext="$(echo "$ext" | xargs)"
+  if [[ ! "$ext" =~ ^\.[a-zA-Z0-9]+$ ]]; then
+    echo "Error: Invalid extension '$ext'. Must match pattern '.<alphanumeric>'" >&2
+    exit 1
   fi
-  FIND_NAMES="$FIND_NAMES -name \"*${ext}\""
 done
 
-# --- Build find ignore patterns ---
+# --- Build find args as arrays (safe from injection) ---
 IFS=',' read -ra IGNORE_ARRAY <<< "$DEFAULT_IGNORE"
-FIND_PRUNE=""
+
+FIND_ARGS=("$DIR" "-maxdepth" "$MAX_DEPTH")
+
+# Add prune patterns
 for ign in "${IGNORE_ARRAY[@]}"; do
   ign="$(echo "$ign" | xargs)"
-  FIND_PRUNE="$FIND_PRUNE -name \"$ign\" -prune -o"
+  FIND_ARGS+=("-name" "$ign" "-prune" "-o")
 done
 
+# Add extension patterns
+FIND_ARGS+=("-type" "f" "(")
+first=true
+for ext in "${EXT_ARRAY[@]}"; do
+  ext="$(echo "$ext" | xargs)"
+  if [ "$first" = true ]; then
+    first=false
+  else
+    FIND_ARGS+=("-o")
+  fi
+  FIND_ARGS+=("-name" "*${ext}")
+done
+FIND_ARGS+=(")" "-print")
+
 # --- Find files ---
-# Use eval to handle the dynamically built command
-FILES=$(eval "find \"$DIR\" -maxdepth $MAX_DEPTH $FIND_PRUNE -type f \\( $FIND_NAMES \\) -print" 2>/dev/null || true)
+FILES=$(find "${FIND_ARGS[@]}" 2>/dev/null || true)
 
 if [[ -z "$FILES" ]]; then
   echo '{"scanned":0,"ingested":0,"skipped":0,"errors":0}'
@@ -89,8 +107,9 @@ while IFS= read -r filepath; do
   MANIFEST_MTIME=$(jq -r --arg p "$filepath" '.files[$p].mtime // 0' "$MANIFEST_FILE" 2>/dev/null || echo 0)
   MANIFEST_SIZE=$(jq -r --arg p "$filepath" '.files[$p].size // 0' "$MANIFEST_FILE" 2>/dev/null || echo 0)
 
-  # Skip if unchanged
-  if [[ "$FILE_MTIME" == "$MANIFEST_MTIME" && "$FILE_SIZE" == "$MANIFEST_SIZE" ]]; then
+  # Skip if unchanged (manifest stores mtime in ms)
+  FILE_MTIME_MS_CHECK=$((FILE_MTIME * 1000))
+  if [[ "$FILE_MTIME_MS_CHECK" == "$MANIFEST_MTIME" && "$FILE_SIZE" == "$MANIFEST_SIZE" ]]; then
     SKIPPED=$((SKIPPED + 1))
     continue
   fi
@@ -117,9 +136,10 @@ while IFS= read -r filepath; do
   if printf '%s' "$JSON_BODY" | bash "$SCRIPT_DIR/nex-api.sh" POST /v1/context/text >/dev/null 2>&1; then
     INGESTED=$((INGESTED + 1))
 
-    # Update manifest
+    # Update manifest (mtime in ms to match Node.js format)
+    FILE_MTIME_MS=$((FILE_MTIME * 1000))
     TMP=$(mktemp)
-    jq --arg p "$filepath" --argjson mt "$FILE_MTIME" --argjson sz "$FILE_SIZE" --arg ctx "$CONTEXT" --argjson now "$(date +%s)000" \
+    jq --arg p "$filepath" --argjson mt "$FILE_MTIME_MS" --argjson sz "$FILE_SIZE" --arg ctx "$CONTEXT" --argjson now "$(date +%s)000" \
       '.files[$p] = {mtime: $mt, size: $sz, ingestedAt: $now, context: $ctx}' \
       "$MANIFEST_FILE" > "$TMP" && mv "$TMP" "$MANIFEST_FILE"
   else

--- a/scripts/nex-scan-files.sh
+++ b/scripts/nex-scan-files.sh
@@ -30,7 +30,16 @@ while [[ $# -gt 0 ]]; do
     --max-files) MAX_FILES="$2"; shift 2 ;;
     --max-depth) MAX_DEPTH="$2"; shift 2 ;;
     --extensions) EXTENSIONS="$2"; shift 2 ;;
-    *) echo "Unknown option: $1" >&2; exit 1 ;;
+    -h|--help)
+      echo "Usage: nex-scan-files.sh [OPTIONS]"
+      echo "  --dir PATH        Directory to scan (default: .)"
+      echo "  --max-files N     Max files to ingest per scan (default: 5)"
+      echo "  --max-depth N     Max directory depth (default: 2)"
+      echo "  --extensions LIST Comma-separated extensions (default: .md,.txt,.csv,.json,.yaml,.yml)"
+      echo "  -h, --help        Show this help"
+      exit 0
+      ;;
+    *) echo "Unknown option: $1. Use --help for usage." >&2; exit 1 ;;
   esac
 done
 

--- a/scripts/nex-scan-files.sh
+++ b/scripts/nex-scan-files.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Nex file scanner — discovers project files and ingests changed ones
+# Uses manifest-based change detection via ~/.nex/file-scan-manifest.json
+# ENV: NEX_API_KEY (required)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MANIFEST_FILE="$HOME/.nex/file-scan-manifest.json"
+MAX_FILE_SIZE=102400  # 100KB
+DEFAULT_EXTENSIONS=".md,.txt,.csv,.json,.yaml,.yml"
+DEFAULT_IGNORE="node_modules,.git,dist,build,.next,__pycache__,vendor,.venv,.claude,coverage,.turbo,.cache"
+DEFAULT_MAX_FILES=5
+DEFAULT_MAX_DEPTH=2
+
+# Counters
+SCANNED=0
+INGESTED=0
+SKIPPED=0
+ERRORS=0
+
+# --- Parse arguments ---
+DIR="."
+MAX_FILES="$DEFAULT_MAX_FILES"
+MAX_DEPTH="$DEFAULT_MAX_DEPTH"
+EXTENSIONS="$DEFAULT_EXTENSIONS"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dir) DIR="$2"; shift 2 ;;
+    --max-files) MAX_FILES="$2"; shift 2 ;;
+    --max-depth) MAX_DEPTH="$2"; shift 2 ;;
+    --extensions) EXTENSIONS="$2"; shift 2 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+# Resolve to absolute path
+DIR="$(cd "$DIR" && pwd)"
+
+# --- Ensure manifest directory exists ---
+mkdir -p "$HOME/.nex"
+if [[ ! -f "$MANIFEST_FILE" ]]; then
+  echo '{"version":1,"files":{}}' > "$MANIFEST_FILE"
+fi
+
+# --- Build find command for extensions ---
+# Convert ".md,.txt" to -name "*.md" -o -name "*.txt"
+IFS=',' read -ra EXT_ARRAY <<< "$EXTENSIONS"
+FIND_NAMES=""
+for ext in "${EXT_ARRAY[@]}"; do
+  ext="$(echo "$ext" | xargs)"  # trim whitespace
+  if [[ -n "$FIND_NAMES" ]]; then
+    FIND_NAMES="$FIND_NAMES -o"
+  fi
+  FIND_NAMES="$FIND_NAMES -name \"*${ext}\""
+done
+
+# --- Build find ignore patterns ---
+IFS=',' read -ra IGNORE_ARRAY <<< "$DEFAULT_IGNORE"
+FIND_PRUNE=""
+for ign in "${IGNORE_ARRAY[@]}"; do
+  ign="$(echo "$ign" | xargs)"
+  FIND_PRUNE="$FIND_PRUNE -name \"$ign\" -prune -o"
+done
+
+# --- Find files ---
+# Use eval to handle the dynamically built command
+FILES=$(eval "find \"$DIR\" -maxdepth $MAX_DEPTH $FIND_PRUNE -type f \\( $FIND_NAMES \\) -print" 2>/dev/null || true)
+
+if [[ -z "$FILES" ]]; then
+  echo '{"scanned":0,"ingested":0,"skipped":0,"errors":0}'
+  exit 0
+fi
+
+# --- Check each file against manifest ---
+while IFS= read -r filepath; do
+  SCANNED=$((SCANNED + 1))
+
+  # Get file stats
+  if [[ "$(uname)" == "Darwin" ]]; then
+    FILE_SIZE=$(stat -f%z "$filepath" 2>/dev/null || echo 0)
+    FILE_MTIME=$(stat -f%m "$filepath" 2>/dev/null || echo 0)
+  else
+    FILE_SIZE=$(stat -c%s "$filepath" 2>/dev/null || echo 0)
+    FILE_MTIME=$(stat -c%Y "$filepath" 2>/dev/null || echo 0)
+  fi
+
+  # Check manifest for existing entry
+  MANIFEST_MTIME=$(jq -r --arg p "$filepath" '.files[$p].mtime // 0' "$MANIFEST_FILE" 2>/dev/null || echo 0)
+  MANIFEST_SIZE=$(jq -r --arg p "$filepath" '.files[$p].size // 0' "$MANIFEST_FILE" 2>/dev/null || echo 0)
+
+  # Skip if unchanged
+  if [[ "$FILE_MTIME" == "$MANIFEST_MTIME" && "$FILE_SIZE" == "$MANIFEST_SIZE" ]]; then
+    SKIPPED=$((SKIPPED + 1))
+    continue
+  fi
+
+  # Stop if we've hit max files
+  if [[ $INGESTED -ge $MAX_FILES ]]; then
+    SKIPPED=$((SKIPPED + 1))
+    continue
+  fi
+
+  # Read file content (truncate if too large)
+  CONTENT=$(head -c "$MAX_FILE_SIZE" "$filepath" 2>/dev/null || true)
+  if [[ ${#CONTENT} -ge $MAX_FILE_SIZE ]]; then
+    CONTENT="$CONTENT
+[...truncated]"
+  fi
+
+  # Get relative path for context tag
+  REL_PATH="${filepath#$DIR/}"
+  CONTEXT="file-scan:$REL_PATH"
+
+  # Ingest via API
+  JSON_BODY=$(jq -n --arg content "$CONTENT" --arg context "$CONTEXT" '{content: $content, context: $context}')
+  if printf '%s' "$JSON_BODY" | bash "$SCRIPT_DIR/nex-api.sh" POST /v1/context/text >/dev/null 2>&1; then
+    INGESTED=$((INGESTED + 1))
+
+    # Update manifest
+    TMP=$(mktemp)
+    jq --arg p "$filepath" --argjson mt "$FILE_MTIME" --argjson sz "$FILE_SIZE" --arg ctx "$CONTEXT" --argjson now "$(date +%s)000" \
+      '.files[$p] = {mtime: $mt, size: $sz, ingestedAt: $now, context: $ctx}' \
+      "$MANIFEST_FILE" > "$TMP" && mv "$TMP" "$MANIFEST_FILE"
+  else
+    ERRORS=$((ERRORS + 1))
+    echo "Failed to ingest: $REL_PATH" >&2
+  fi
+done <<< "$FILES"
+
+# --- Output summary ---
+echo "{\"scanned\":$SCANNED,\"ingested\":$INGESTED,\"skipped\":$SKIPPED,\"errors\":$ERRORS}"


### PR DESCRIPTION
## Summary
- New `scripts/nex-scan-files.sh` — manifest-based file scanner with `--dir`, `--max-files`, `--max-depth`, `--extensions`, `--help` flags
- Add "File Scanning" section to SKILL.md with usage docs, flags table, ignored dirs
- Add "Entity Search" section documenting entity_references extraction
- Add shared config fallback (`~/.nex-mcp.json`) to bootstrap docs
- Update SKILL.md metadata to include new script

## Security
- No `eval` — uses array-based `find` args
- Extension validation: rejects non-alphanumeric patterns
- Directory validation: rejects nonexistent paths
- mtime stored in milliseconds (matches Node.js manifest format)

## Review fixes applied
- C1: Removed `eval` injection vector, added input validation
- H7: mtime multiplied by 1000 for cross-surface manifest compatibility

## Test plan
- [ ] `bash -n scripts/nex-scan-files.sh` passes
- [ ] `--help` shows usage
- [ ] Malicious `--extensions` rejected
- [ ] Nonexistent `--dir` rejected
- [ ] Manifest idempotency: second scan ingests 0 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)