### PR TITLE
feat(cli): add file scanning command

### DIFF
--- a/cli/src/commands/scan.ts
+++ b/cli/src/commands/scan.ts
@@ -1,0 +1,82 @@
+/**
+ * nex scan [dir] — Scan directory for text files and ingest into Nex.
+ */
+
+import { program } from "../cli.js";
+import { resolveApiKey, resolveFormat, resolveTimeout } from "../lib/config.js";
+import { NexClient } from "../lib/client.js";
+import { printOutput, printError } from "../lib/output.js";
+import { scanFiles, loadScanConfig, isScanEnabled } from "../lib/file-scanner.js";
+import type { Format } from "../lib/output.js";
+
+program
+  .command("scan")
+  .description("Scan a directory for text files and ingest new/changed files into Nex")
+  .argument("[dir]", "Directory to scan (default: current directory)", ".")
+  .option("--extensions <exts>", "File extensions to scan (comma-separated)")
+  .option("--max-files <n>", "Maximum files per scan run")
+  .option("--depth <n>", "Maximum directory depth")
+  .option("--force", "Re-scan all files (ignore manifest)")
+  .option("--dry-run", "Show what would be scanned without ingesting")
+  .action(
+    async (
+      dir: string,
+      opts: {
+        extensions?: string;
+        maxFiles?: string;
+        depth?: string;
+        force?: boolean;
+        dryRun?: boolean;
+      },
+    ) => {
+      const globalOpts = program.opts();
+      const apiKey = resolveApiKey(globalOpts.apiKey);
+      const format = resolveFormat(globalOpts.format) as Format;
+
+      if (!opts.dryRun && !apiKey) {
+        printError("No API key. Run 'nex register --email <email>' first or set NEX_API_KEY.");
+        process.exit(2);
+      }
+
+      if (!isScanEnabled()) {
+        printError("File scanning is disabled (NEX_SCAN_ENABLED=false).");
+        process.exit(0);
+      }
+
+      const scanOpts = loadScanConfig({
+        extensions: opts.extensions?.split(",").map((e) => e.trim()),
+        maxFiles: opts.maxFiles ? parseInt(opts.maxFiles, 10) : undefined,
+        depth: opts.depth ? parseInt(opts.depth, 10) : undefined,
+        force: opts.force,
+        dryRun: opts.dryRun,
+      });
+
+      const client = new NexClient(apiKey, resolveTimeout(globalOpts.timeout));
+
+      const result = await scanFiles(dir, scanOpts, async (content, context) => {
+        return client.post("/v1/context/text", { content, context });
+      });
+
+      if (opts.dryRun) {
+        printOutput(
+          {
+            dry_run: true,
+            would_scan: result.scanned,
+            would_skip: result.skipped,
+            files: result.files,
+          },
+          format,
+        );
+      } else {
+        printOutput(
+          {
+            scanned: result.scanned,
+            skipped: result.skipped,
+            errors: result.errors,
+            files: result.files,
+          },
+          format,
+        );
+      }
+    },
+  );

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -23,6 +23,7 @@ import "./commands/list-job.js";
 import "./commands/task.js";
 import "./commands/note.js";
 import "./commands/session.js";
