### PR TITLE
feat: Claude Code memory plugin with /entities command

### DIFF
--- a/claude-code-plugin/commands/entities.md
+++ b/claude-code-plugin/commands/entities.md
@@ -1,0 +1,18 @@
+---
+description: Search for entities (people, companies, topics) in Nex knowledge base
+---
+Search for entities matching: $ARGUMENTS
+If no query provided, respond: "Usage: /entities <search query>"
+
+Use the `mcp__nex__query_context` tool with the query.
+From the response, extract the `entity_references` array.
+If no entities found, respond: "No matching entities found."
+
+Format each entity as a bullet list:
+```
+Found {count} entities:
+- {name} ({type_label}) — {mention_count} mentions
+```
+
+Type labels: type "14" → Person, type "15" → Company, all others → Entity.
+Only show mention count if available (count > 0).

--- a/claude-code-plugin/commands/register.md
+++ b/claude-code-plugin/commands/register.md
@@ -1,0 +1,18 @@
+---
+description: Register for a Nex API key (required for first-time setup)
+---
+Register for a Nex account to get an API key for the memory plugin.
+
+If $ARGUMENTS contains an email address, use it directly. Otherwise, ask the user for their email.
+
+Run the registration script:
+```
+node <plugin-dir>/dist/auto-register.js <email> [name] [company]
+```
+
+After successful registration:
+1. The API key is saved to ~/.nex-mcp.json automatically
+2. All Nex memory features (auto-recall, auto-capture, file scanning) will work immediately
+3. No need to set NEX_API_KEY manually
+
+If already registered, inform the user their existing API key is active.

--- a/claude-code-plugin/commands/scan.md
+++ b/claude-code-plugin/commands/scan.md
@@ -1,0 +1,8 @@
+---
+description: Scan and ingest project files into Nex knowledge base
+---
+Scan the current project directory for business documents (md, txt, csv, json, yaml)
+and ingest new or changed files into the Nex knowledge base.
+Use the mcp__nex__context_add_text tool for each file found.
+If $ARGUMENTS contains a path, scan that directory instead.
+Report which files were ingested and which were skipped.

--- a/claude-code-plugin/settings.json
+++ b/claude-code-plugin/settings.json
@@ -7,7 +7,7 @@
           {
             "type": "command",
             "command": "node <path-to>/claude-code-plugin/dist/auto-session-start.js",
-            "timeout": 10000,
+            "timeout": 120000,
             "statusMessage": "Loading knowledge context..."
           }
         ]
@@ -33,7 +33,7 @@
           {
             "type": "command",
             "command": "node <path-to>/claude-code-plugin/dist/auto-capture.js",
-            "timeout": 5000,
+            "timeout": 10000,
             "async": true
           }
         ]

--- a/claude-code-plugin/src/auto-capture.ts
+++ b/claude-code-plugin/src/auto-capture.ts
@@ -1,26 +1,86 @@
 #!/usr/bin/env node
 /**
- * Claude Code Stop hook — auto-capture conversation to Nex.
+ * Claude Code Stop hook — auto-capture conversation to Nex + plan file ingestion.
  *
  * Reads { last_assistant_message, session_id } from stdin,
- * filters and sends to Nex for ingestion.
+ * filters and sends to Nex for ingestion. Also checks .claude/plans/
+ * for changed plan files and ingests up to 2.
  *
  * On ANY error: outputs {} and exits 0 (graceful degradation).
  */
 
-import { loadConfig } from "./config.js";
+import { readdirSync, statSync, readFileSync } from "node:fs";
+import { join, extname } from "node:path";
+import { loadConfig, loadScanConfig } from "./config.js";
 import { NexClient } from "./nex-client.js";
 import { captureFilter } from "./capture-filter.js";
 import { RateLimiter } from "./rate-limiter.js";
+import { readManifest, writeManifest, isChanged, markIngested } from "./file-manifest.js";
 
-/** Ingest timeout — 3s leaves buffer within 5s hook timeout */
+/** Ingest timeout — 3s leaves buffer within hook timeout */
 const INGEST_TIMEOUT_MS = 3_000;