+import "./commands/scan.js";
 
 /**
  * Read all data from stdin (non-TTY only).

--- a/cli/src/lib/file-scanner.ts
+++ b/cli/src/lib/file-scanner.ts
@@ -46,7 +46,19 @@ export interface ScanResult {
 
 export const MANIFEST_PATH = join(homedir(), ".nex", "file-scan-manifest.json");
 
-const DEFAULT_EXTENSIONS = [".md", ".txt", ".csv", ".json", ".yaml", ".yml"];
+const DEFAULT_EXTENSIONS = [
+  // Documents
+  ".md", ".txt", ".rtf", ".html", ".htm",
+  // Data / config
+  ".csv", ".tsv", ".json", ".yaml", ".yml", ".toml", ".xml",
+  // Code / scripts
+  ".js", ".ts", ".jsx", ".tsx", ".py", ".rb", ".go", ".rs", ".java",
+  ".sh", ".bash", ".zsh", ".fish",
+  // Markup / notes
+  ".org", ".rst", ".adoc", ".tex", ".log",
+  // Config / CI
+  ".env", ".ini", ".cfg", ".conf", ".properties",
+];
 const SKIP_DIRS = new Set([
   "node_modules", ".git", "dist", "build", ".next", "__pycache__", ".venv",
   ".cache", ".turbo", "coverage", ".nyc_output",

--- a/cli/src/lib/file-scanner.ts
+++ b/cli/src/lib/file-scanner.ts
@@ -1,0 +1,241 @@
+/**
+ * File scanner — discovers text files, tracks changes via content hash,
+ * and ingests new/changed files into Nex via POST /v1/context/text.
+ *
+ * Manifest stored at ~/.nex/file-scan-manifest.json.
+ */
+
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync, mkdirSync, statSync, readdirSync } from "node:fs";
+import { join, extname, resolve, dirname } from "node:path";
+import { homedir } from "node:os";
+
+// --- Types ---
+
+export interface ManifestEntry {
+  hash: string;
+  size: number;
+  scanned_at: string;
+}
+
+export interface Manifest {
+  version: number;
+  files: Record<string, ManifestEntry>;
+}
+
+export interface ScanOptions {
+  extensions: string[];
+  maxFiles: number;
+  depth: number;
+  force: boolean;
+  dryRun: boolean;
+}
+
+export interface ScanResult {
+  scanned: number;
+  skipped: number;
+  errors: number;
+  files: Array<{
+    path: string;
+    status: "ingested" | "skipped" | "error";
+    reason?: string;
+  }>;
+}
+
+// --- Constants ---
+
+export const MANIFEST_PATH = join(homedir(), ".nex", "file-scan-manifest.json");
+
+const DEFAULT_EXTENSIONS = [".md", ".txt", ".csv", ".json", ".yaml", ".yml"];
+const SKIP_DIRS = new Set([
+  "node_modules", ".git", "dist", "build", ".next", "__pycache__", ".venv",
+  ".cache", ".turbo", "coverage", ".nyc_output",
+]);
+
+// --- Config from env ---
+
+export function loadScanConfig(overrides?: Partial<ScanOptions>): ScanOptions {
+  const envEnabled = process.env.NEX_SCAN_ENABLED;
+  if (envEnabled === "false" || envEnabled === "0") {
+    // Caller should check this separately; config still resolves
+  }
+
+  const envExts = process.env.NEX_SCAN_EXTENSIONS;
+  const extensions = overrides?.extensions
+    ?? (envExts ? envExts.split(",").map((e) => e.trim()) : DEFAULT_EXTENSIONS);
+
+  const envMaxFiles = process.env.NEX_SCAN_MAX_FILES;
+  const maxFiles = overrides?.maxFiles
+    ?? (envMaxFiles ? parseInt(envMaxFiles, 10) : 5);
+
+  const envDepth = process.env.NEX_SCAN_DEPTH;
+  const depth = overrides?.depth
+    ?? (envDepth ? parseInt(envDepth, 10) : 2);
+
+  return {
+    extensions,
+    maxFiles,
+    depth,
+    force: overrides?.force ?? false,
+    dryRun: overrides?.dryRun ?? false,
+  };
+}
+
+export function isScanEnabled(): boolean {
+  const v = process.env.NEX_SCAN_ENABLED;
+  return v !== "false" && v !== "0";
+}
+
+// --- Manifest ---
+
+export function loadManifest(): Manifest {
+  try {
+    const raw = readFileSync(MANIFEST_PATH, "utf-8");
+    const data = JSON.parse(raw) as Manifest;
+    if (data.version === 1 && typeof data.files === "object") return data;
+  } catch {
+    // missing or corrupt
+  }
+  return { version: 1, files: {} };
+}
+
+export function saveManifest(manifest: Manifest): void {
+  mkdirSync(dirname(MANIFEST_PATH), { recursive: true });
+  writeFileSync(MANIFEST_PATH, JSON.stringify(manifest, null, 2) + "\n", "utf-8");
+}
+
+// --- File discovery ---
+
+interface DiscoveredFile {
+  path: string;
+  size: number;
+  mtime: number;
+}
+
+function discoverFiles(
+  dir: string,
+  extensions: Set<string>,
+  maxDepth: number,
+  currentDepth = 0,
+): DiscoveredFile[] {
+  if (currentDepth > maxDepth) return [];
+
+  const results: DiscoveredFile[] = [];
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return results;
+  }
+
+  for (const entry of entries) {
+    if (entry.startsWith(".") && SKIP_DIRS.has(entry)) continue;
+    if (SKIP_DIRS.has(entry)) continue;
+
+    const fullPath = join(dir, entry);
+    let stat;
+    try {
+      stat = statSync(fullPath);
+    } catch {
+      continue;
+    }
+
+    if (stat.isDirectory()) {
+      results.push(...discoverFiles(fullPath, extensions, maxDepth, currentDepth + 1));
+    } else if (stat.isFile() && extensions.has(extname(entry).toLowerCase())) {
+      results.push({ path: fullPath, size: stat.size, mtime: stat.mtimeMs });
+    }
+  }
+
+  return results;
+}
+
+// --- Hashing ---
+
+function hashFile(filePath: string): string {
+  const content = readFileSync(filePath);
+  return "sha256-" + createHash("sha256").update(content).digest("hex");
+}
+
+// --- Scanner ---
+
+export async function scanFiles(
+  dir: string,
+  opts: ScanOptions,
+  ingestFn: (content: string, context: string) => Promise<unknown>,
+): Promise<ScanResult> {
+  const absDir = resolve(dir);
+  const extSet = new Set(opts.extensions.map((e) => (e.startsWith(".") ? e : `.${e}`).toLowerCase()));
+
+  // Discover files
+  const discovered = discoverFiles(absDir, extSet, opts.depth);
+
+  // Sort by mtime descending (newest first), cap at maxFiles
+  discovered.sort((a, b) => b.mtime - a.mtime);
+  const candidates = discovered.slice(0, opts.maxFiles);
+
+  const manifest = opts.force ? { version: 1, files: {} } as Manifest : loadManifest();
+  const result: ScanResult = { scanned: 0, skipped: 0, errors: 0, files: [] };
+
+  for (const file of candidates) {
+    const hash = hashFile(file.path);
+    const existing = manifest.files[file.path];
+
+    // Skip if hash matches (already ingested)
+    if (existing && existing.hash === hash && !opts.force) {
+      result.skipped++;
+      result.files.push({ path: file.path, status: "skipped", reason: "unchanged" });
+      continue;
+    }
+
+    if (opts.dryRun) {
+      result.scanned++;
+      result.files.push({
+        path: file.path,
+        status: "ingested",
+        reason: existing ? "changed" : "new",
+      });
+      continue;
+    }
+
+    // Read and ingest
+    try {
+      const content = readFileSync(file.path, "utf-8");
+      if (!content.trim()) {
+        result.skipped++;
+        result.files.push({ path: file.path, status: "skipped", reason: "empty" });
+        continue;
+      }
+
+      await ingestFn(content, `file-scan:${file.path}`);
+
+      // Update manifest
+      manifest.files[file.path] = {
+        hash,
+        size: file.size,
+        scanned_at: new Date().toISOString(),
+      };
+
+      result.scanned++;
+      result.files.push({
+        path: file.path,
+        status: "ingested",
+        reason: existing ? "changed" : "new",
+      });
+    } catch (err) {
+      result.errors++;
+      result.files.push({
+        path: file.path,
+        status: "error",
+        reason: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  // Persist manifest (unless dry-run)
+  if (!opts.dryRun) {
+    saveManifest(manifest);
+  }
+
+  return result;
+}

--- a/cli/src/lib/file-scanner.ts
+++ b/cli/src/lib/file-scanner.ts
@@ -70,7 +70,7 @@ export function loadScanConfig(overrides?: Partial<ScanOptions>): ScanOptions {
 
   const envDepth = process.env.NEX_SCAN_DEPTH;
   const depth = overrides?.depth
-    ?? (envDepth ? parseInt(envDepth, 10) : 2);
+    ?? (envDepth ? parseInt(envDepth, 10) : 20);
 
   return {
     extensions,


### PR DESCRIPTION
## Summary
- Adds `nex scan [dir]` command with `--force`, `--dry-run`, `--extensions`, `--max-files`, `--depth` flags
- Core scanner in `lib/file-scanner.ts`: discovers text files by extension, tracks changes via SHA-256 content hash in `~/.nex/file-scan-manifest.json`, ingests new/changed files via `POST /v1/context/text`
- Configurable via `NEX_SCAN_*` env vars (default depth: 20, max files: 5)

## Test plan
- [ ] `nex scan --dry-run` shows files that would be scanned
- [ ] `nex scan .` ingests files and updates manifest
- [ ] `nex scan .` again skips all (no changes)
- [ ] Edit a file → `nex scan .` detects change, re-ingests
- [ ] `nex scan --force .` re-ingests all regardless of manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)