+const MAX_PLAN_FILES = 2;
 
 const rateLimiter = new RateLimiter();
 
 interface HookInput {
   last_assistant_message?: string;
   session_id?: string;
+}
+
+/**
+ * Scan .claude/plans/ for changed .md files and ingest up to MAX_PLAN_FILES.
+ */
+async function ingestPlanFiles(client: NexClient): Promise<void> {
+  const scanConfig = loadScanConfig();
+  if (!scanConfig.enabled) return;
+
+  const plansDir = join(process.cwd(), ".claude", "plans");
+
+  let entries;
+  try {
+    entries = readdirSync(plansDir, { withFileTypes: true });
+  } catch {
+    return; // No .claude/plans/ dir — normal, skip silently
+  }
+
+  const manifest = readManifest();
+  let ingested = 0;
+
+  for (const entry of entries) {
+    if (ingested >= MAX_PLAN_FILES) break;
+    if (!entry.isFile()) continue;
+    if (extname(entry.name).toLowerCase() !== ".md") continue;
+
+    const fullPath = join(plansDir, entry.name);
+    try {
+      const stat = statSync(fullPath);
+      if (!isChanged(fullPath, stat, manifest)) continue;
+
+      if (!rateLimiter.canProceed()) {
+        process.stderr.write("[nex-capture] Rate limited — skipping plan file ingest\n");
+        break;
+      }
+
+      let content = readFileSync(fullPath, "utf-8");
+      if (content.length > 100_000) {
+        content = content.slice(0, 100_000) + "\n[...truncated]";
+      }
+
+      const context = `claude-code-plan:${entry.name}`;
+      await client.ingest(content, context, INGEST_TIMEOUT_MS);
+      markIngested(fullPath, stat, context, manifest);
+      ingested++;
+    } catch (err) {
+      process.stderr.write(
+        `[nex-capture] Plan file ingest failed (${entry.name}): ${err instanceof Error ? err.message : String(err)}\n`
+      );
+    }
+  }
+
+  if (ingested > 0) {
+    writeManifest(manifest);
+  }
 }
 
 async function main(): Promise<void> {
@@ -40,12 +100,6 @@ async function main(): Promise<void> {
       return;
     }
 
-    const message = input.last_assistant_message?.trim();
-    if (!message) {
-      process.stdout.write("{}");
-      return;
-    }
-
     let cfg;
     try {
       cfg = loadConfig();
@@ -54,27 +108,34 @@ async function main(): Promise<void> {
       return;
     }
 
-    const filterResult = captureFilter(message);
-
-    if (filterResult.skipped) {
-      process.stdout.write("{}");
-      return;
-    }
-
-    // Check rate limit before making API call
-    if (!rateLimiter.canProceed()) {
-      process.stderr.write("[nex-capture] Rate limited — skipping ingest\n");
-      process.stdout.write("{}");
-      return;
-    }
-
-    // Fire-and-forget ingest with tight timeout
     const client = new NexClient(cfg.apiKey, cfg.baseUrl);
+
+    // --- Conversation capture (existing behavior) ---
+    const message = input.last_assistant_message?.trim();
+    if (message) {
+      const filterResult = captureFilter(message);
+
+      if (!filterResult.skipped) {
+        if (rateLimiter.canProceed()) {
+          try {
+            await client.ingest(filterResult.text, "claude-code-conversation", INGEST_TIMEOUT_MS);
+          } catch (err) {
+            process.stderr.write(
+              `[nex-capture] Ingest failed: ${err instanceof Error ? err.message : String(err)}\n`
+            );
+          }
+        } else {
+          process.stderr.write("[nex-capture] Rate limited — skipping conversation ingest\n");
+        }
+      }
+    }
+
+    // --- Plan file ingestion ---
     try {
-      await client.ingest(filterResult.text, "claude-code-conversation", INGEST_TIMEOUT_MS);
+      await ingestPlanFiles(client);
     } catch (err) {
       process.stderr.write(
-        `[nex-capture] Ingest failed: ${err instanceof Error ? err.message : String(err)}\n`
+        `[nex-capture] Plan file scan error: ${err instanceof Error ? err.message : String(err)}\n`
       );
     }
 

--- a/claude-code-plugin/src/auto-register.ts
+++ b/claude-code-plugin/src/auto-register.ts
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+/**
+ * Registration entry point — creates a Nex account and persists the API key.
+ *
+ * Usage: node dist/auto-register.js <email> [name] [company]
+ *
+ * On success: prints API key and saves to ~/.nex-mcp.json (shared with MCP server).
+ * If already registered (API key exists): prints status and exits.
+ */
+
+import { loadMcpConfig, persistRegistration, loadBaseUrl, MCP_CONFIG_PATH } from "./config.js";
+import { NexClient } from "./nex-client.js";
+
+async function main(): Promise<void> {
+  const email = process.argv[2];
+  const name = process.argv[3];
+  const company = process.argv[4];
+
+  if (!email) {
+    console.error("Usage: auto-register.js <email> [name] [company]");
+    process.exit(1);
+  }
+
+  // Check if already registered
+  const existing = loadMcpConfig();
+  if (existing.api_key) {
+    console.log("Already registered.");
+    console.log(`  API key: ${existing.api_key.slice(0, 12)}...`);
+    console.log(`  Config: ${MCP_CONFIG_PATH}`);
+    console.log("\nTo re-register, delete ~/.nex-mcp.json first.");
+    return;
+  }
+
+  const baseUrl = loadBaseUrl();
+  console.log(`Registering ${email} at ${baseUrl} ...`);
+
+  try {
+    const result = await NexClient.register(baseUrl, email, name, company);
+
+    if (!result.api_key) {
+      console.error("Registration succeeded but no API key returned.");
+      console.error("Response:", JSON.stringify(result, null, 2));
+      process.exit(1);
+    }
+
+    // Persist to shared config
+    persistRegistration(result as Record<string, unknown>);
+
+    console.log("Registration successful!");
+    console.log(`  API key: ${result.api_key.slice(0, 12)}...`);
+    if (result.workspace_slug) console.log(`  Workspace: ${result.workspace_slug}`);
+    console.log(`  Saved to: ${MCP_CONFIG_PATH}`);
+    console.log("\nAll Nex memory features are now active. No restart needed.");
+  } catch (err) {
+    console.error(`Registration failed: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/claude-code-plugin/src/auto-scan.ts
+++ b/claude-code-plugin/src/auto-scan.ts
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+/**
+ * Standalone entry point for the /scan slash command.
+ *
+ * Reads optional directory from argv[2] or stdin, scans for project files,
+ * and ingests changed ones into Nex. Prints results to stdout.
+ *
+ * Usage: node dist/auto-scan.js [directory]
+ */
+
+import { loadConfig, loadScanConfig } from "./config.js";
+import { NexClient } from "./nex-client.js";
+import { RateLimiter } from "./rate-limiter.js";
+import { scanAndIngest } from "./file-scanner.js";
+
+async function main(): Promise<void> {
+  try {
+    // Determine target directory: argv[2] > cwd
+    const targetDir = process.argv[2] || process.cwd();
+
+    let cfg;
+    try {
+      cfg = loadConfig();
+    } catch (err) {
+      console.error(`Config error: ${err instanceof Error ? err.message : String(err)}`);
+      process.exit(1);
+    }
+
+    const scanConfig = loadScanConfig();
+    if (!scanConfig.enabled) {
+      console.log("File scanning is disabled (NEX_SCAN_ENABLED=false).");
+      return;
+    }
+
+    const client = new NexClient(cfg.apiKey, cfg.baseUrl);
+    const rateLimiter = new RateLimiter();
+
+    console.log(`Scanning ${targetDir} ...`);
+    const result = await scanAndIngest(client, rateLimiter, targetDir, scanConfig);
+
+    console.log(`Scan complete:`);
+    console.log(`  Scanned: ${result.scanned} files`);
+    console.log(`  Ingested: ${result.ingested} files`);
+    console.log(`  Skipped: ${result.skipped} files (unchanged)`);
+    if (result.errors > 0) {
+      console.log(`  Errors: ${result.errors}`);
+    }
+  } catch (err) {
+    console.error(`Scan failed: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/claude-code-plugin/src/auto-session-start.ts
+++ b/claude-code-plugin/src/auto-session-start.ts
@@ -1,24 +1,31 @@
 #!/usr/bin/env node
 /**
- * Claude Code SessionStart hook — bulk context load from Nex.
+ * Claude Code SessionStart hook — bulk context load from Nex + file scan.
  *
  * Fires once when a new Claude Code session begins. Queries Nex for
  * a baseline context summary and injects it so the agent "already knows"
  * relevant business context from the first message.
  *
+ * On startup/clear: also scans project files and ingests changed ones.
+ * On compact/resume: skips file scan (files already ingested, just re-query summary).
+ *
  * On ANY error: outputs {} and exits 0 (graceful degradation).
  */
 
-import { loadConfig } from "./config.js";
+import { loadConfig, loadScanConfig } from "./config.js";
 import { NexClient } from "./nex-client.js";
+import { RateLimiter } from "./rate-limiter.js";
 import { formatNexContext } from "./context-format.js";
 import { SessionStore } from "./session-store.js";
 import { recordRecall } from "./recall-filter.js";
+import { scanAndIngest } from "./file-scanner.js";
+import { ingestContextFiles } from "./context-files.js";
 
 const sessions = new SessionStore();
 
 interface HookInput {
   session_id?: string;
+  source?: string; // "startup" | "resume" | "clear" | "compact"
 }
 
 const SESSION_START_QUERY = "Summarize the key active context, recent interactions, and important updates for this user.";
@@ -51,10 +58,53 @@ async function main(): Promise<void> {
     }
 
     const client = new NexClient(cfg.apiKey, cfg.baseUrl);
+    const contextParts: string[] = [];
 
+    // --- File scan on startup or clear ---
+    const source = input.source ?? "startup";
+    const shouldScan = source === "startup" || source === "clear";
+
+    if (shouldScan) {
+      const rateLimiter = new RateLimiter();
+      const cwd = process.cwd();
+
+      // --- Ingest CLAUDE.md + memory files (highest priority) ---
+      try {
+        const ctxResult = await ingestContextFiles(client, rateLimiter, cwd);
+        if (ctxResult.ingested > 0) {
+          contextParts.push(
+            `[Context files: ${ctxResult.ingested} ingested (${ctxResult.files.join(", ")})]`
+          );
+        }
+      } catch (err) {
+        process.stderr.write(
+          `[nex-session-start] Context files error: ${err instanceof Error ? err.message : String(err)}\n`
+        );
+      }
+
+      // --- Project file scan ---
+      try {
+        const scanConfig = loadScanConfig();
+        if (scanConfig.enabled) {
+          const scanResult = await scanAndIngest(client, rateLimiter, cwd, scanConfig);
+
+          if (scanResult.ingested > 0) {
+            contextParts.push(
+              `[File scan: ${scanResult.ingested} file${scanResult.ingested === 1 ? "" : "s"} ingested, ${scanResult.scanned} scanned]`
+            );
+          }
+        }
+      } catch (err) {
+        process.stderr.write(
+          `[nex-session-start] File scan error: ${err instanceof Error ? err.message : String(err)}\n`
+        );
+      }
+    }
+
+    // --- Nex context query ---
     const result = await client.ask(SESSION_START_QUERY, undefined, 10_000);
 
-    if (!result.answer) {
+    if (!result.answer && contextParts.length === 0) {
       process.stdout.write("{}");
       return;
     }
@@ -74,10 +124,15 @@ async function main(): Promise<void> {
       sessionId: result.session_id,
     });
 
+    // Append scan summary if any
+    const fullContext = contextParts.length > 0
+      ? `${context}\n${contextParts.join("\n")}`
+      : context;
+
     const output = JSON.stringify({
       hookSpecificOutput: {
         hookEventName: "SessionStart",
-        additionalContext: context,
+        additionalContext: fullContext,
       },
     });
     process.stdout.write(output);

--- a/claude-code-plugin/src/auto-session-start.ts
+++ b/claude-code-plugin/src/auto-session-start.ts
@@ -12,7 +12,7 @@
  * On ANY error: outputs {} and exits 0 (graceful degradation).
  */
 
-import { loadConfig, loadScanConfig } from "./config.js";
+import { loadConfig, loadScanConfig, ConfigError } from "./config.js";
 import { NexClient } from "./nex-client.js";
 import { RateLimiter } from "./rate-limiter.js";
 import { formatNexContext } from "./context-format.js";
@@ -20,6 +20,8 @@ import { SessionStore } from "./session-store.js";
 import { recordRecall } from "./recall-filter.js";
 import { scanAndIngest } from "./file-scanner.js";
 import { ingestContextFiles } from "./context-files.js";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
 
 const sessions = new SessionStore();
 
@@ -50,6 +52,30 @@ async function main(): Promise<void> {
     try {
       cfg = loadConfig();
     } catch (err) {
+      if (err instanceof ConfigError) {
+        // No API key — inject registration prompt so Claude handles it
+        const pluginDir = dirname(fileURLToPath(import.meta.url));
+        const registerScript = join(pluginDir, "auto-register.js");
+        const registrationPrompt = [
+          "[Nex Memory Plugin] No API key configured. Registration is required to enable persistent memory.",
+          "",
+          "IMPORTANT: Before proceeding with the user's request, you must set up Nex memory:",
+          "1. Ask the user for their email address to register for a Nex account",
+          "2. Run the registration command: node " + registerScript + " <email> [name] [company]",
+          "3. Once registration succeeds, the API key is saved automatically — all memory features activate immediately",
+          "",
+          "Keep it brief — just ask for the email and register. No restart needed after registration.",
+        ].join("\n");
+
+        const output = JSON.stringify({
+          hookSpecificOutput: {
+            hookEventName: "SessionStart",
+            additionalContext: registrationPrompt,
+          },
+        });
+        process.stdout.write(output);
+        return;
+      }
       process.stderr.write(
         `[nex-session-start] Config error: ${err instanceof Error ? err.message : String(err)}\n`
       );

--- a/claude-code-plugin/src/config.ts
+++ b/claude-code-plugin/src/config.ts
@@ -7,6 +7,15 @@ export interface NexConfig {
   baseUrl: string;
 }
 
+export interface ScanConfig {
+  extensions: string[];
+  maxFileSize: number;
+  maxFilesPerScan: number;
+  scanDepth: number;
+  ignoreDirs: string[];
+  enabled: boolean;
+}
+
 export class ConfigError extends Error {
   constructor(message: string) {
     super(message);
@@ -32,4 +41,40 @@ export function loadConfig(): NexConfig {
   baseUrl = baseUrl.replace(/\/+$/, "");
 
   return { apiKey, baseUrl };
+}
+
+const DEFAULT_SCAN_EXTENSIONS = [".md", ".txt", ".csv", ".json", ".yaml", ".yml"];
+const DEFAULT_IGNORE_DIRS = [
+  "node_modules", ".git", "dist", "build", ".next", "__pycache__",
+  "vendor", ".venv", ".claude", "coverage", ".turbo", ".cache",
+];
+
+/**
+ * Load scan config from NEX_SCAN_* environment variables.
+ * All fields have sensible defaults; NEX_SCAN_ENABLED=false is the kill switch.
+ */
+export function loadScanConfig(): ScanConfig {
+  const enabled = (process.env.NEX_SCAN_ENABLED ?? "true").toLowerCase() !== "false";
+
+  const extensions = process.env.NEX_SCAN_EXTENSIONS
+    ? process.env.NEX_SCAN_EXTENSIONS.split(",").map((e) => e.trim())
+    : DEFAULT_SCAN_EXTENSIONS;
+
+  const maxFileSize = process.env.NEX_SCAN_MAX_FILE_SIZE
+    ? parseInt(process.env.NEX_SCAN_MAX_FILE_SIZE, 10)
+    : 100_000;
+
+  const maxFilesPerScan = process.env.NEX_SCAN_MAX_FILES
+    ? parseInt(process.env.NEX_SCAN_MAX_FILES, 10)
+    : 5;
+
+  const scanDepth = process.env.NEX_SCAN_DEPTH
+    ? parseInt(process.env.NEX_SCAN_DEPTH, 10)
+    : 2;
+
+  const ignoreDirs = process.env.NEX_SCAN_IGNORE_DIRS
+    ? process.env.NEX_SCAN_IGNORE_DIRS.split(",").map((d) => d.trim())
+    : DEFAULT_IGNORE_DIRS;
+
+  return { extensions, maxFileSize, maxFilesPerScan, scanDepth, ignoreDirs, enabled };
 }

--- a/claude-code-plugin/src/config.ts
+++ b/claude-code-plugin/src/config.ts
@@ -1,6 +1,11 @@
 /**
- * Plugin configuration — reads from environment variables.
+ * Plugin configuration — reads from environment variables,
+ * with fallback to ~/.nex-mcp.json (shared with MCP server).
  */
+
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { homedir } from "node:os";
 
 export interface NexConfig {
   apiKey: string;
@@ -23,16 +28,58 @@ export class ConfigError extends Error {
   }
 }
 
+/** Shared config file with MCP server — stores registration data. */
+const MCP_CONFIG_PATH = join(homedir(), ".nex-mcp.json");
+
+export { MCP_CONFIG_PATH };
+
+interface McpConfig {
+  api_key?: string;
+  base_url?: string;
+  workspace_id?: string;
+  workspace_slug?: string;
+}
+
+/** Read ~/.nex-mcp.json (shared with MCP server registration). */
+export function loadMcpConfig(): McpConfig {
+  try {
+    const raw = readFileSync(MCP_CONFIG_PATH, "utf-8");
+    return JSON.parse(raw) as McpConfig;
+  } catch {
+    return {};
+  }
+}
+
+/** Write registration data to ~/.nex-mcp.json. */
+export function persistRegistration(data: Record<string, unknown>): void {
+  const existing = loadMcpConfig() as Record<string, unknown>;
+  if (typeof data.api_key === "string") existing.api_key = data.api_key;
+  if (typeof data.workspace_id === "string" || typeof data.workspace_id === "number") {
+    existing.workspace_id = String(data.workspace_id);
+  }
+  if (typeof data.workspace_slug === "string") existing.workspace_slug = data.workspace_slug;
+  mkdirSync(dirname(MCP_CONFIG_PATH), { recursive: true });
+  writeFileSync(MCP_CONFIG_PATH, JSON.stringify(existing, null, 2) + "\n", "utf-8");
+}
+
 /**
- * Load config from environment variables.
- * - NEX_API_KEY: required
- * - NEX_API_BASE_URL: optional (default: https://api.nex-crm.com)
+ * Load config from environment variables, with fallback to ~/.nex-mcp.json.
+ *
+ * Priority: NEX_API_KEY env > ~/.nex-mcp.json api_key
+ * If neither is set, throws ConfigError with registration instructions.
  */
 export function loadConfig(): NexConfig {
-  const apiKey = process.env.NEX_API_KEY;
+  let apiKey = process.env.NEX_API_KEY;
+
+  if (!apiKey) {
+    // Fallback to shared MCP config
+    const mcpConfig = loadMcpConfig();
+    apiKey = mcpConfig.api_key;
+  }
+
   if (!apiKey) {
     throw new ConfigError(
-      "NEX_API_KEY environment variable is required. Export it before using the Nex memory plugin."
+      "No API key found. Set NEX_API_KEY or run /register to create an account."
     );
   }
 
@@ -41,6 +88,15 @@ export function loadConfig(): NexConfig {
   baseUrl = baseUrl.replace(/\/+$/, "");
 
   return { apiKey, baseUrl };
+}
+
+/**
+ * Load base URL without requiring an API key.
+ * Used for registration (which doesn't need auth).
+ */
+export function loadBaseUrl(): string {
+  let baseUrl = process.env.NEX_API_BASE_URL ?? "https://app.nex.ai";
+  return baseUrl.replace(/\/+$/, "");
 }
 
 const DEFAULT_SCAN_EXTENSIONS = [".md", ".txt", ".csv", ".json", ".yaml", ".yml"];

--- a/claude-code-plugin/src/context-files.ts
+++ b/claude-code-plugin/src/context-files.ts
@@ -1,0 +1,128 @@
+/**
+ * Ingests Claude Code context files (CLAUDE.md + memory files) into Nex.
+ *
+ * Reads from both global and project-level locations:
+ * - ~/.claude/CLAUDE.md (global instructions)
+ * - {cwd}/CLAUDE.md (project instructions)
+ * - ~/.claude/projects/{project-key}/memory/MEMORY.md (auto-memory)
+ * - ~/.claude/projects/{project-key}/memory/*.md (topic memory files)
+ *
+ * Uses the file manifest for change detection — unchanged files are skipped.
+ */
+
+import { existsSync, readdirSync, statSync, readFileSync } from "node:fs";
+import { join, extname, basename } from "node:path";
+import { homedir } from "node:os";
+import type { NexClient } from "./nex-client.js";
+import type { RateLimiter } from "./rate-limiter.js";
+import { readManifest, writeManifest, isChanged, markIngested } from "./file-manifest.js";
+
+const CLAUDE_DIR = join(homedir(), ".claude");
+const INGEST_TIMEOUT_MS = 10_000;
+const MAX_FILE_SIZE = 100_000;
+
+export interface ContextFilesResult {
+  ingested: number;
+  skipped: number;
+  errors: number;
+  files: string[]; // context tags of ingested files
+}
+
+/**
+ * Derive the Claude Code project key from a cwd path.
+ * e.g. /Users/foo/bar → -Users-foo-bar
+ */
+function projectKey(cwd: string): string {
+  return cwd.replace(/\//g, "-");
+}
+
+/**
+ * Collect all context file paths to check.
+ */
+function collectContextFiles(cwd: string): Array<{ path: string; contextTag: string }> {
+  const files: Array<{ path: string; contextTag: string }> = [];
+  const key = projectKey(cwd);
+
+  // 1. Global CLAUDE.md
+  const globalClaude = join(CLAUDE_DIR, "CLAUDE.md");
+  if (existsSync(globalClaude)) {
+    files.push({ path: globalClaude, contextTag: "claude-md:global" });
+  }
+
+  // 2. Project CLAUDE.md
+  const projectClaude = join(cwd, "CLAUDE.md");
+  if (existsSync(projectClaude)) {
+    files.push({ path: projectClaude, contextTag: "claude-md:project" });
+  }
+
+  // 3. Memory files: ~/.claude/projects/{key}/memory/*.md
+  const memoryDir = join(CLAUDE_DIR, "projects", key, "memory");
+  if (existsSync(memoryDir)) {
+    try {
+      const entries = readdirSync(memoryDir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isFile()) continue;
+        if (extname(entry.name).toLowerCase() !== ".md") continue;
+        const fullPath = join(memoryDir, entry.name);
+        const name = basename(entry.name, ".md");
+        files.push({ path: fullPath, contextTag: `claude-memory:${name}` });
+      }
+    } catch {
+      // memoryDir unreadable — skip silently
+    }
+  }
+
+  return files;
+}
+
+/**
+ * Ingest changed CLAUDE.md and memory files into Nex.
+ */
+export async function ingestContextFiles(
+  client: NexClient,
+  rateLimiter: RateLimiter,
+  cwd: string
+): Promise<ContextFilesResult> {
+  const result: ContextFilesResult = { ingested: 0, skipped: 0, errors: 0, files: [] };
+  const manifest = readManifest();
+  const candidates = collectContextFiles(cwd);
+  let dirty = false;
+
+  for (const { path, contextTag } of candidates) {
+    try {
+      const stat = statSync(path);
+      if (!isChanged(path, stat, manifest)) {
+        result.skipped++;
+        continue;
+      }
+
+      if (!rateLimiter.canProceed()) {
+        process.stderr.write("[nex-context-files] Rate limited — stopping context file ingest\n");
+        result.skipped += candidates.length - result.ingested - result.skipped - result.errors;
+        break;
+      }
+
+      let content = readFileSync(path, "utf-8");
+      if (content.length > MAX_FILE_SIZE) {
+        content = content.slice(0, MAX_FILE_SIZE) + "\n[...truncated]";
+      }
+
+      await client.ingest(content, contextTag, INGEST_TIMEOUT_MS);
+      markIngested(path, stat, contextTag, manifest);
+      result.ingested++;
+      result.files.push(contextTag);
+      dirty = true;
+    } catch (err) {
+      process.stderr.write(
+        `[nex-context-files] Failed to ingest ${contextTag}: ${err instanceof Error ? err.message : String(err)}\n`
+      );
+      result.errors++;
+    }
+  }
+
+  if (dirty) {
+    writeManifest(manifest);
+  }
+
+  return result;
+}

--- a/claude-code-plugin/src/file-manifest.ts
+++ b/claude-code-plugin/src/file-manifest.ts
@@ -1,0 +1,67 @@
+/**
+ * Persistent file manifest — tracks which files have been ingested
+ * using mtime + size as change detection.
+ *
+ * Stored at ~/.nex/file-scan-manifest.json. Follows session-store.ts pattern.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, type Stats } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+export interface FileManifestEntry {
+  mtime: number;      // fs.statSync().mtimeMs
+  size: number;       // fs.statSync().size
+  ingestedAt: number; // Date.now()
+  context: string;    // context tag used for ingest
+}
+
+export interface FileManifest {
+  version: 1;
+  files: Record<string, FileManifestEntry>; // key = absolute path
+}
+
+const DATA_DIR = join(homedir(), ".nex");
+const MANIFEST_PATH = join(DATA_DIR, "file-scan-manifest.json");
+
+export function readManifest(): FileManifest {
+  try {
+    const raw = readFileSync(MANIFEST_PATH, "utf-8");
+    const data = JSON.parse(raw);
+    if (data && data.version === 1 && data.files) {
+      return data as FileManifest;
+    }
+    return { version: 1, files: {} };
+  } catch {
+    return { version: 1, files: {} };
+  }
+}
+
+export function writeManifest(manifest: FileManifest): void {
+  try {
+    mkdirSync(DATA_DIR, { recursive: true });
+    writeFileSync(MANIFEST_PATH, JSON.stringify(manifest, null, 2), "utf-8");
+  } catch {
+    // Best-effort — if we can't write, next scan re-ingests
+  }
+}
+
+export function isChanged(path: string, stat: Stats, manifest: FileManifest): boolean {
+  const entry = manifest.files[path];
+  if (!entry) return true;
+  return entry.mtime !== stat.mtimeMs || entry.size !== stat.size;
+}
+
+export function markIngested(
+  path: string,
+  stat: Stats,
+  context: string,
+  manifest: FileManifest
+): void {
+  manifest.files[path] = {
+    mtime: stat.mtimeMs,
+    size: stat.size,
+    ingestedAt: Date.now(),
+    context,
+  };
+}

--- a/claude-code-plugin/src/file-scanner.ts
+++ b/claude-code-plugin/src/file-scanner.ts
@@ -1,0 +1,128 @@
+/**
+ * Core file scanner — walks project directories, detects changed files,
+ * and ingests them into Nex via the developer API.
+ *
+ * No new dependencies — uses only Node.js built-ins.
+ */
+
+import { readdirSync, statSync, readFileSync } from "node:fs";
+import { join, relative, extname } from "node:path";
+import type { Stats } from "node:fs";
+import type { NexClient } from "./nex-client.js";
+import type { RateLimiter } from "./rate-limiter.js";
+import type { ScanConfig } from "./config.js";
+import { readManifest, writeManifest, isChanged, markIngested } from "./file-manifest.js";
+
+export interface ScanResult {
+  scanned: number;
+  ingested: number;
+  skipped: number;
+  errors: number;
+}
+
+interface CandidateFile {
+  absolutePath: string;
+  relativePath: string;
+  stat: Stats;
+}
+
+/**
+ * Recursively collect candidate files up to scanDepth levels.
+ */
+function walkDir(
+  dir: string,
+  cwd: string,
+  config: ScanConfig,
+  depth: number,
+  results: CandidateFile[]
+): void {
+  if (depth > config.scanDepth) return;
+
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return; // Permission denied or missing — skip silently
+  }
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      if (config.ignoreDirs.includes(entry.name)) continue;
+      walkDir(fullPath, cwd, config, depth + 1, results);
+    } else if (entry.isFile()) {
+      const ext = extname(entry.name).toLowerCase();
+      if (!config.extensions.includes(ext)) continue;
+
+      try {
+        const stat = statSync(fullPath);
+        results.push({
+          absolutePath: fullPath,
+          relativePath: relative(cwd, fullPath),
+          stat,
+        });
+      } catch {
+        // stat failed — skip
+      }
+    }
+  }
+}
+
+/**
+ * Scan project directory for text files and ingest changed ones into Nex.
+ */
+export async function scanAndIngest(
+  client: NexClient,
+  rateLimiter: RateLimiter,
+  cwd: string,
+  config: ScanConfig
+): Promise<ScanResult> {
+  const result: ScanResult = { scanned: 0, ingested: 0, skipped: 0, errors: 0 };
+
+  if (!config.enabled) return result;
+
+  const manifest = readManifest();
+  const candidates: CandidateFile[] = [];
+  walkDir(cwd, cwd, config, 0, candidates);
+
+  result.scanned = candidates.length;
+
+  // Filter to changed files, sort by mtime descending (newest first)
+  const changed = candidates
+    .filter((f) => isChanged(f.absolutePath, f.stat, manifest))
+    .sort((a, b) => b.stat.mtimeMs - a.stat.mtimeMs)
+    .slice(0, config.maxFilesPerScan);
+
+  result.skipped = candidates.length - changed.length;
+
+  for (const file of changed) {
+    if (!rateLimiter.canProceed()) {
+      process.stderr.write(`[nex-scan] Rate limited — stopping after ${result.ingested} files\n`);
+      result.skipped += changed.length - result.ingested - result.errors;
+      break;
+    }
+
+    try {
+      let content = readFileSync(file.absolutePath, "utf-8");
+
+      // Truncate large files
+      if (content.length > config.maxFileSize) {
+        content = content.slice(0, config.maxFileSize) + "\n[...truncated]";
+      }
+
+      const context = `file-scan:${file.relativePath}`;
+      await client.ingest(content, context, 10_000);
+      markIngested(file.absolutePath, file.stat, context, manifest);
+      result.ingested++;
+    } catch (err) {
+      process.stderr.write(
+        `[nex-scan] Failed to ingest ${file.relativePath}: ${err instanceof Error ? err.message : String(err)}\n`
+      );
+      result.errors++;
+    }
+  }
+
+  writeManifest(manifest);
+  return result;
+}

--- a/claude-code-plugin/src/nex-client.ts
+++ b/claude-code-plugin/src/nex-client.ts
@@ -34,6 +34,13 @@ export class NexServerError extends Error {
 
 // --- Response types ---
 
+export interface RegisterResponse {
+  api_key: string;
+  workspace_id?: string | number;
+  workspace_slug?: string;
+  [key: string]: unknown;
+}
+
 export interface IngestResponse {
   artifact_id: string;
 }
@@ -110,6 +117,44 @@ export class NexClient {
       const text = await res.text();
       if (!text || !text.trim()) return {} as T;
       return JSON.parse(text) as T;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /**
+   * Register a new account and get an API key.
+   * Does NOT require an existing API key — uses the public registration endpoint.
+   */
+  static async register(
+    baseUrl: string,
+    email: string,
+    name?: string,
+    companyName?: string,
+  ): Promise<RegisterResponse> {
+    const url = `${baseUrl}/api/v1/agents/register`;
+    const body: Record<string, string> = { email, source: "claude-code" };
+    if (name) body.name = name;
+    if (companyName) body.company_name = companyName;
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 30_000);
+
+    try {
+      const res = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+
+      if (!res.ok) {
+        let errorBody: string | undefined;
+        try { errorBody = await res.text(); } catch { /* ignore */ }
+        throw new NexServerError(res.status, errorBody);
+      }
+
+      return await res.json() as RegisterResponse;
     } finally {
       clearTimeout(timer);
     }


### PR DESCRIPTION
## Summary
- Full Claude Code memory plugin: auto-recall, auto-capture, file scanning, session tracking
- `/recall`, `/remember`, `/scan`, `/register`, `/entities` slash commands
- Smart recall filter (question detection, debounce, opt-out)
- File-based rate limiter and session store
- Shared config fallback via `~/.nex-mcp.json`

## New in this update
- `/entities` command — searches for people, companies, topics via `mcp__nex__query_context`, formats entity_references with type labels (Person/Company/Entity)

## Test plan
- [ ] TypeScript compiles clean (`tsc --noEmit`)
- [ ] `/entities <query>` returns formatted entity list
- [ ] All existing hooks and commands still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)