### PR TITLE
feat: full API parity across all Nex surfaces

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
     paths:
       - "cli/**"
+      - "claude-code-plugin/src/**"
+      - "claude-code-plugin/commands/**"
 
 jobs:
   publish:
@@ -25,6 +27,11 @@ jobs:
           node-version: 20
           registry-url: https://registry.npmjs.org
 
+      - name: Sync plugin into CLI
+        run: |
+          rsync -a --delete ../claude-code-plugin/src/ src/plugin/
+          rsync -a --delete ../claude-code-plugin/commands/ plugin-commands/
+
       - run: npm ci
 
       - run: npm run build
@@ -34,7 +41,7 @@ jobs:
       - name: Bump patch version
         id: bump
         run: |
-          PUBLISHED=$(npm view @nex-ai/cli version 2>/dev/null || echo "0.0.0")
+          PUBLISHED=$(npm view @nex-ai/nex version 2>/dev/null || echo "0.0.0")
           LOCAL=$(node -p "require('./package.json').version")
           if [ "$LOCAL" = "$PUBLISHED" ]; then
             npm version patch --no-git-tag-version
@@ -63,6 +70,6 @@ jobs:
           cd ..
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add cli/package.json
+          git add cli/package.json cli/src/plugin/ cli/plugin-commands/
           git commit -m "chore(cli): bump to v${{ steps.bump.outputs.version }} [skip ci]"
           git push

--- a/.github/workflows/sync-plugin.yml
+++ b/.github/workflows/sync-plugin.yml
@@ -1,0 +1,38 @@
+name: Sync Plugin to CLI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "claude-code-plugin/src/**"
+      - "claude-code-plugin/commands/**"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sync plugin source and commands into CLI
+        run: |
+          rsync -a --delete claude-code-plugin/src/ cli/src/plugin/
+          rsync -a --delete claude-code-plugin/commands/ cli/plugin-commands/
+
+      - name: Check for changes
+        id: diff
+        run: |
+          git diff --quiet cli/src/plugin/ cli/plugin-commands/ && echo "changed=false" >> "$GITHUB_OUTPUT" || echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Commit synced files
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add cli/src/plugin/ cli/plugin-commands/
+          git commit -m "chore(cli): sync plugin from claude-code-plugin [skip ci]"
+          git push

--- a/SKILL.md
+++ b/SKILL.md
@@ -1534,6 +1534,75 @@ Receive insights as they are discovered in real time.
 
 **When to use**: Keep the SSE connection open in the background during active conversations. For one-off queries, use the Ask API instead.
 
+## Integrations
+
+Manage third-party integrations (Gmail, Google Calendar, Outlook, Outlook Calendar, Slack, Attio, HubSpot, Salesforce).
+
+**Scope**: `integration.read`, `integration.write`
+
+### List Integrations
+
+**Endpoint**: `GET /v1/integrations/`
+
+Lists available integration types and their current connection status.
+
+```json
+{
+  "tool": "exec",
+  "command": "bash {baseDir}/scripts/nex-api.sh GET /v1/integrations/",
+  "timeout": 120
+}
+```
+
+### Connect Integration
+
+**Endpoint**: `POST /v1/integrations/{type}/{provider}/connect`
+
+Start an OAuth connection flow. Returns an `auth_url` for the user to open in their browser.
+
+| Type | Providers |
+|------|-----------|
+| `email` | `google`, `microsoft` |
+| `calendar` | `google`, `microsoft` |
+| `messaging` | `slack` |
+| `crm` | `attio`, `hubspot`, `salesforce` |
+
+```json
+{
+  "tool": "exec",
+  "command": "printf '%s' '{}' | bash {baseDir}/scripts/nex-api.sh POST /v1/integrations/email/google/connect",
+  "timeout": 120
+}
+```
+
+### Check Connection Status
+
+**Endpoint**: `GET /v1/integrations/connect/{connect_id}/status`
+
+Poll this endpoint to check if the user has completed the OAuth flow.
+
+```json
+{
+  "tool": "exec",
+  "command": "bash {baseDir}/scripts/nex-api.sh GET /v1/integrations/connect/CONNECT_ID/status",
+  "timeout": 120
+}
+```
+
+### Disconnect Integration
+
+**Endpoint**: `DELETE /v1/integrations/connections/{connection_id}`
+
+Remove an existing integration connection.
+
+```json
+{
+  "tool": "exec",
+  "command": "bash {baseDir}/scripts/nex-api.sh DELETE /v1/integrations/connections/CONNECTION_ID",
+  "timeout": 120
+}
+```
+
 ## Error Handling
 
 | Status Code | Meaning | Action |

--- a/claude-code-plugin/commands/integrate.md
+++ b/claude-code-plugin/commands/integrate.md
@@ -16,19 +16,19 @@ Help the user connect third-party integrations (Gmail, Google Calendar, Outlook,
 ## Steps
 
 1. First, list current integrations to see what's already connected:
-   Use the `list_integrations` MCP tool, or suggest the user runs `nex-ai integrate list` in the terminal.
+   Use the `list_integrations` MCP tool, or suggest the user runs `nex integrate list` in the terminal.
 
 2. To connect a new integration:
    Use the `connect_integration` MCP tool with the `type` and `provider` from the table above.
    This returns an `auth_url` — open it in the user's browser.
-   Alternatively, the user can run: `nex-ai integrate connect <type> <provider>`
+   Alternatively, the user can run: `nex integrate connect <type> <provider>`
 
 3. Poll for completion:
    Use the `get_connect_status` MCP tool with the `connect_id` every few seconds until `status` is `"connected"`.
 
 4. To disconnect:
    Use the `disconnect_integration` MCP tool with the `connection_id`.
-   Alternatively: `nex-ai integrate disconnect <id>`
+   Alternatively: `nex integrate disconnect <id>`
 
 5. To check overall setup status:
-   Suggest the user runs `nex-ai setup status` to see all platforms, integrations, and config status.
+   Suggest the user runs `nex setup status` to see all platforms, integrations, and config status.

--- a/claude-code-plugin/commands/integrate.md
+++ b/claude-code-plugin/commands/integrate.md
@@ -1,0 +1,29 @@
+Help the user connect third-party integrations (Gmail, Google Calendar, Outlook, Outlook Calendar, Slack, Attio, HubSpot, Salesforce) to their Nex workspace.
+
+## Available Integrations
+
+| Type | Provider | Display Name |
+|------|----------|-------------|
+| email | google | Gmail |
+| calendar | google | Google Calendar |
+| email | microsoft | Outlook |
+| calendar | microsoft | Outlook Calendar |
+| messaging | slack | Slack |
+| crm | attio | Attio |
+| crm | hubspot | HubSpot |
+| crm | salesforce | Salesforce |
+
+## Steps
+
+1. First, list current integrations to see what's already connected:
+   Use the `list_integrations` MCP tool.
+
+2. To connect a new integration:
+   Use the `connect_integration` MCP tool with the `type` and `provider` from the table above.
+   This returns an `auth_url` — open it in the user's browser.
+
+3. Poll for completion:
+   Use the `get_connect_status` MCP tool with the `connect_id` every few seconds until `status` is `"connected"`.
+
+4. To disconnect:
+   Use the `disconnect_integration` MCP tool with the `connection_id`.

--- a/claude-code-plugin/commands/integrate.md
+++ b/claude-code-plugin/commands/integrate.md
@@ -16,14 +16,19 @@ Help the user connect third-party integrations (Gmail, Google Calendar, Outlook,
 ## Steps
 
 1. First, list current integrations to see what's already connected:
-   Use the `list_integrations` MCP tool.
+   Use the `list_integrations` MCP tool, or suggest the user runs `nex-ai integrate list` in the terminal.
 
 2. To connect a new integration:
    Use the `connect_integration` MCP tool with the `type` and `provider` from the table above.
    This returns an `auth_url` — open it in the user's browser.
+   Alternatively, the user can run: `nex-ai integrate connect <type> <provider>`
 
 3. Poll for completion:
    Use the `get_connect_status` MCP tool with the `connect_id` every few seconds until `status` is `"connected"`.
 
 4. To disconnect:
    Use the `disconnect_integration` MCP tool with the `connection_id`.
+   Alternatively: `nex-ai integrate disconnect <id>`
+
+5. To check overall setup status:
+   Suggest the user runs `nex-ai setup status` to see all platforms, integrations, and config status.

--- a/claude-code-plugin/src/auto-capture.ts
+++ b/claude-code-plugin/src/auto-capture.ts
@@ -11,7 +11,7 @@
 
 import { readdirSync, statSync, readFileSync } from "node:fs";
 import { join, extname } from "node:path";
-import { loadConfig, loadScanConfig } from "./config.js";
+import { loadConfig, loadScanConfig, isHookEnabled } from "./config.js";
 import { NexClient } from "./nex-client.js";
 import { captureFilter } from "./capture-filter.js";
 import { RateLimiter } from "./rate-limiter.js";
@@ -91,6 +91,12 @@ async function main(): Promise<void> {
       chunks.push(chunk as Buffer);
     }
     const raw = Buffer.concat(chunks).toString("utf-8");
+
+    // Check .nex.toml kill switch
+    if (!isHookEnabled("capture")) {
+      process.stdout.write("{}");
+      return;
+    }
 
     let input: HookInput;
     try {

--- a/claude-code-plugin/src/auto-recall.ts
+++ b/claude-code-plugin/src/auto-recall.ts
@@ -9,7 +9,7 @@
  * On ANY error: outputs {} and exits 0 (graceful degradation).
  */
 
-import { loadConfig } from "./config.js";
+import { loadConfig, isHookEnabled } from "./config.js";
 import { NexClient } from "./nex-client.js";
 import { formatNexContext } from "./context-format.js";
 import { SessionStore } from "./session-store.js";
@@ -47,6 +47,12 @@ async function main(): Promise<void> {
       input = JSON.parse(raw) as HookInput;
     } catch {
       process.stderr.write("[nex-recall] Failed to parse stdin JSON\n");
+      process.stdout.write("{}");
+      return;
+    }
+
+    // Check .nex.toml kill switch
+    if (!isHookEnabled("recall")) {
       process.stdout.write("{}");
       return;
     }

--- a/claude-code-plugin/src/auto-session-start.ts
+++ b/claude-code-plugin/src/auto-session-start.ts
@@ -12,7 +12,7 @@
  * On ANY error: outputs {} and exits 0 (graceful degradation).
  */
 
-import { loadConfig, loadScanConfig, ConfigError } from "./config.js";
+import { loadConfig, loadScanConfig, ConfigError, isHookEnabled } from "./config.js";
 import { NexClient } from "./nex-client.js";
 import { RateLimiter } from "./rate-limiter.js";
 import { formatNexContext } from "./context-format.js";
@@ -40,6 +40,12 @@ async function main(): Promise<void> {
       chunks.push(chunk as Buffer);
     }
     const raw = Buffer.concat(chunks).toString("utf-8");
+
+    // Check .nex.toml kill switch
+    if (!isHookEnabled("session_start")) {
+      process.stdout.write("{}");
+      return;
+    }
 
     let input: HookInput = {};
     try {

--- a/claude-code-plugin/src/config.ts
+++ b/claude-code-plugin/src/config.ts
@@ -99,6 +99,95 @@ export function loadBaseUrl(): string {
   return baseUrl.replace(/\/+$/, "");
 }
 
+// --- .nex.toml project config support ---
+
+interface HookTomlConfig {
+  enabled?: boolean;
+  debounce_ms?: number;
+  min_length?: number;
+  max_length?: number;
+}
+
+interface ProjectTomlConfig {
+  hooks?: {
+    enabled?: boolean;
+    recall?: HookTomlConfig;
+    capture?: HookTomlConfig;
+    session_start?: HookTomlConfig;
+  };
+}
+
+function parseTomlValue(raw: string): unknown {
+  if (raw === "true") return true;
+  if (raw === "false") return false;
+  if (/^-?\d+(\.\d+)?$/.test(raw)) return Number(raw);
+  if ((raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))) {
+    return raw.slice(1, -1);
+  }
+  if (raw.startsWith("[") && raw.endsWith("]")) {
+    const inner = raw.slice(1, -1).trim();
+    if (!inner) return [];
+    return inner.split(",").map((item) => parseTomlValue(item.trim()));
+  }
+  return raw;
+}
+
+function parseToml(content: string): Record<string, unknown> {
+  const obj: Record<string, unknown> = {};
+  const currentSection: string[] = [];
+
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+
+    const sectionMatch = trimmed.match(/^\[([^\]]+)\]$/);
+    if (sectionMatch) {
+      currentSection.length = 0;
+      currentSection.push(...sectionMatch[1].split("."));
+      continue;
+    }
+
+    const kvMatch = trimmed.match(/^([a-zA-Z_][a-zA-Z0-9_.]*)\s*=\s*(.+)$/);
+    if (!kvMatch) continue;
+
+    const path = [...currentSection, ...kvMatch[1].trim().split(".")];
+    const value = parseTomlValue(kvMatch[2].trim());
+
+    let target: Record<string, unknown> = obj;
+    for (let i = 0; i < path.length - 1; i++) {
+      if (!(path[i] in target) || typeof target[path[i]] !== "object") {
+        target[path[i]] = {};
+      }
+      target = target[path[i]] as Record<string, unknown>;
+    }
+    target[path[path.length - 1]] = value;
+  }
+  return obj;
+}
+
+/**
+ * Check if a specific hook is enabled in .nex.toml.
+ * Returns true by default (hooks are opt-out).
+ */
+export function isHookEnabled(hookName: "recall" | "capture" | "session_start"): boolean {
+  try {
+    const tomlPath = join(process.cwd(), ".nex.toml");
+    const content = readFileSync(tomlPath, "utf-8");
+    const config = parseToml(content) as ProjectTomlConfig;
+
+    // Master kill switch
+    if (config.hooks?.enabled === false) return false;
+
+    // Per-hook setting
+    const hookConfig = config.hooks?.[hookName];
+    if (hookConfig?.enabled === false) return false;
+
+    return true;
+  } catch {
+    return true; // No .nex.toml or read error → hooks enabled by default
+  }
+}
+
 const DEFAULT_SCAN_EXTENSIONS = [".md", ".txt", ".csv", ".json", ".yaml", ".yml"];
 const DEFAULT_IGNORE_DIRS = [
   "node_modules", ".git", "dist", "build", ".next", "__pycache__",

--- a/cli/README.md
+++ b/cli/README.md
@@ -57,18 +57,22 @@ All MCP-based platforms use the same server entry:
 ## Setup Command
 
 ```bash
-nex setup                          # Auto-detect platforms, install Claude Code plugin, create .nex.toml
+nex setup                          # Auto-detect platforms, install plugin, scan files, create .nex.toml
 nex setup --with-mcp               # Also write MCP config to all detected platforms
 nex setup --platform cursor        # Install for a specific platform only
 nex setup --no-plugin              # Only create config files, skip hooks/commands
+nex setup --no-scan                # Skip file scanning during setup
 nex setup status                   # Show all platforms, install status, and connections
 ```
 
 **Default behavior** (no flags):
 - Claude Code: installs hooks + slash commands (no MCP — avoids filling context windows)
 - Other platforms: detected but MCP not written until `--with-mcp` is passed
+- Scans current directory and ingests new/changed files into Nex
 - Creates `.nex.toml` project config with commented defaults
 - Syncs API key to `~/.nex-mcp.json` (shared config)
+
+**Single install**: `npm install -g @nex-ai/nex` bundles everything — the Claude Code plugin hooks, slash commands, and MCP server are all included. No separate packages needed.
 
 > **Tip:** AI agents don't automatically know about Nex. Explicitly tell your agent to "use Nex for context and memory" in your prompts or CLAUDE.md instructions.
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,4 +1,4 @@
-# nex-ai
+# @nex-ai/nex
 
 Nex CLI provides organizational context & memory to AI agents across 10+ platforms.
 
@@ -6,28 +6,28 @@ Nex CLI provides organizational context & memory to AI agents across 10+ platfor
 
 ```bash
 # Install globally
-npm install -g nex-ai
+npm install -g @nex-ai/nex
 
 # Or run directly (no install)
-npx nex-ai ask "who is Maria?"
+npx @nex-ai/nex ask "who is Maria?"
 ```
 
 ## Quick Start
 
 ```bash
 # 1. Register for an API key
-nex-ai register --email you@company.com
+nex register --email you@company.com
 
 # 2. Set up your platforms (auto-detects installed tools)
-nex-ai setup
+nex setup
 
 # 3. Query your knowledge
-nex-ai ask "what's the latest on the Acme deal?"
+nex ask "what's the latest on the Acme deal?"
 ```
 
 ## Supported Platforms
 
-`nex-ai setup` auto-detects and configures these platforms:
+`nex setup` auto-detects and configures these platforms:
 
 | Platform | Detection | Integration |
 |----------|-----------|-------------|
@@ -57,11 +57,11 @@ All MCP-based platforms use the same server entry:
 ## Setup Command
 
 ```bash
-nex-ai setup                          # Auto-detect platforms, install Claude Code plugin, create .nex.toml
-nex-ai setup --with-mcp               # Also write MCP config to all detected platforms
-nex-ai setup --platform cursor        # Install for a specific platform only
-nex-ai setup --no-plugin              # Only create config files, skip hooks/commands
-nex-ai setup status                   # Show all platforms, install status, and connections
+nex setup                          # Auto-detect platforms, install Claude Code plugin, create .nex.toml
+nex setup --with-mcp               # Also write MCP config to all detected platforms
+nex setup --platform cursor        # Install for a specific platform only
+nex setup --no-plugin              # Only create config files, skip hooks/commands
+nex setup status                   # Show all platforms, install status, and connections
 ```
 
 **Default behavior** (no flags):
@@ -74,7 +74,7 @@ nex-ai setup status                   # Show all platforms, install status, and 
 
 ## Project Config: `.nex.toml`
 
-Per-project settings file created by `nex-ai setup`. All fields are optional.
+Per-project settings file created by `nex setup`. All fields are optional.
 
 ```toml
 [auth]
@@ -104,7 +104,7 @@ Per-project settings file created by `nex-ai setup`. All fields are optional.
 # depth = 2
 
 [mcp]
-# enabled = false             # Set to true by `nex-ai setup --with-mcp`
+# enabled = false             # Set to true by `nex setup --with-mcp`
 
 [output]
 # format = "text"             # "text" | "json"
@@ -118,22 +118,22 @@ Per-project settings file created by `nex-ai setup`. All fields are optional.
 ### Knowledge Graph
 
 ```bash
-nex-ai ask <query>              # Query with natural language
-nex-ai remember <content>       # Ingest text (meeting notes, emails, docs)
-nex-ai recall <query>           # Query → XML-wrapped for agent injection
-nex-ai capture [content]        # Rate-limited ingestion for agent hooks
-nex-ai artifact <id>            # Check processing status
-nex-ai search <query>           # Search CRM records by name
-nex-ai insight list [--last 24h]  # Recent insights
+nex ask <query>              # Query with natural language
+nex remember <content>       # Ingest text (meeting notes, emails, docs)
+nex recall <query>           # Query → XML-wrapped for agent injection
+nex capture [content]        # Rate-limited ingestion for agent hooks
+nex artifact <id>            # Check processing status
+nex search <query>           # Search CRM records by name
+nex insight list [--last 24h]  # Recent insights
 ```
 
 ### Integrations
 
 ```bash
-nex-ai integrate list                        # Show all integrations with connection status
-nex-ai integrate connect email google        # Connect Gmail via OAuth
-nex-ai integrate connect messaging slack     # Connect Slack
-nex-ai integrate disconnect <id>             # Disconnect by connection ID
+nex integrate list                        # Show all integrations with connection status
+nex integrate connect email google        # Connect Gmail via OAuth
+nex integrate connect messaging slack     # Connect Slack
+nex integrate disconnect <id>             # Disconnect by connection ID
 ```
 
 Supported providers: Gmail, Google Calendar, Outlook, Outlook Calendar, Slack, Attio, HubSpot, Salesforce.
@@ -141,32 +141,32 @@ Supported providers: Gmail, Google Calendar, Outlook, Outlook Calendar, Slack, A
 ### CRM Records
 
 ```bash
-nex-ai object list              # List object types (person, company, deal)
-nex-ai record list person --limit 10
-nex-ai record create person --data '{"name":"Jane Doe"}'
-nex-ai record upsert person --match email --data '{"name":"Jane","email":"jane@co.com"}'
-nex-ai record update <id> --data '{"phone":"+1234"}'
-nex-ai record delete <id>
-nex-ai record timeline <id>
+nex object list              # List object types (person, company, deal)
+nex record list person --limit 10
+nex record create person --data '{"name":"Jane Doe"}'
+nex record upsert person --match email --data '{"name":"Jane","email":"jane@co.com"}'
+nex record update <id> --data '{"phone":"+1234"}'
+nex record delete <id>
+nex record timeline <id>
 ```
 
 ### Tasks & Notes
 
 ```bash
-nex-ai task create --title "Follow up" --priority high --due 2026-04-01
-nex-ai task list --assignee me --search "follow up"
-nex-ai task update <id> --completed
-nex-ai note create --title "Call notes" --content "..." --entity <record-id>
+nex task create --title "Follow up" --priority high --due 2026-04-01
+nex task list --assignee me --search "follow up"
+nex task update <id> --completed
+nex note create --title "Call notes" --content "..." --entity <record-id>
 ```
 
 ### Relationships & Lists
 
 ```bash
-nex-ai rel list-defs
-nex-ai rel create <record-id> --def <def-id> --entity1 <id1> --entity2 <id2>
-nex-ai list list person
-nex-ai list add-member <list-id> --parent <record-id>
-nex-ai list-job create "enterprise contacts in EMEA"
+nex rel list-defs
+nex rel create <record-id> --def <def-id> --entity1 <id1> --entity2 <id2>
+nex list list person
+nex list add-member <list-id> --parent <record-id>
+nex list-job create "enterprise contacts in EMEA"
 ```
 
 ### File Scanning
@@ -182,11 +182,11 @@ Configure via `.nex.toml` `[scan]` section or environment variables (`NEX_SCAN_E
 ### Config & Sessions
 
 ```bash
-nex-ai config show              # Resolved config (key masked)
-nex-ai config set default_format text
-nex-ai config path              # ~/.nex/config.json
-nex-ai session list             # Stored session mappings
-nex-ai session clear
+nex config show              # Resolved config (key masked)
+nex config set default_format text
+nex config path              # ~/.nex/config.json
+nex session list             # Stored session mappings
+nex session clear
 ```
 
 ## Global Flags
@@ -204,9 +204,9 @@ nex-ai session clear
 `ask`, `remember`, and `capture` read from stdin when no argument is provided:
 
 ```bash
-cat meeting-notes.txt | nex-ai remember
-echo "what happened today?" | nex-ai ask
-git diff | nex-ai capture
+cat meeting-notes.txt | nex remember
+echo "what happened today?" | nex ask
+git diff | nex capture
 ```
 
 ## Exit Codes
@@ -224,5 +224,5 @@ npm install
 npm run build     # TypeScript → dist/
 npm run dev       # Run with tsx (no build)
 npm test          # Unit tests
-NEX_DEV_URL=http://localhost:30000 nex-ai ask "test"  # Local API
+NEX_DEV_URL=http://localhost:30000 nex ask "test"  # Local API
 ```

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,93 +1,199 @@
-# @nex-ai/cli
+# nex-ai
 
-Nex CLI provides organizational context & memory to AI agents.
+Nex CLI provides organizational context & memory to AI agents across 10+ platforms.
 
 ## Install
 
 ```bash
-# Run directly (no install)
-npx @nex-ai/cli ask "who is Maria?"
-
 # Install globally
-npm install -g @nex-ai/cli
+npm install -g nex-ai
 
-# Or run from source
-cd cli && npm install && npm run build && node dist/index.js
+# Or run directly (no install)
+npx nex-ai ask "who is Maria?"
 ```
 
-## Setup
+## Quick Start
 
 ```bash
-# Register for an API key
-nex register --email you@company.com
+# 1. Register for an API key
+nex-ai register --email you@company.com
 
-# Or set an existing key
-export NEX_API_KEY=sk-your_key_here
+# 2. Set up your platforms (auto-detects installed tools)
+nex-ai setup
 
-# Verify
-nex config show
+# 3. Query your knowledge
+nex-ai ask "what's the latest on the Acme deal?"
 ```
+
+## Supported Platforms
+
+`nex-ai setup` auto-detects and configures these platforms:
+
+| Platform | Detection | Integration |
+|----------|-----------|-------------|
+| **Claude Code** | `~/.claude/` | Hooks (auto-recall, auto-capture, session start) + slash commands + MCP |
+| **Claude Desktop** | App config exists | MCP server |
+| **Cursor** | `~/.cursor/` | MCP server |
+| **VS Code (Copilot)** | `which code` or `.vscode/` | MCP server (workspace-level) |
+| **Windsurf** | `~/.codeium/windsurf/` | MCP server |
+| **Cline** | VS Code extension installed | MCP server (globalStorage config) |
+| **Continue.dev** | `.continue/` or `~/.continue/` | MCP server |
+| **Zed** | `~/.config/zed/` | MCP server (context_servers) |
+| **Kilo Code** | `.kilocode/` in project | MCP server |
+| **OpenCode** | `~/.config/opencode/` | MCP server |
+
+All MCP-based platforms use the same server entry:
+
+```json
+{
+  "nex": {
+    "command": "npx",
+    "args": ["-y", "@nex-crm/mcp-server"],
+    "env": { "NEX_API_KEY": "sk-..." }
+  }
+}
+```
+
+## Setup Command
+
+```bash
+nex-ai setup                          # Auto-detect platforms, install Claude Code plugin, create .nex.toml
+nex-ai setup --with-mcp               # Also write MCP config to all detected platforms
+nex-ai setup --platform cursor        # Install for a specific platform only
+nex-ai setup --no-plugin              # Only create config files, skip hooks/commands
+nex-ai setup status                   # Show all platforms, install status, and connections
+```
+
+**Default behavior** (no flags):
+- Claude Code: installs hooks + slash commands (no MCP — avoids filling context windows)
+- Other platforms: detected but MCP not written until `--with-mcp` is passed
+- Creates `.nex.toml` project config with commented defaults
+- Syncs API key to `~/.nex-mcp.json` (shared config)
+
+> **Tip:** AI agents don't automatically know about Nex. Explicitly tell your agent to "use Nex for context and memory" in your prompts or CLAUDE.md instructions.
+
+## Project Config: `.nex.toml`
+
+Per-project settings file created by `nex-ai setup`. All fields are optional.
+
+```toml
+[auth]
+# api_key = "sk-..."          # Prefer NEX_API_KEY env var or ~/.nex/config.json
+
+[hooks]
+# enabled = true              # Master kill switch for all hooks
+
+[hooks.recall]
+# enabled = true              # Auto-recall context on each prompt
+# debounce_ms = 30000
+
+[hooks.capture]
+# enabled = true              # Auto-capture on conversation stop
+# min_length = 20
+# max_length = 50000
+
+[hooks.session_start]
+# enabled = true              # Load context on session start
+
+[scan]
+# enabled = true
+# extensions = [".md", ".txt", ".csv", ".json", ".yaml", ".yml"]
+# ignore_dirs = ["node_modules", ".git", "dist", "build", "__pycache__"]
+# max_files = 5
+# max_file_size = 100000
+# depth = 2
+
+[mcp]
+# enabled = false             # Set to true by `nex-ai setup --with-mcp`
+
+[output]
+# format = "text"             # "text" | "json"
+# timeout = 120000
+```
+
+**Resolution order:** CLI flags > `.nex.toml` > env vars > `~/.nex/config.json` > defaults
 
 ## Commands
 
 ### Knowledge Graph
 
 ```bash
-nex ask <query>              # Query with natural language
-nex remember <content>       # Ingest text (meeting notes, emails, docs)
-nex recall <query>           # Query → XML-wrapped for agent injection
-nex capture [content]        # Rate-limited ingestion for agent hooks
-nex artifact <id>            # Check processing status
-nex search <query>           # Search CRM records by name
-nex insight list [--last 24h]  # Recent insights
+nex-ai ask <query>              # Query with natural language
+nex-ai remember <content>       # Ingest text (meeting notes, emails, docs)
+nex-ai recall <query>           # Query → XML-wrapped for agent injection
+nex-ai capture [content]        # Rate-limited ingestion for agent hooks
+nex-ai artifact <id>            # Check processing status
+nex-ai search <query>           # Search CRM records by name
+nex-ai insight list [--last 24h]  # Recent insights
 ```
+
+### Integrations
+
+```bash
+nex-ai integrate list                        # Show all integrations with connection status
+nex-ai integrate connect email google        # Connect Gmail via OAuth
+nex-ai integrate connect messaging slack     # Connect Slack
+nex-ai integrate disconnect <id>             # Disconnect by connection ID
+```
+
+Supported providers: Gmail, Google Calendar, Outlook, Outlook Calendar, Slack, Attio, HubSpot, Salesforce.
 
 ### CRM Records
 
 ```bash
-nex object list              # List object types (person, company, deal)
-nex record list person --limit 10
-nex record create person --data '{"name":"Jane Doe"}'
-nex record upsert person --match email --data '{"name":"Jane","email":"jane@co.com"}'
-nex record update <id> --data '{"phone":"+1234"}'
-nex record delete <id>
-nex record timeline <id>
+nex-ai object list              # List object types (person, company, deal)
+nex-ai record list person --limit 10
+nex-ai record create person --data '{"name":"Jane Doe"}'
+nex-ai record upsert person --match email --data '{"name":"Jane","email":"jane@co.com"}'
+nex-ai record update <id> --data '{"phone":"+1234"}'
+nex-ai record delete <id>
+nex-ai record timeline <id>
 ```
 
 ### Tasks & Notes
 
 ```bash
-nex task create --title "Follow up" --priority high --due 2026-04-01
-nex task list --assignee me --search "follow up"
-nex task update <id> --completed
-nex note create --title "Call notes" --content "..." --entity <record-id>
+nex-ai task create --title "Follow up" --priority high --due 2026-04-01
+nex-ai task list --assignee me --search "follow up"
+nex-ai task update <id> --completed
+nex-ai note create --title "Call notes" --content "..." --entity <record-id>
 ```
 
 ### Relationships & Lists
 
 ```bash
-nex rel list-defs
-nex rel create <record-id> --def <def-id> --entity1 <id1> --entity2 <id2>
-nex list list person
-nex list add-member <list-id> --parent <record-id>
-nex list-job create "enterprise contacts in EMEA"
+nex-ai rel list-defs
+nex-ai rel create <record-id> --def <def-id> --entity1 <id1> --entity2 <id2>
+nex-ai list list person
+nex-ai list add-member <list-id> --parent <record-id>
+nex-ai list-job create "enterprise contacts in EMEA"
 ```
+
+### File Scanning
+
+On session start, Nex automatically scans project files and ingests changed content.
+
+**Default text-based extensions:** `.md`, `.txt`, `.csv`, `.json`, `.yaml`, `.yml`
+
+**Document formats** (handled separately): `.docx`, `.doc`, `.odt`, `.xlsx`, `.xls`, `.pptx`, `.ppt`, `.pdf`
+
+Configure via `.nex.toml` `[scan]` section or environment variables (`NEX_SCAN_ENABLED`, `NEX_SCAN_EXTENSIONS`, etc.).
 
 ### Config & Sessions
 
 ```bash
-nex config show              # Resolved config (key masked)
-nex config set default_format text
-nex config path              # ~/.nex/config.json
-nex session list             # Stored session mappings
-nex session clear
+nex-ai config show              # Resolved config (key masked)
+nex-ai config set default_format text
+nex-ai config path              # ~/.nex/config.json
+nex-ai session list             # Stored session mappings
+nex-ai session clear
 ```
 
 ## Global Flags
 
 ```
 --api-key <key>     Override API key (env: NEX_API_KEY)
---format <fmt>      json (default) | text | quiet
+--format <fmt>      json | text (default for integrate list) | quiet
 --timeout <ms>      Request timeout (default: 120000)
 --session <id>      Session ID for multi-turn context
 --debug             Debug output on stderr
@@ -98,9 +204,9 @@ nex session clear
 `ask`, `remember`, and `capture` read from stdin when no argument is provided:
 
 ```bash
-cat meeting-notes.txt | nex remember
-echo "what happened today?" | nex ask
-git diff | nex capture
+cat meeting-notes.txt | nex-ai remember
+echo "what happened today?" | nex-ai ask
+git diff | nex-ai capture
 ```
 
 ## Exit Codes
@@ -111,26 +217,12 @@ git diff | nex capture
 | 1 | General error (server error, rate limit, invalid input) |
 | 2 | Auth error (no API key, invalid key, 401/403) |
 
-## For Agent Builders
-
-Build auto-recall and auto-capture hooks for any AI agent:
-
-```bash
-# Auto-recall: inject context before each prompt
-nex recall "$USER_PROMPT"  # Returns <nex-context>...</nex-context> or empty
-
-# Auto-capture: save agent output after each turn
-nex capture "$AGENT_RESPONSE"  # Rate-limited, filtered, idempotent
-```
-
-The `recall` command includes smart filtering (skips short prompts, tool commands, code-heavy content) and the `capture` command includes rate limiting (10 req/min) and content filtering (strips previously injected context blocks).
-
 ## Development
 
 ```bash
 npm install
 npm run build     # TypeScript → dist/
 npm run dev       # Run with tsx (no build)
-npm test          # 65 unit tests
-NEX_DEV_URL=http://localhost:30000 nex ask "test"  # Local API
+npm test          # Unit tests
+NEX_DEV_URL=http://localhost:30000 nex-ai ask "test"  # Local API
 ```

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nex-ai/cli",
-  "version": "0.1.0",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nex-ai/cli",
-      "version": "0.1.0",
+      "version": "0.1.8",
       "license": "MIT",
       "dependencies": {
         "commander": "^13.0.0"

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nex-ai/cli",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nex-ai/cli",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "license": "MIT",
       "dependencies": {
         "commander": "^13.0.0"

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nex-ai/cli",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nex-ai/cli",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "MIT",
       "dependencies": {
         "commander": "^13.0.0"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nex-ai/nex",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Nex CLI provides organizational context & memory to AI agents",
   "type": "module",
   "bin": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -8,6 +8,7 @@
   },
   "files": [
     "dist",
+    "plugin-commands",
     "README.md"
   ],
   "scripts": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "nex-ai",
+  "name": "@nex-ai/nex",
   "version": "0.1.7",
   "description": "Nex CLI provides organizational context & memory to AI agents",
   "type": "module",
   "bin": {
-    "nex-ai": "dist/index.js"
+    "nex": "dist/index.js"
   },
   "files": [
     "dist",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nex-ai/nex",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Nex CLI provides organizational context & memory to AI agents",
   "type": "module",
   "bin": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@nex-ai/cli",
+  "name": "nex-ai",
   "version": "0.1.7",
   "description": "Nex CLI provides organizational context & memory to AI agents",
   "type": "module",
   "bin": {
-    "nex": "dist/index.js"
+    "nex-ai": "dist/index.js"
   },
   "files": [
     "dist",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nex-ai/nex",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Nex CLI provides organizational context & memory to AI agents",
   "type": "module",
   "bin": {

--- a/cli/plugin-commands/add-field.md
+++ b/cli/plugin-commands/add-field.md
@@ -1,0 +1,12 @@
+---
+description: Add a field (attribute) to an object type
+---
+Add a field to an object type: $ARGUMENTS
+
+If insufficient arguments, respond: "Usage: /add-field <object_slug> <field_name> <field_type> [--required] [--label <label>]"
+
+Supported field types: text, number, email, phone, url, date, datetime, boolean, select, multi_select, currency, rich_text.
+
+Parse the object slug, field name, type, and optional flags from arguments.
+Use the `mcp__nex__create_attribute` tool with the parsed parameters.
+Confirm the field was added successfully.

--- a/cli/plugin-commands/artifact.md
+++ b/cli/plugin-commands/artifact.md
@@ -1,0 +1,14 @@
+---
+description: Check processing status of an ingested artifact
+---
+Check artifact status: $ARGUMENTS
+
+If no artifact ID provided, respond: "Usage: /artifact <artifact_id>"
+
+Use the `mcp__nex__get_artifact_status` tool with the provided artifact_id.
+
+Show:
+- **Status**: processing state (pending, processing, completed, failed)
+- **Extracted entities**: list if available
+- **Relationships**: list if available
+- **Error**: details if status is failed

--- a/cli/plugin-commands/create-note.md
+++ b/cli/plugin-commands/create-note.md
@@ -1,0 +1,10 @@
+---
+description: Create a new note
+---
+Create a note: $ARGUMENTS
+
+If no title provided, respond: "Usage: /create-note <title> [--content <body>] [--entity <entity_id>]"
+
+Parse the title and optional content/entity from arguments.
+Use the `mcp__nex__create_note` tool with the parsed parameters.
+Confirm creation with the note ID and details.

--- a/cli/plugin-commands/create-object.md
+++ b/cli/plugin-commands/create-object.md
@@ -1,0 +1,10 @@
+---
+description: Create a new object type definition
+---
+Create a new object type: $ARGUMENTS
+
+If no name provided, respond: "Usage: /create-object <object name> [--plural <plural name>] [--description <description>]"
+
+Parse the arguments for the object name, optional plural name, and description.
+Use the `mcp__nex__create_object` tool with the parsed parameters.
+Confirm creation with the returned slug and details.

--- a/cli/plugin-commands/create-record.md
+++ b/cli/plugin-commands/create-record.md
@@ -1,0 +1,11 @@
+---
+description: Create a new record
+---
+Create a new record: $ARGUMENTS
+
+If insufficient arguments, respond: "Usage: /create-record <object_slug> <field=value> [field=value ...]"
+Example: /create-record contacts name="Jane Doe" email="jane@example.com"
+
+Parse the object slug and field key=value pairs from arguments.
+Use the `mcp__nex__create_record` tool with object_slug and the attributes object.
+Confirm creation with the returned record ID and details.

--- a/cli/plugin-commands/create-task.md
+++ b/cli/plugin-commands/create-task.md
@@ -1,0 +1,10 @@
+---
+description: Create a new task
+---
+Create a task: $ARGUMENTS
+
+If no title provided, respond: "Usage: /create-task <title> [--due <date>] [--priority <low|medium|high>] [--entity <entity_id>]"
+
+Parse the title and optional flags from arguments.
+Use the `mcp__nex__create_task` tool with the parsed parameters.
+Confirm creation with the task ID and details.

--- a/cli/plugin-commands/entities.md
+++ b/cli/plugin-commands/entities.md
@@ -1,0 +1,18 @@
+---
+description: Search for entities (people, companies, topics) in Nex knowledge base
+---
+Search for entities matching: $ARGUMENTS
+If no query provided, respond: "Usage: /entities <search query>"
+
+Use the `mcp__nex__query_context` tool with the query.
+From the response, extract the `entity_references` array.
+If no entities found, respond: "No matching entities found."
+
+Format each entity as a bullet list:
+```
+Found {count} entities:
+- {name} ({type_label}) — {mention_count} mentions
+```
+
+Type labels: type "14" → Person, type "15" → Company, all others → Entity.
+Only show mention count if available (count > 0).

--- a/cli/plugin-commands/insights.md
+++ b/cli/plugin-commands/insights.md
@@ -1,0 +1,13 @@
+---
+description: Get recent insights from the context graph
+---
+Get insights: $ARGUMENTS
+
+Use the `mcp__nex__get_insights` tool. If $ARGUMENTS specifies a time window (e.g. "2h", "1d", "30m"), use it as the `last` parameter. Default to "1h" if not specified.
+
+Format each insight as:
+- **Type**: insight content
+  - Confidence: X% | Source entities
+  - Timestamp
+
+If no insights found, respond: "No recent insights found in the specified time window."

--- a/cli/plugin-commands/integrate.md
+++ b/cli/plugin-commands/integrate.md
@@ -1,0 +1,34 @@
+Help the user connect third-party integrations (Gmail, Google Calendar, Outlook, Outlook Calendar, Slack, Attio, HubSpot, Salesforce) to their Nex workspace.
+
+## Available Integrations
+
+| Type | Provider | Display Name |
+|------|----------|-------------|
+| email | google | Gmail |
+| calendar | google | Google Calendar |
+| email | microsoft | Outlook |
+| calendar | microsoft | Outlook Calendar |
+| messaging | slack | Slack |
+| crm | attio | Attio |
+| crm | hubspot | HubSpot |
+| crm | salesforce | Salesforce |
+
+## Steps
+
+1. First, list current integrations to see what's already connected:
+   Use the `list_integrations` MCP tool, or suggest the user runs `nex integrate list` in the terminal.
+
+2. To connect a new integration:
+   Use the `connect_integration` MCP tool with the `type` and `provider` from the table above.
+   This returns an `auth_url` — open it in the user's browser.
+   Alternatively, the user can run: `nex integrate connect <type> <provider>`
+
+3. Poll for completion:
+   Use the `get_connect_status` MCP tool with the `connect_id` every few seconds until `status` is `"connected"`.
+
+4. To disconnect:
+   Use the `disconnect_integration` MCP tool with the `connection_id`.
+   Alternatively: `nex integrate disconnect <id>`
+
+5. To check overall setup status:
+   Suggest the user runs `nex setup status` to see all platforms, integrations, and config status.

--- a/cli/plugin-commands/link-records.md
+++ b/cli/plugin-commands/link-records.md
@@ -1,0 +1,10 @@
+---
+description: Link two records with a relationship
+---
+Link records: $ARGUMENTS
+
+If insufficient arguments, respond: "Usage: /link-records <definition_id> <source_record_id> <target_record_id>"
+
+Parse the relationship definition ID, source record ID, and target record ID from arguments.
+Use the `mcp__nex__create_relationship` tool with the parsed parameters.
+Confirm the relationship was created.

--- a/cli/plugin-commands/list-members.md
+++ b/cli/plugin-commands/list-members.md
@@ -1,0 +1,15 @@
+---
+description: View records in a list
+---
+Show list members: $ARGUMENTS
+
+If no list ID provided, respond: "Usage: /list-members <list_id>"
+
+Use the `mcp__nex__list_list_records` tool with the provided list_id.
+
+Format results as a table showing:
+- Record name/title
+- Key attributes
+- Date added to list
+
+If no members found, respond: "This list has no members."

--- a/cli/plugin-commands/lists.md
+++ b/cli/plugin-commands/lists.md
@@ -1,0 +1,14 @@
+---
+description: View lists for an object type
+---
+Show lists for: $ARGUMENTS
+
+If no object slug provided, respond: "Usage: /lists <object_slug>"
+
+Use the `mcp__nex__list_object_lists` tool with the provided object_slug.
+
+Format each list as:
+- **List Name** (ID: `list_id`)
+  - Description and member count if available
+
+If no lists found, respond: "No lists found for this object type."

--- a/cli/plugin-commands/notes.md
+++ b/cli/plugin-commands/notes.md
@@ -1,0 +1,13 @@
+---
+description: List notes, optionally for a specific record
+---
+List notes: $ARGUMENTS
+
+Use the `mcp__nex__list_notes` tool. If $ARGUMENTS is provided, use it as an entity_id filter to show notes for that specific record.
+
+Format each note as:
+- **Title** (ID: `note_id`, Created: date)
+  - Content preview (first 100 chars)
+  - Linked entity if applicable
+
+If no notes found, respond: "No notes found."

--- a/cli/plugin-commands/recall.md
+++ b/cli/plugin-commands/recall.md
@@ -1,0 +1,5 @@
+---
+description: Recall relevant memories from Nex knowledge base
+---
+Search the nex knowledge base for: $ARGUMENTS
+Use the mcp__nex__context_ask tool to query and return formatted results with sources.

--- a/cli/plugin-commands/record.md
+++ b/cli/plugin-commands/record.md
@@ -1,0 +1,12 @@
+---
+description: Get a record by ID
+---
+Get record: $ARGUMENTS
+
+If no record ID provided, respond: "Usage: /record <record_id>"
+
+Use the `mcp__nex__get_record` tool with the provided record_id.
+Format the record as:
+- **Name** (Type: `object_type`)
+- All attributes in a readable key-value list
+- Show created_at and updated_at timestamps

--- a/cli/plugin-commands/register.md
+++ b/cli/plugin-commands/register.md
@@ -1,0 +1,28 @@
+---
+description: Register for a Nex API key (required for first-time setup)
+---
+Register for a Nex account to get an API key for the memory plugin.
+
+If $ARGUMENTS contains an email address, use it directly. Otherwise, ask the user for their email.
+
+Run the registration script. Find the script path by running:
+```
+node -e "console.log(require('path').join(require('path').dirname(require.resolve('@nex-ai/nex/package.json')), 'dist', 'plugin', 'auto-register.js'))"
+```
+
+Then run:
+```
+node <resolved-path> <email> [name] [company]
+```
+
+If the resolve fails, try the global install path:
+```
+node $(npm prefix -g)/lib/node_modules/@nex-ai/nex/dist/plugin/auto-register.js <email> [name] [company]
+```
+
+After successful registration:
+1. The API key is saved to ~/.nex-mcp.json automatically
+2. All Nex memory features (auto-recall, auto-capture, file scanning) will work immediately
+3. No need to set NEX_API_KEY manually
+
+If already registered, inform the user their existing API key is active.

--- a/cli/plugin-commands/relationships.md
+++ b/cli/plugin-commands/relationships.md
@@ -1,0 +1,12 @@
+---
+description: View relationship definitions in the workspace
+---
+List relationship definitions: $ARGUMENTS
+
+Use the `mcp__nex__list_relationship_definitions` tool.
+
+Format each relationship as:
+- **Name**: source_object → target_object (cardinality)
+  - Description if available
+
+If no relationships defined, respond: "No relationship definitions found in this workspace."

--- a/cli/plugin-commands/remember.md
+++ b/cli/plugin-commands/remember.md
@@ -1,0 +1,5 @@
+---
+description: Store information in Nex knowledge base
+---
+Use the mcp__nex__context_add_text tool to store the following text: $ARGUMENTS
+Confirm what was stored.

--- a/cli/plugin-commands/scan.md
+++ b/cli/plugin-commands/scan.md
@@ -1,0 +1,8 @@
+---
+description: Scan and ingest project files into Nex knowledge base
+---
+Scan the current project directory for business documents (md, txt, csv, json, yaml)
+and ingest new or changed files into the Nex knowledge base.
+Use the mcp__nex__context_add_text tool for each file found.
+If $ARGUMENTS contains a path, scan that directory instead.
+Report which files were ingested and which were skipped.

--- a/cli/plugin-commands/schema.md
+++ b/cli/plugin-commands/schema.md
@@ -1,0 +1,12 @@
+---
+description: View workspace schema (object types and their fields)
+---
+$ARGUMENTS
+
+If a specific object slug is provided, use the `mcp__nex__get_object` tool with that slug to show its details and attributes.
+
+Otherwise, use `mcp__nex__list_objects` with include_attributes=true to list all object types.
+
+Format each object type as:
+- **Object Name** (`slug`) — description
+  - Fields: list each attribute with name, type, and whether required

--- a/cli/plugin-commands/search.md
+++ b/cli/plugin-commands/search.md
@@ -1,0 +1,12 @@
+---
+description: Search CRM records by name across all types
+---
+Search for: $ARGUMENTS
+
+If no query provided, respond: "Usage: /search <query>"
+
+Use the `mcp__nex__search_records` tool with the query.
+Format results grouped by object type. For each result show:
+- **Name** (ID: `record_id`) — object type
+- Key attributes if available
+If no results found, respond: "No records found matching your query."

--- a/cli/plugin-commands/tasks.md
+++ b/cli/plugin-commands/tasks.md
@@ -1,0 +1,13 @@
+---
+description: List tasks, optionally filtered
+---
+List tasks: $ARGUMENTS
+
+Use the `mcp__nex__list_tasks` tool. If $ARGUMENTS is provided, use it as a search filter.
+
+Format each task as:
+- [ ] or [x] **Title** (Priority: X, Due: date)
+  - Status, assignee if set
+  - Brief description if available
+
+If no tasks found, respond: "No tasks found."

--- a/cli/plugin-commands/timeline.md
+++ b/cli/plugin-commands/timeline.md
@@ -1,0 +1,12 @@
+---
+description: View timeline events for a record
+---
+Show timeline for record: $ARGUMENTS
+
+If no record ID provided, respond: "Usage: /timeline <record_id>"
+
+Use the `mcp__nex__get_record_timeline` tool with the provided record_id.
+Format timeline entries chronologically, showing for each:
+- Timestamp
+- Event type
+- Summary of what changed

--- a/cli/plugin-commands/update-field.md
+++ b/cli/plugin-commands/update-field.md
@@ -1,0 +1,10 @@
+---
+description: Update a field (attribute) on an object type
+---
+Update a field: $ARGUMENTS
+
+If insufficient arguments, respond: "Usage: /update-field <object_slug> <attribute_slug> [--label <label>] [--required true|false] [--description <desc>]"
+
+Parse the object slug, attribute slug, and fields to update from arguments.
+Use the `mcp__nex__update_attribute` tool with the parsed parameters.
+Confirm the update with the returned details.

--- a/cli/plugin-commands/update-record.md
+++ b/cli/plugin-commands/update-record.md
@@ -1,0 +1,11 @@
+---
+description: Update an existing record
+---
+Update record: $ARGUMENTS
+
+If insufficient arguments, respond: "Usage: /update-record <record_id> <field=value> [field=value ...]"
+Example: /update-record rec_123 email="new@example.com" phone="+1234567890"
+
+Parse the record ID and field key=value pairs from arguments.
+Use the `mcp__nex__update_record` tool with the record_id and attributes object.
+Confirm the update with the returned details.

--- a/cli/plugin-commands/upsert-record.md
+++ b/cli/plugin-commands/upsert-record.md
@@ -1,0 +1,13 @@
+---
+description: Create or update a record (upsert)
+---
+Upsert record: $ARGUMENTS
+
+If insufficient arguments, respond: "Usage: /upsert-record <object_slug> --match <attribute> <field=value> [field=value ...]"
+Example: /upsert-record contacts --match email name="Jane Doe" email="jane@example.com"
+
+The `--match` flag specifies the matching_attribute used to find existing records. If a record with the same value for that attribute exists, it will be updated; otherwise a new record is created.
+
+Parse the object slug, matching attribute, and field key=value pairs.
+Use the `mcp__nex__upsert_record` tool with object_slug, matching_attribute, and attributes.
+Report whether the record was created or updated.

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -11,7 +11,7 @@ const { version } = require("../package.json") as { version: string };
 export const program = new Command();
 
 program
-  .name("nex-ai")
+  .name("nex")
   .description("Nex CLI — command-line interface for the Nex Developer API")
   .version(version)
   .option("--api-key <key>", "Override API key (env: NEX_API_KEY)")

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -11,7 +11,7 @@ const { version } = require("../package.json") as { version: string };
 export const program = new Command();
 
 program
-  .name("nex")
+  .name("nex-ai")
   .description("Nex CLI — command-line interface for the Nex Developer API")
   .version(version)
   .option("--api-key <key>", "Override API key (env: NEX_API_KEY)")

--- a/cli/src/commands/integrate.ts
+++ b/cli/src/commands/integrate.ts
@@ -2,10 +2,11 @@
  * Integration commands: list, connect, disconnect.
  */
 
-import { execSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import { program } from "../cli.js";
 import { NexClient } from "../lib/client.js";
 import { resolveApiKey, resolveFormat, resolveTimeout } from "../lib/config.js";
+import { AuthError, ServerError } from "../lib/errors.js";
 import { printOutput, printError } from "../lib/output.js";
 import type { Format } from "../lib/output.js";
 
@@ -44,16 +45,24 @@ integrate
       throw new Error("No auth URL returned from API");
     }
 
-    // Open browser — URL is from our own API, not user input
+    // Open browser using spawn (no shell interpolation — safe from injection)
     const url = result.auth_url;
     try {
+      let cmd: string;
+      let args: string[];
       if (process.platform === "darwin") {
-        execSync(`open ${JSON.stringify(url)}`, { stdio: "ignore" });
+        cmd = "open";
+        args = [url];
       } else if (process.platform === "linux") {
-        execSync(`xdg-open ${JSON.stringify(url)}`, { stdio: "ignore" });
+        cmd = "xdg-open";
+        args = [url];
       } else if (process.platform === "win32") {
-        execSync(`start "" ${JSON.stringify(url)}`, { stdio: "ignore" });
+        cmd = "cmd";
+        args = ["/c", "start", "", url];
+      } else {
+        throw new Error("Unsupported platform");
       }
+      spawn(cmd, args, { stdio: "ignore", detached: true }).unref();
     } catch {
       process.stderr.write(`Open this URL in your browser:\n${url}\n\n`);
     }
@@ -80,6 +89,9 @@ integrate
           return;
         }
       } catch (err) {
+        // Fail fast on non-transient errors
+        if (err instanceof AuthError) throw err;
+        if (err instanceof ServerError && (err.status === 410 || err.status === 403)) throw err;
         // Continue polling on transient errors
         if (program.opts().debug) {
           process.stderr.write(`Poll error: ${err}\n`);

--- a/cli/src/commands/integrate.ts
+++ b/cli/src/commands/integrate.ts
@@ -65,8 +65,8 @@ integrate
     }
 
     lines.push("");
-    lines.push("Connect:     nex-ai integrate connect <type> <provider>");
-    lines.push("Disconnect:  nex-ai integrate disconnect <id>");
+    lines.push("Connect:     nex integrate connect <type> <provider>");
+    lines.push("Disconnect:  nex integrate disconnect <id>");
 
     process.stdout.write(lines.join("\n") + "\n");
   });
@@ -141,7 +141,7 @@ integrate
       }
     }
 
-    printError("Timed out waiting for OAuth completion. You can check status with 'nex-ai integrate list'.");
+    printError("Timed out waiting for OAuth completion. You can check status with 'nex integrate list'.");
     process.exit(1);
   });
 

--- a/cli/src/commands/integrate.ts
+++ b/cli/src/commands/integrate.ts
@@ -1,0 +1,103 @@
+/**
+ * Integration commands: list, connect, disconnect.
+ */
+
+import { execSync } from "node:child_process";
+import { program } from "../cli.js";
+import { NexClient } from "../lib/client.js";
+import { resolveApiKey, resolveFormat, resolveTimeout } from "../lib/config.js";
+import { printOutput, printError } from "../lib/output.js";
+import type { Format } from "../lib/output.js";
+
+function getClient(): { client: NexClient; format: Format } {
+  const opts = program.opts();
+  const client = new NexClient(resolveApiKey(opts.apiKey), resolveTimeout(opts.timeout));
+  return { client, format: resolveFormat(opts.format) as Format };
+}
+
+const integrate = program
+  .command("integrate")
+  .description("Manage third-party integrations (Gmail, Slack, Salesforce, etc.)");
+
+integrate
+  .command("list")
+  .description("List all available integrations and their connection status")
+  .action(async () => {
+    const { client, format } = getClient();
+    const result = await client.get("/v1/integrations/");
+    printOutput(result, format);
+  });
+
+integrate
+  .command("connect")
+  .description("Connect a third-party integration via OAuth")
+  .argument("<type>", "Integration type: email, calendar, crm, messaging")
+  .argument("<provider>", "Provider: google, microsoft, attio, slack, salesforce, hubspot")
+  .action(async (type: string, provider: string) => {
+    const { client, format } = getClient();
+
+    const result = await client.post<{ auth_url: string; connect_id: string }>(
+      `/v1/integrations/${encodeURIComponent(type)}/${encodeURIComponent(provider)}/connect`
+    );
+
+    if (!result.auth_url) {
+      throw new Error("No auth URL returned from API");
+    }
+
+    // Open browser — URL is from our own API, not user input
+    const url = result.auth_url;
+    try {
+      if (process.platform === "darwin") {
+        execSync(`open ${JSON.stringify(url)}`, { stdio: "ignore" });
+      } else if (process.platform === "linux") {
+        execSync(`xdg-open ${JSON.stringify(url)}`, { stdio: "ignore" });
+      } else if (process.platform === "win32") {
+        execSync(`start "" ${JSON.stringify(url)}`, { stdio: "ignore" });
+      }
+    } catch {
+      process.stderr.write(`Open this URL in your browser:\n${url}\n\n`);
+    }
+
+    process.stderr.write("Waiting for OAuth completion...\n");
+
+    // Poll for status
+    const connectId = result.connect_id;
+    const maxWaitMs = 5 * 60 * 1000; // 5 minutes
+    const pollIntervalMs = 2000;
+    const startTime = Date.now();
+
+    while (Date.now() - startTime < maxWaitMs) {
+      await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+
+      try {
+        const status = await client.get<{ status: string; connection_id?: number }>(
+          `/v1/integrations/connect/${encodeURIComponent(connectId)}/status`
+        );
+
+        if (status.status === "connected") {
+          process.stderr.write(`\nConnected successfully!\n`);
+          printOutput(status, format);
+          return;
+        }
+      } catch (err) {
+        // Continue polling on transient errors
+        if (program.opts().debug) {
+          process.stderr.write(`Poll error: ${err}\n`);
+        }
+      }
+    }
+
+    printError("Timed out waiting for OAuth completion. You can check status with 'nex integrate list'.");
+    process.exit(1);
+  });
+
+integrate
+  .command("disconnect")
+  .description("Disconnect an integration")
+  .argument("<connection_id>", "Connection ID to disconnect")
+  .action(async (connectionId: string) => {
+    const { client, format } = getClient();
+    const result = await client.delete(`/v1/integrations/connections/${encodeURIComponent(connectionId)}`);
+    printOutput(result, format);
+    process.stderr.write("Disconnected successfully.\n");
+  });

--- a/cli/src/commands/integrate.ts
+++ b/cli/src/commands/integrate.ts
@@ -10,6 +10,10 @@ import { AuthError, ServerError } from "../lib/errors.js";
 import { printOutput, printError } from "../lib/output.js";
 import type { Format } from "../lib/output.js";
 
+function padRight(str: string, len: number): string {
+  return str.length >= len ? str : str + " ".repeat(len - str.length);
+}
+
 function getClient(): { client: NexClient; format: Format } {
   const opts = program.opts();
   const client = new NexClient(resolveApiKey(opts.apiKey), resolveTimeout(opts.timeout));
@@ -25,8 +29,46 @@ integrate
   .description("List all available integrations and their connection status")
   .action(async () => {
     const { client, format } = getClient();
-    const result = await client.get("/v1/integrations/");
-    printOutput(result, format);
+    const result = await client.get<Record<string, unknown>[]>("/v1/integrations/");
+
+    if (format === "json") {
+      printOutput(result, "json");
+      return;
+    }
+
+    // Human-readable text output
+    if (!Array.isArray(result) || result.length === 0) {
+      process.stdout.write("No integrations available.\n");
+      return;
+    }
+
+    const lines: string[] = [];
+    lines.push("Integrations");
+    lines.push("\u2500".repeat(50));
+
+    for (const integration of result) {
+      const type = String(integration.type ?? "");
+      const provider = String(integration.provider ?? "");
+      const label = `${type} / ${provider}`;
+      const connections = integration.connections as Array<Record<string, unknown>> | undefined;
+
+      if (connections && connections.length > 0) {
+        for (const conn of connections) {
+          const displayName = conn.display_name ?? conn.email ?? "";
+          lines.push(
+            `${padRight(label, 25)} \u25CF connected     ${displayName}     (ID: ${conn.id})`
+          );
+        }
+      } else {
+        lines.push(`${padRight(label, 25)} \u25CB not connected`);
+      }
+    }
+
+    lines.push("");
+    lines.push("Connect:     nex-ai integrate connect <type> <provider>");
+    lines.push("Disconnect:  nex-ai integrate disconnect <id>");
+
+    process.stdout.write(lines.join("\n") + "\n");
   });
 
 integrate
@@ -99,7 +141,7 @@ integrate
       }
     }
 
-    printError("Timed out waiting for OAuth completion. You can check status with 'nex integrate list'.");
+    printError("Timed out waiting for OAuth completion. You can check status with 'nex-ai integrate list'.");
     process.exit(1);
   });
 

--- a/cli/src/commands/register.ts
+++ b/cli/src/commands/register.ts
@@ -11,7 +11,7 @@ import { resolveFormat } from "../lib/config.js";
 
 program
   .command("register")
-  .description("Register a new Nex developer account")
+  .description("Register a new Nex workspace and get an API key")
   .requiredOption("--email <email>", "Email address")
   .option("--name <name>", "Your name")
   .option("--company <company>", "Company name")

--- a/cli/src/commands/scan.ts
+++ b/cli/src/commands/scan.ts
@@ -34,7 +34,7 @@ program
       const format = resolveFormat(globalOpts.format) as Format;
 
       if (!opts.dryRun && !apiKey) {
-        printError("No API key. Run 'nex-ai register --email <email>' first or set NEX_API_KEY.");
+        printError("No API key. Run 'nex register --email <email>' first or set NEX_API_KEY.");
         process.exit(2);
       }
 

--- a/cli/src/commands/scan.ts
+++ b/cli/src/commands/scan.ts
@@ -34,7 +34,7 @@ program
       const format = resolveFormat(globalOpts.format) as Format;
 
       if (!opts.dryRun && !apiKey) {
-        printError("No API key. Run 'nex register --email <email>' first or set NEX_API_KEY.");
+        printError("No API key. Run 'nex-ai register --email <email>' first or set NEX_API_KEY.");
         process.exit(2);
       }
 

--- a/cli/src/commands/setup.ts
+++ b/cli/src/commands/setup.ts
@@ -70,7 +70,7 @@ async function showStatus(format: Format): Promise<void> {
   if (apiKey) {
     lines.push(`Auth: Configured (${maskKey(apiKey)})`);
   } else {
-    lines.push("Auth: Not configured — run `nex-ai register` first");
+    lines.push("Auth: Not configured — run `nex register` first");
   }
   lines.push("");
 
@@ -120,7 +120,7 @@ async function showStatus(format: Format): Promise<void> {
               lines.push(`  ${padRight(label, 25)} \u25CF connected     ${displayName}     (ID: ${conn.id})`);
             }
           } else {
-            lines.push(`  ${padRight(label, 25)} \u25CB not connected \u2192 nex-ai integrate connect ${type} ${provider}`);
+            lines.push(`  ${padRight(label, 25)} \u25CB not connected \u2192 nex integrate connect ${type} ${provider}`);
           }
         }
       }
@@ -145,7 +145,7 @@ async function runSetup(opts: {
 
   // 1. Check auth
   if (!apiKey) {
-    printError("No API key found. Run `nex-ai register` first to create an account.");
+    printError("No API key found. Run `nex register` first to create an account.");
     process.exit(2);
   }
 

--- a/cli/src/commands/setup.ts
+++ b/cli/src/commands/setup.ts
@@ -1,10 +1,11 @@
 /**
  * `nex setup` command — detect platforms, install plugin/MCP, create .nex.toml.
  *
- * nex setup                     Interactive: detect → install plugin + config
+ * nex setup                     Interactive: detect → install plugin + scan files + config
  * nex setup --platform <name>   Direct install for specific platform
  * nex setup --with-mcp          Also install MCP server
  * nex setup --no-plugin         Skip hooks/commands, only config files
+ * nex setup --no-scan           Skip file scanning during setup
  * nex setup status              Show install status + integration connections
  */
 
@@ -20,6 +21,7 @@ import { detectPlatforms, getPlatformById, VALID_PLATFORM_IDS } from "../lib/pla
 import type { Platform } from "../lib/platform-detect.js";
 import { installMcpServer, installClaudeCodePlugin, syncApiKeyToMcpConfig } from "../lib/installers.js";
 import { writeDefaultProjectConfig } from "../lib/project-config.js";
+import { scanFiles, loadScanConfig, isScanEnabled } from "../lib/file-scanner.js";
 
 function getClient(): { client: NexClient; format: Format } {
   const opts = program.opts();
@@ -139,6 +141,7 @@ async function runSetup(opts: {
   platform?: string;
   withMcp: boolean;
   noPlugin: boolean;
+  noScan: boolean;
   format: Format;
 }): Promise<void> {
   const globalOpts = program.opts();
@@ -150,8 +153,23 @@ async function runSetup(opts: {
     const wantsRegister = await confirm("Register a new Nex workspace?");
 
     if (!wantsRegister) {
-      printError("Setup requires an API key. Run `nex register --email <email>` or set NEX_API_KEY.");
-      process.exit(2);
+      process.stderr.write("\nSetup complete, but no API key configured.\n\n");
+      process.stderr.write("To use Nex, set your API key in one of these locations:\n");
+      process.stderr.write('  1. Environment variable: export NEX_API_KEY="sk-..."\n');
+      process.stderr.write('  2. Global config:        ~/.nex-mcp.json  → {"api_key": "sk-..."}\n');
+      process.stderr.write('  3. Project config:       .nex.toml        → [auth] api_key = "sk-..."\n');
+      process.stderr.write("\nGet an API key: nex register --email you@company.com\n\n");
+
+      // Still install plugin hooks/commands (they'll gracefully degrade without a key)
+      const platforms = detectPlatforms().filter((p) => p.detected);
+      for (const platform of platforms) {
+        if (platform.id === "claude-code" && !opts.noPlugin) {
+          installClaudeCodePlugin();
+        }
+      }
+
+      writeDefaultProjectConfig();
+      return;
     }
 
     const email = await ask("Email (required):", true);
@@ -204,11 +222,11 @@ async function runSetup(opts: {
         } else {
           results.push("Claude Code: hooks already configured");
         }
-        if (result.commandsLinked.length > 0) {
-          results.push(`Claude Code: commands linked (${result.commandsLinked.join(", ")})`);
+        if (result.commandsCopied.length > 0) {
+          results.push(`Claude Code: commands installed (${result.commandsCopied.join(", ")})`);
         }
       } else {
-        results.push("Claude Code: plugin directory not found — install @nex-crm/claude-code-nex-plugin");
+        results.push("Claude Code: bundled plugin not found — reinstall @nex-ai/nex");
       }
     }
 
@@ -239,7 +257,30 @@ async function runSetup(opts: {
     results.push(".nex.toml already exists");
   }
 
-  // 6. Output results
+  // 6. Scan and ingest project files (requires API key)
+  if (!opts.noScan && apiKey && isScanEnabled()) {
+    if (opts.format !== "json") {
+      process.stderr.write("\nScanning project files...\n");
+    }
+    const scanOpts = loadScanConfig();
+    const client = new NexClient(apiKey, resolveTimeout(globalOpts.timeout));
+    try {
+      const scanResult = await scanFiles(process.cwd(), scanOpts, async (content, context) => {
+        return client.post("/v1/context/text", { content, context });
+      });
+      if (scanResult.scanned > 0) {
+        results.push(`File scan: ${scanResult.scanned} files ingested, ${scanResult.skipped} skipped, ${scanResult.errors} errors`);
+      } else if (scanResult.skipped > 0) {
+        results.push(`File scan: all ${scanResult.skipped} files already up to date`);
+      } else {
+        results.push("File scan: no eligible files found in current directory");
+      }
+    } catch (err) {
+      results.push(`File scan: failed — ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  // 7. Output results
   if (opts.format === "json") {
     printOutput({
       platforms: targetPlatforms.map((p) => ({
@@ -257,7 +298,7 @@ async function runSetup(opts: {
     process.stderr.write("\n");
   }
 
-  // 7. Show status
+  // 8. Show status
   if (opts.format !== "json") {
     await showStatus(opts.format);
   }
@@ -286,13 +327,15 @@ const setup = program
   .option("--platform <name>", `Target platform: ${VALID_PLATFORM_IDS.join(", ")}`)
   .option("--with-mcp", "Also install MCP server for detected platforms", false)
   .option("--no-plugin", "Skip plugin (hooks/commands), only update config files")
+  .option("--no-scan", "Skip file scanning during setup")
   .action(async (cmdOpts) => {
     const globalOpts = program.opts();
     const format = resolveFormat(globalOpts.format) as Format;
     await runSetup({
       platform: cmdOpts.platform,
       withMcp: cmdOpts.withMcp,
-      noPlugin: cmdOpts.noPlugin ?? false,
+      noPlugin: cmdOpts.plugin === false,
+      noScan: cmdOpts.scan === false,
       format,
     });
   });

--- a/cli/src/commands/setup.ts
+++ b/cli/src/commands/setup.ts
@@ -181,7 +181,10 @@ async function runSetup(opts: {
     persistRegistration(data);
     apiKey = data.api_key as string;
 
-    process.stderr.write(`\n  ✓ Workspace created! API key: ${maskKey(apiKey)}\n`);
+    const wsSlug = data.workspace_slug as string | undefined;
+    process.stderr.write(`\n  ✓ Workspace created!${wsSlug ? ` (${wsSlug})` : ""}\n`);
+    process.stderr.write(`    API key: ${apiKey}\n`);
+    process.stderr.write(`    Saved to: ~/.nex-mcp.json\n`);
   }
 
   // 2. Sync API key to shared config

--- a/cli/src/commands/setup.ts
+++ b/cli/src/commands/setup.ts
@@ -11,9 +11,10 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { program } from "../cli.js";
-import { resolveApiKey, resolveFormat, resolveTimeout } from "../lib/config.js";
+import { resolveApiKey, resolveFormat, resolveTimeout, persistRegistration } from "../lib/config.js";
 import { NexClient } from "../lib/client.js";
 import { printOutput, printError } from "../lib/output.js";
+import { confirm, ask } from "../lib/prompt.js";
 import type { Format } from "../lib/output.js";
 import { detectPlatforms, getPlatformById, VALID_PLATFORM_IDS } from "../lib/platform-detect.js";
 import type { Platform } from "../lib/platform-detect.js";
@@ -141,12 +142,28 @@ async function runSetup(opts: {
   format: Format;
 }): Promise<void> {
   const globalOpts = program.opts();
-  const apiKey = resolveApiKey(globalOpts.apiKey);
+  let apiKey = resolveApiKey(globalOpts.apiKey);
 
-  // 1. Check auth
+  // 1. Register if no API key
   if (!apiKey) {
-    printError("No API key found. Run `nex register` first to create an account.");
-    process.exit(2);
+    process.stderr.write("\nNo API key found. Let's set up your Nex account.\n\n");
+    const wantsRegister = await confirm("Register a new Nex workspace?");
+
+    if (!wantsRegister) {
+      printError("Setup requires an API key. Run `nex register --email <email>` or set NEX_API_KEY.");
+      process.exit(2);
+    }
+
+    const email = await ask("Email (required):", true);
+    const name = await ask("Name (optional):");
+
+    process.stderr.write("\nRegistering...\n");
+    const client = new NexClient(undefined, resolveTimeout(globalOpts.timeout));
+    const data = await client.register(email, name || undefined);
+    persistRegistration(data);
+    apiKey = data.api_key as string;
+
+    process.stderr.write(`\n  ✓ Workspace created! API key: ${maskKey(apiKey)}\n`);
   }
 
   // 2. Sync API key to shared config

--- a/cli/src/commands/setup.ts
+++ b/cli/src/commands/setup.ts
@@ -1,0 +1,290 @@
+/**
+ * `nex setup` command — detect platforms, install plugin/MCP, create .nex.toml.
+ *
+ * nex setup                     Interactive: detect → install plugin + config
+ * nex setup --platform <name>   Direct install for specific platform
+ * nex setup --with-mcp          Also install MCP server
+ * nex setup --no-plugin         Skip hooks/commands, only config files
+ * nex setup status              Show install status + integration connections
+ */
+
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { program } from "../cli.js";
+import { resolveApiKey, resolveFormat, resolveTimeout } from "../lib/config.js";
+import { NexClient } from "../lib/client.js";
+import { printOutput, printError } from "../lib/output.js";
+import type { Format } from "../lib/output.js";
+import { detectPlatforms, getPlatformById, VALID_PLATFORM_IDS } from "../lib/platform-detect.js";
+import type { Platform } from "../lib/platform-detect.js";
+import { installMcpServer, installClaudeCodePlugin, syncApiKeyToMcpConfig } from "../lib/installers.js";
+import { writeDefaultProjectConfig } from "../lib/project-config.js";
+
+function getClient(): { client: NexClient; format: Format } {
+  const opts = program.opts();
+  const client = new NexClient(resolveApiKey(opts.apiKey), resolveTimeout(opts.timeout));
+  return { client, format: resolveFormat(opts.format) as Format };
+}
+
+// --- Status subcommand ---
+
+async function showStatus(format: Format): Promise<void> {
+  const opts = program.opts();
+  const apiKey = resolveApiKey(opts.apiKey);
+  const platforms = detectPlatforms();
+
+  if (format === "json") {
+    const data: Record<string, unknown> = {
+      auth: apiKey ? { configured: true, key_preview: maskKey(apiKey) } : { configured: false },
+      platforms: platforms.map((p) => ({
+        id: p.id,
+        name: p.displayName,
+        detected: p.detected,
+        nex_installed: p.nexInstalled,
+        plugin_support: p.pluginSupport,
+      })),
+      project_config: projectConfigExists(),
+    };
+
+    // Fetch integrations if authenticated
+    if (apiKey) {
+      try {
+        const client = new NexClient(apiKey, resolveTimeout(opts.timeout));
+        data.integrations = await client.get("/v1/integrations/");
+      } catch {
+        data.integrations = null;
+      }
+    }
+
+    printOutput(data, "json");
+    return;
+  }
+
+  // Text format
+  const lines: string[] = [];
+  lines.push("Nex Setup Status");
+  lines.push("================");
+  lines.push("");
+
+  // Auth
+  if (apiKey) {
+    lines.push(`Auth: Configured (${maskKey(apiKey)})`);
+  } else {
+    lines.push("Auth: Not configured — run `nex-ai register` first");
+  }
+  lines.push("");
+
+  // Platforms
+  lines.push("Platforms:");
+  for (const p of platforms) {
+    if (!p.detected) {
+      lines.push(`  ${padRight(p.displayName, 20)} Not found`);
+      continue;
+    }
+
+    const parts = [`  ${padRight(p.displayName, 20)} Detected`];
+
+    if (p.pluginSupport) {
+      parts.push(`   Plugin: ${p.nexInstalled ? "installed" : "not installed"}`);
+    }
+
+    // MCP status
+    if (p.id !== "claude-code") {
+      parts.push(`   MCP: ${p.nexInstalled ? "installed" : "not installed"}`);
+    }
+
+    lines.push(parts.join(""));
+  }
+  lines.push("");
+
+  // Project config
+  lines.push(`Project Config: ${projectConfigExists() ? ".nex.toml found" : ".nex.toml not found"}`);
+  lines.push("");
+
+  // Integrations
+  if (apiKey) {
+    try {
+      const client = new NexClient(apiKey, resolveTimeout(opts.timeout));
+      const integrations = await client.get<Record<string, unknown>[]>("/v1/integrations/");
+      if (Array.isArray(integrations) && integrations.length > 0) {
+        lines.push("Connections:");
+        for (const integration of integrations) {
+          const type = String(integration.type ?? "");
+          const provider = String(integration.provider ?? "");
+          const label = `${type} / ${provider}`;
+          const connections = integration.connections as Array<Record<string, unknown>> | undefined;
+
+          if (connections && connections.length > 0) {
+            for (const conn of connections) {
+              const displayName = conn.display_name ?? conn.email ?? "";
+              lines.push(`  ${padRight(label, 25)} \u25CF connected     ${displayName}     (ID: ${conn.id})`);
+            }
+          } else {
+            lines.push(`  ${padRight(label, 25)} \u25CB not connected \u2192 nex-ai integrate connect ${type} ${provider}`);
+          }
+        }
+      }
+    } catch {
+      lines.push("Connections: Could not fetch (check auth)");
+    }
+  }
+
+  process.stdout.write(lines.join("\n") + "\n");
+}
+
+// --- Main setup flow ---
+
+async function runSetup(opts: {
+  platform?: string;
+  withMcp: boolean;
+  noPlugin: boolean;
+  format: Format;
+}): Promise<void> {
+  const globalOpts = program.opts();
+  const apiKey = resolveApiKey(globalOpts.apiKey);
+
+  // 1. Check auth
+  if (!apiKey) {
+    printError("No API key found. Run `nex-ai register` first to create an account.");
+    process.exit(2);
+  }
+
+  // 2. Sync API key to shared config
+  syncApiKeyToMcpConfig(apiKey);
+
+  // 3. Detect or select platforms
+  let targetPlatforms: Platform[];
+
+  if (opts.platform) {
+    const p = getPlatformById(opts.platform);
+    if (!p) {
+      printError(
+        `Unknown platform "${opts.platform}". Valid: ${VALID_PLATFORM_IDS.join(", ")}`
+      );
+      process.exit(1);
+    }
+    targetPlatforms = [p];
+  } else {
+    targetPlatforms = detectPlatforms().filter((p) => p.detected);
+
+    if (targetPlatforms.length === 0) {
+      process.stderr.write("No supported platforms detected.\n");
+      process.stderr.write(`Supported: ${VALID_PLATFORM_IDS.join(", ")}\n`);
+      process.stderr.write("Use --platform <name> to install manually.\n");
+    }
+  }
+
+  const results: string[] = [];
+
+  // 4. Install for each platform
+  for (const platform of targetPlatforms) {
+    // Claude Code — install plugin (hooks + commands) unless --no-plugin
+    if (platform.id === "claude-code" && !opts.noPlugin) {
+      const result = installClaudeCodePlugin();
+      if (result.installed) {
+        if (result.hooksAdded.length > 0) {
+          results.push(`Claude Code: hooks installed (${result.hooksAdded.join(", ")})`);
+        } else {
+          results.push("Claude Code: hooks already configured");
+        }
+        if (result.commandsLinked.length > 0) {
+          results.push(`Claude Code: commands linked (${result.commandsLinked.join(", ")})`);
+        }
+      } else {
+        results.push("Claude Code: plugin directory not found — install @nex-crm/claude-code-nex-plugin");
+      }
+    }
+
+    // MCP server — only with --with-mcp
+    if (opts.withMcp && platform.id !== "claude-code") {
+      const result = installMcpServer(platform, apiKey);
+      if (result.installed) {
+        results.push(`${platform.displayName}: MCP server configured at ${result.configPath}`);
+      }
+    } else if (platform.id !== "claude-code" && !opts.withMcp) {
+      results.push(`${platform.displayName}: detected — use --with-mcp to install MCP server`);
+    }
+
+    // Claude Code MCP — also with --with-mcp
+    if (opts.withMcp && platform.id === "claude-code") {
+      const result = installMcpServer(platform, apiKey);
+      if (result.installed) {
+        results.push(`Claude Code: MCP server configured`);
+      }
+    }
+  }
+
+  // 5. Create .nex.toml
+  const created = writeDefaultProjectConfig();
+  if (created) {
+    results.push("Created .nex.toml with default settings");
+  } else {
+    results.push(".nex.toml already exists");
+  }
+
+  // 6. Output results
+  if (opts.format === "json") {
+    printOutput({
+      platforms: targetPlatforms.map((p) => ({
+        id: p.id,
+        name: p.displayName,
+        detected: p.detected,
+      })),
+      results,
+    }, "json");
+  } else {
+    process.stderr.write("\n");
+    for (const r of results) {
+      process.stderr.write(`  \u2713 ${r}\n`);
+    }
+    process.stderr.write("\n");
+  }
+
+  // 7. Show status
+  if (opts.format !== "json") {
+    await showStatus(opts.format);
+  }
+}
+
+// --- Helpers ---
+
+function maskKey(key: string): string {
+  if (key.length <= 8) return "****";
+  return key.slice(0, 4) + "****" + key.slice(-4);
+}
+
+function padRight(str: string, len: number): string {
+  return str.length >= len ? str : str + " ".repeat(len - str.length);
+}
+
+function projectConfigExists(): boolean {
+  return existsSync(join(process.cwd(), ".nex.toml"));
+}
+
+// --- Command registration ---
+
+const setup = program
+  .command("setup")
+  .description("Set up Nex integration for your development environment")
+  .option("--platform <name>", `Target platform: ${VALID_PLATFORM_IDS.join(", ")}`)
+  .option("--with-mcp", "Also install MCP server for detected platforms", false)
+  .option("--no-plugin", "Skip plugin (hooks/commands), only update config files")
+  .action(async (cmdOpts) => {
+    const globalOpts = program.opts();
+    const format = resolveFormat(globalOpts.format) as Format;
+    await runSetup({
+      platform: cmdOpts.platform,
+      withMcp: cmdOpts.withMcp,
+      noPlugin: cmdOpts.noPlugin ?? false,
+      format,
+    });
+  });
+
+setup
+  .command("status")
+  .description("Show Nex installation status across all platforms")
+  .action(async () => {
+    const globalOpts = program.opts();
+    const format = resolveFormat(globalOpts.format) as Format;
+    await showStatus(format);
+  });

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -24,6 +24,7 @@ import "./commands/task.js";
 import "./commands/note.js";
 import "./commands/session.js";
 import "./commands/scan.js";
+import "./commands/integrate.js";
 
 /**
  * Read all data from stdin (non-TTY only).

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -25,6 +25,7 @@ import "./commands/note.js";
 import "./commands/session.js";
 import "./commands/scan.js";
 import "./commands/integrate.js";
+import "./commands/setup.js";
 
 /**
  * Read all data from stdin (non-TTY only).

--- a/cli/src/lib/errors.ts
+++ b/cli/src/lib/errors.ts
@@ -6,7 +6,7 @@
 export class AuthError extends Error {
   public exitCode = 2;
 
-  constructor(message = "No API key configured. Run 'nex-ai register' or set NEX_API_KEY.") {
+  constructor(message = "No API key configured. Run 'nex register' or set NEX_API_KEY.") {
     super(message);
     this.name = "AuthError";
   }

--- a/cli/src/lib/errors.ts
+++ b/cli/src/lib/errors.ts
@@ -6,7 +6,7 @@
 export class AuthError extends Error {
   public exitCode = 2;
 
-  constructor(message = "No API key configured. Run 'nex register' or set NEX_API_KEY.") {
+  constructor(message = "No API key configured. Run 'nex-ai register' or set NEX_API_KEY.") {
     super(message);
     this.name = "AuthError";
   }

--- a/cli/src/lib/installers.ts
+++ b/cli/src/lib/installers.ts
@@ -7,11 +7,10 @@
  * - Continue.dev writes YAML config
  */
 
-import { readFileSync, writeFileSync, mkdirSync, existsSync, symlinkSync, readdirSync } from "node:fs";
-import { join, dirname, resolve } from "node:path";
+import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync, unlinkSync, copyFileSync } from "node:fs";
+import { join, dirname } from "node:path";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
-import { execFileSync } from "node:child_process";
 import type { Platform } from "./platform-detect.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -126,19 +125,38 @@ interface SettingsJson {
   [key: string]: unknown;
 }
 
-export function installClaudeCodePlugin(pluginDir?: string): {
+/**
+ * Resolve bundled plugin paths.
+ * Plugin source is compiled into dist/plugin/ alongside the CLI.
+ * Slash commands are at plugin-commands/ in the package root.
+ *
+ * From dist/lib/installers.js:
+ *   __dirname = <pkg>/dist/lib/
+ *   dist/plugin/ = __dirname/../plugin/
+ *   plugin-commands/ = __dirname/../../plugin-commands/
+ */
+function getPluginDistDir(): string {
+  return join(__dirname, "..", "plugin");
+}
+
+function getPluginCommandsDir(): string {
+  return join(__dirname, "..", "..", "plugin-commands");
+}
+
+export function installClaudeCodePlugin(): {
   installed: boolean;
   hooksAdded: string[];
-  commandsLinked: string[];
+  commandsCopied: string[];
 } {
   const home = homedir();
   const claudeDir = join(home, ".claude");
   const settingsPath = join(claudeDir, "settings.json");
 
-  // Resolve plugin directory — find it relative to the CLI package
-  const resolvedPluginDir = pluginDir ?? findPluginDir();
-  if (!resolvedPluginDir) {
-    return { installed: false, hooksAdded: [], commandsLinked: [] };
+  const distDir = getPluginDistDir();
+
+  // Verify bundled plugin exists
+  if (!existsSync(join(distDir, "auto-recall.js"))) {
+    return { installed: false, hooksAdded: [], commandsCopied: [] };
   }
 
   // 1. Read existing settings.json
@@ -155,9 +173,8 @@ export function installClaudeCodePlugin(pluginDir?: string): {
   }
 
   const hooksAdded: string[] = [];
-  const distDir = join(resolvedPluginDir, "dist");
 
-  // 2. Add hooks (idempotent — check if nex hooks already exist)
+  // 2. Add hooks (idempotent — remove stale nex hooks, then add fresh ones)
   const hookDefs: Array<{
     event: string;
     script: string;
@@ -191,32 +208,33 @@ export function installClaudeCodePlugin(pluginDir?: string): {
     }
 
     const groups = settings.hooks![def.event];
-    const alreadyInstalled = groups.some((g) =>
-      g.hooks.some((h) => h.command.includes("nex") || h.command.includes("auto-recall") || h.command.includes("auto-capture") || h.command.includes("auto-session-start"))
+
+    // Remove any existing nex hook entries (handles path updates on upgrade)
+    const filtered = groups.filter((g) =>
+      !g.hooks.some((h) => h.command.includes("auto-recall") || h.command.includes("auto-capture") || h.command.includes("auto-session-start"))
     );
 
-    if (!alreadyInstalled) {
-      const hookEntry: HookEntry = {
-        type: "command",
-        command: `node ${def.script}`,
-        timeout: def.timeout,
-      };
-      if (def.statusMessage) hookEntry.statusMessage = def.statusMessage;
-      if (def.async) hookEntry.async = true;
+    const hookEntry: HookEntry = {
+      type: "command",
+      command: `node ${def.script}`,
+      timeout: def.timeout,
+    };
+    if (def.statusMessage) hookEntry.statusMessage = def.statusMessage;
+    if (def.async) hookEntry.async = true;
 
-      groups.push({ matcher: "", hooks: [hookEntry] });
-      hooksAdded.push(def.event);
-    }
+    filtered.push({ matcher: "", hooks: [hookEntry] });
+    settings.hooks![def.event] = filtered;
+    hooksAdded.push(def.event);
   }
 
   // 3. Write settings.json
   mkdirSync(claudeDir, { recursive: true });
   writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n", "utf-8");
 
-  // 4. Symlink slash commands
-  const commandsLinked: string[] = [];
+  // 4. Copy slash commands (copy, not symlink — survives npm updates)
+  const commandsCopied: string[] = [];
   const commandsDir = join(claudeDir, "commands");
-  const sourceCommandsDir = join(resolvedPluginDir, "commands");
+  const sourceCommandsDir = getPluginCommandsDir();
 
   if (existsSync(sourceCommandsDir)) {
     mkdirSync(commandsDir, { recursive: true });
@@ -228,13 +246,18 @@ export function installClaudeCodePlugin(pluginDir?: string): {
         const target = join(commandsDir, entry);
         const source = join(sourceCommandsDir, entry);
 
-        if (!existsSync(target)) {
-          try {
-            symlinkSync(source, target, "file");
-            commandsLinked.push(entry);
-          } catch {
-            // May fail if file already exists as regular file — skip
-          }
+        // Remove stale symlink or existing file, then copy fresh
+        try {
+          unlinkSync(target);
+        } catch {
+          // File didn't exist — fine
+        }
+
+        try {
+          copyFileSync(source, target);
+          commandsCopied.push(entry);
+        } catch {
+          // Copy failed — non-critical
         }
       }
     } catch {
@@ -242,38 +265,7 @@ export function installClaudeCodePlugin(pluginDir?: string): {
     }
   }
 
-  return { installed: true, hooksAdded, commandsLinked };
-}
-
-/**
- * Find the claude-code-plugin directory relative to the CLI install.
- * Looks for it as a sibling package in the monorepo or as a globally installed npm package.
- */
-function findPluginDir(): string | undefined {
-  // Try common locations
-  const candidates = [
-    // Sibling in monorepo (from dist/lib/ → ../../.. = repo root → claude-code-plugin)
-    resolve(__dirname, "..", "..", "..", "claude-code-plugin"),
-    // Relative to cli package root (from dist/lib/ → ../.. = cli root → claude-code-plugin)
-    resolve(__dirname, "..", "..", "claude-code-plugin"),
-  ];
-
-  // Also check npm global node_modules for the published plugin package
-  try {
-    const globalPrefix = execFileSync("npm", ["prefix", "-g"], { encoding: "utf-8" }).trim();
-    candidates.push(join(globalPrefix, "lib", "node_modules", "@nex-crm", "claude-code-nex-plugin"));
-    candidates.push(join(globalPrefix, "lib", "node_modules", "@nex-ai", "claude-code-plugin"));
-  } catch {
-    // npm not available — skip
-  }
-
-  for (const candidate of candidates) {
-    if (existsSync(join(candidate, "package.json"))) {
-      return candidate;
-    }
-  }
-
-  return undefined;
+  return { installed: true, hooksAdded, commandsCopied };
 }
 
 // --- Sync API key to ~/.nex-mcp.json ---

--- a/cli/src/lib/installers.ts
+++ b/cli/src/lib/installers.ts
@@ -11,6 +11,7 @@ import { readFileSync, writeFileSync, mkdirSync, existsSync, symlinkSync, readdi
 import { join, dirname, resolve } from "node:path";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
+import { execFileSync } from "node:child_process";
 import type { Platform } from "./platform-detect.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -246,18 +247,25 @@ export function installClaudeCodePlugin(pluginDir?: string): {
 
 /**
  * Find the claude-code-plugin directory relative to the CLI install.
- * Looks for it as a sibling package in the monorepo.
+ * Looks for it as a sibling package in the monorepo or as a globally installed npm package.
  */
 function findPluginDir(): string | undefined {
   // Try common locations
   const candidates = [
-    // Sibling in monorepo (development)
+    // Sibling in monorepo (from dist/lib/ → ../../.. = repo root → claude-code-plugin)
     resolve(__dirname, "..", "..", "..", "claude-code-plugin"),
-    // npm global install (node_modules sibling)
-    resolve(__dirname, "..", "..", "..", "..", "@nex-crm", "claude-code-nex-plugin"),
-    // Relative to cli package
+    // Relative to cli package root (from dist/lib/ → ../.. = cli root → claude-code-plugin)
     resolve(__dirname, "..", "..", "claude-code-plugin"),
   ];
+
+  // Also check npm global node_modules for the published plugin package
+  try {
+    const globalPrefix = execFileSync("npm", ["prefix", "-g"], { encoding: "utf-8" }).trim();
+    candidates.push(join(globalPrefix, "lib", "node_modules", "@nex-crm", "claude-code-nex-plugin"));
+    candidates.push(join(globalPrefix, "lib", "node_modules", "@nex-ai", "claude-code-plugin"));
+  } catch {
+    // npm not available — skip
+  }
 
   for (const candidate of candidates) {
     if (existsSync(join(candidate, "package.json"))) {

--- a/cli/src/lib/installers.ts
+++ b/cli/src/lib/installers.ts
@@ -1,0 +1,278 @@
+/**
+ * Platform-specific installers for Nex MCP server and Claude Code plugin.
+ *
+ * - Generic MCP installer handles 9/12 platforms (same JSON mcpServers format)
+ * - Claude Code installer handles hooks + slash commands
+ * - Zed installer uses context_servers instead of mcpServers
+ * - Continue.dev writes YAML config
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync, symlinkSync, readdirSync } from "node:fs";
+import { join, dirname, resolve } from "node:path";
+import { homedir } from "node:os";
+import { fileURLToPath } from "node:url";
+import type { Platform } from "./platform-detect.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const MCP_SERVER_ENTRY = {
+  command: "npx",
+  args: ["-y", "@nex-crm/mcp-server"],
+  env: {} as Record<string, string>,
+};
+
+// --- Generic MCP Installer ---
+
+function readJsonFile(path: string): Record<string, unknown> {
+  try {
+    const raw = readFileSync(path, "utf-8");
+    return JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+function writeJsonFile(path: string, data: Record<string, unknown>): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(data, null, 2) + "\n", "utf-8");
+}
+
+export function installMcpServer(
+  platform: Platform,
+  apiKey: string,
+): { installed: boolean; configPath: string } {
+  const entry = {
+    ...MCP_SERVER_ENTRY,
+    env: { NEX_API_KEY: apiKey },
+  };
+
+  if (platform.configFormat === "zed") {
+    return installZedMcp(platform.configPath, entry);
+  }
+
+  if (platform.configFormat === "continue") {
+    return installContinueMcp(platform.configPath, apiKey);
+  }
+
+  // Standard JSON format (Cursor, Claude Desktop, VS Code, Windsurf, Cline, Kilo Code, OpenCode)
+  const config = readJsonFile(platform.configPath);
+
+  if (!config.mcpServers || typeof config.mcpServers !== "object") {
+    config.mcpServers = {};
+  }
+  (config.mcpServers as Record<string, unknown>).nex = entry;
+
+  writeJsonFile(platform.configPath, config);
+  return { installed: true, configPath: platform.configPath };
+}
+
+function installZedMcp(
+  configPath: string,
+  entry: typeof MCP_SERVER_ENTRY,
+): { installed: boolean; configPath: string } {
+  const config = readJsonFile(configPath);
+
+  if (!config.context_servers || typeof config.context_servers !== "object") {
+    config.context_servers = {};
+  }
+  (config.context_servers as Record<string, unknown>).nex = {
+    command: { path: entry.command, args: entry.args, env: entry.env },
+  };
+
+  writeJsonFile(configPath, config);
+  return { installed: true, configPath };
+}
+
+function installContinueMcp(
+  configPath: string,
+  apiKey: string,
+): { installed: boolean; configPath: string } {
+  // Continue.dev can also accept JSON in a separate mcpServers config
+  // Write a simple JSON file alongside the YAML
+  const mcpPath = configPath.replace("config.yaml", "mcp.json");
+  const config = readJsonFile(mcpPath);
+
+  if (!config.mcpServers || typeof config.mcpServers !== "object") {
+    config.mcpServers = {};
+  }
+  (config.mcpServers as Record<string, unknown>).nex = {
+    ...MCP_SERVER_ENTRY,
+    env: { NEX_API_KEY: apiKey },
+  };
+
+  writeJsonFile(mcpPath, config);
+  return { installed: true, configPath: mcpPath };
+}
+
+// --- Claude Code Plugin Installer ---
+
+interface HookEntry {
+  type: string;
+  command: string;
+  timeout: number;
+  statusMessage?: string;
+  async?: boolean;
+}
+
+interface HookGroup {
+  matcher: string;
+  hooks: HookEntry[];
+}
+
+interface SettingsJson {
+  hooks?: Record<string, HookGroup[]>;
+  [key: string]: unknown;
+}
+
+export function installClaudeCodePlugin(pluginDir?: string): {
+  installed: boolean;
+  hooksAdded: string[];
+  commandsLinked: string[];
+} {
+  const home = homedir();
+  const claudeDir = join(home, ".claude");
+  const settingsPath = join(claudeDir, "settings.json");
+
+  // Resolve plugin directory — find it relative to the CLI package
+  const resolvedPluginDir = pluginDir ?? findPluginDir();
+  if (!resolvedPluginDir) {
+    return { installed: false, hooksAdded: [], commandsLinked: [] };
+  }
+
+  // 1. Read existing settings.json
+  let settings: SettingsJson = {};
+  try {
+    const raw = readFileSync(settingsPath, "utf-8");
+    settings = JSON.parse(raw) as SettingsJson;
+  } catch {
+    // Start fresh
+  }
+
+  if (!settings.hooks) {
+    settings.hooks = {};
+  }
+
+  const hooksAdded: string[] = [];
+  const distDir = join(resolvedPluginDir, "dist");
+
+  // 2. Add hooks (idempotent — check if nex hooks already exist)
+  const hookDefs: Array<{
+    event: string;
+    script: string;
+    timeout: number;
+    statusMessage?: string;
+    async?: boolean;
+  }> = [
+    {
+      event: "SessionStart",
+      script: join(distDir, "auto-session-start.js"),
+      timeout: 120000,
+      statusMessage: "Loading knowledge context...",
+    },
+    {
+      event: "UserPromptSubmit",
+      script: join(distDir, "auto-recall.js"),
+      timeout: 10000,
+      statusMessage: "Recalling relevant memories...",
+    },
+    {
+      event: "Stop",
+      script: join(distDir, "auto-capture.js"),
+      timeout: 10000,
+      async: true,
+    },
+  ];
+
+  for (const def of hookDefs) {
+    if (!settings.hooks![def.event]) {
+      settings.hooks![def.event] = [];
+    }
+
+    const groups = settings.hooks![def.event];
+    const alreadyInstalled = groups.some((g) =>
+      g.hooks.some((h) => h.command.includes("nex") || h.command.includes("auto-recall") || h.command.includes("auto-capture") || h.command.includes("auto-session-start"))
+    );
+
+    if (!alreadyInstalled) {
+      const hookEntry: HookEntry = {
+        type: "command",
+        command: `node ${def.script}`,
+        timeout: def.timeout,
+      };
+      if (def.statusMessage) hookEntry.statusMessage = def.statusMessage;
+      if (def.async) hookEntry.async = true;
+
+      groups.push({ matcher: "", hooks: [hookEntry] });
+      hooksAdded.push(def.event);
+    }
+  }
+
+  // 3. Write settings.json
+  mkdirSync(claudeDir, { recursive: true });
+  writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n", "utf-8");
+
+  // 4. Symlink slash commands
+  const commandsLinked: string[] = [];
+  const commandsDir = join(claudeDir, "commands");
+  const sourceCommandsDir = join(resolvedPluginDir, "commands");
+
+  if (existsSync(sourceCommandsDir)) {
+    mkdirSync(commandsDir, { recursive: true });
+
+    try {
+      const entries = readdirSync(sourceCommandsDir);
+      for (const entry of entries) {
+        if (!entry.endsWith(".md")) continue;
+        const target = join(commandsDir, entry);
+        const source = join(sourceCommandsDir, entry);
+
+        if (!existsSync(target)) {
+          try {
+            symlinkSync(source, target, "file");
+            commandsLinked.push(entry);
+          } catch {
+            // May fail if file already exists as regular file — skip
+          }
+        }
+      }
+    } catch {
+      // Commands dir read failed — non-critical
+    }
+  }
+
+  return { installed: true, hooksAdded, commandsLinked };
+}
+
+/**
+ * Find the claude-code-plugin directory relative to the CLI install.
+ * Looks for it as a sibling package in the monorepo.
+ */
+function findPluginDir(): string | undefined {
+  // Try common locations
+  const candidates = [
+    // Sibling in monorepo (development)
+    resolve(__dirname, "..", "..", "..", "claude-code-plugin"),
+    // npm global install (node_modules sibling)
+    resolve(__dirname, "..", "..", "..", "..", "@nex-crm", "claude-code-nex-plugin"),
+    // Relative to cli package
+    resolve(__dirname, "..", "..", "claude-code-plugin"),
+  ];
+
+  for (const candidate of candidates) {
+    if (existsSync(join(candidate, "package.json"))) {
+      return candidate;
+    }
+  }
+
+  return undefined;
+}
+
+// --- Sync API key to ~/.nex-mcp.json ---
+
+export function syncApiKeyToMcpConfig(apiKey: string): void {
+  const mcpConfigPath = join(homedir(), ".nex-mcp.json");
+  const config = readJsonFile(mcpConfigPath);
+  config.api_key = apiKey;
+  writeJsonFile(mcpConfigPath, config);
+}

--- a/cli/src/lib/platform-detect.ts
+++ b/cli/src/lib/platform-detect.ts
@@ -1,0 +1,208 @@
+/**
+ * Detect installed AI coding platforms and check Nex installation status.
+ */
+
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { execFileSync } from "node:child_process";
+
+export interface Platform {
+  id: string;
+  displayName: string;
+  detected: boolean;
+  nexInstalled: boolean;
+  pluginSupport: boolean;
+  configPath: string;
+  configFormat: "standard" | "zed" | "continue";
+}
+
+const home = homedir();
+
+function exists(path: string): boolean {
+  return existsSync(path);
+}
+
+function whichExists(cmd: string): boolean {
+  try {
+    execFileSync("which", [cmd], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function hasNexMcpEntry(configPath: string, key = "nex"): boolean {
+  try {
+    const raw = readFileSync(configPath, "utf-8");
+    const config = JSON.parse(raw);
+    // Check mcpServers.nex or context_servers.nex
+    return !!(config?.mcpServers?.[key] || config?.context_servers?.[key]);
+  } catch {
+    return false;
+  }
+}
+
+function hasClaudeCodePlugin(): boolean {
+  const settingsPath = join(home, ".claude", "settings.json");
+  try {
+    const raw = readFileSync(settingsPath, "utf-8");
+    return raw.includes("nex") && raw.includes("auto-recall");
+  } catch {
+    return false;
+  }
+}
+
+function claudeDesktopConfigPath(): string {
+  if (process.platform === "darwin") {
+    return join(home, "Library", "Application Support", "Claude", "claude_desktop_config.json");
+  }
+  if (process.platform === "win32") {
+    return join(process.env.APPDATA ?? join(home, "AppData", "Roaming"), "Claude", "claude_desktop_config.json");
+  }
+  // Linux
+  return join(home, ".config", "Claude", "claude_desktop_config.json");
+}
+
+function hasClineExtension(): boolean {
+  const extensionsDir = join(home, ".vscode", "extensions");
+  try {
+    const entries = readdirSync(extensionsDir);
+    return entries.some((e) => e.startsWith("saoudrizwan.claude-dev-"));
+  } catch {
+    return false;
+  }
+}
+
+function clineConfigPath(): string {
+  // Cline stores MCP config in VS Code globalStorage
+  if (process.platform === "darwin") {
+    return join(home, "Library", "Application Support", "Code", "User", "globalStorage", "saoudrizwan.claude-dev", "settings", "cline_mcp_settings.json");
+  }
+  if (process.platform === "win32") {
+    return join(process.env.APPDATA ?? join(home, "AppData", "Roaming"), "Code", "User", "globalStorage", "saoudrizwan.claude-dev", "settings", "cline_mcp_settings.json");
+  }
+  return join(home, ".config", "Code", "User", "globalStorage", "saoudrizwan.claude-dev", "settings", "cline_mcp_settings.json");
+}
+
+export function detectPlatforms(): Platform[] {
+  const cwd = process.cwd();
+
+  const platforms: Platform[] = [
+    {
+      id: "claude-code",
+      displayName: "Claude Code",
+      detected: exists(join(home, ".claude")),
+      nexInstalled: hasClaudeCodePlugin(),
+      pluginSupport: true,
+      configPath: join(home, ".claude", "settings.json"),
+      configFormat: "standard",
+    },
+    {
+      id: "claude-desktop",
+      displayName: "Claude Desktop",
+      detected: exists(claudeDesktopConfigPath()),
+      nexInstalled: hasNexMcpEntry(claudeDesktopConfigPath()),
+      pluginSupport: false,
+      configPath: claudeDesktopConfigPath(),
+      configFormat: "standard",
+    },
+    {
+      id: "cursor",
+      displayName: "Cursor",
+      detected: exists(join(home, ".cursor")),
+      nexInstalled: hasNexMcpEntry(join(home, ".cursor", "mcp.json")),
+      pluginSupport: false,
+      configPath: join(home, ".cursor", "mcp.json"),
+      configFormat: "standard",
+    },
+    {
+      id: "vscode",
+      displayName: "VS Code",
+      detected: whichExists("code") || exists(join(cwd, ".vscode")),
+      nexInstalled: hasNexMcpEntry(join(cwd, ".vscode", "mcp.json")),
+      pluginSupport: false,
+      configPath: join(cwd, ".vscode", "mcp.json"),
+      configFormat: "standard",
+    },
+    {
+      id: "windsurf",
+      displayName: "Windsurf",
+      detected: exists(join(home, ".codeium", "windsurf")),
+      nexInstalled: hasNexMcpEntry(join(home, ".codeium", "windsurf", "mcp_config.json")),
+      pluginSupport: false,
+      configPath: join(home, ".codeium", "windsurf", "mcp_config.json"),
+      configFormat: "standard",
+    },
+    {
+      id: "cline",
+      displayName: "Cline",
+      detected: hasClineExtension(),
+      nexInstalled: hasNexMcpEntry(clineConfigPath()),
+      pluginSupport: false,
+      configPath: clineConfigPath(),
+      configFormat: "standard",
+    },
+    {
+      id: "zed",
+      displayName: "Zed",
+      detected: exists(join(home, ".config", "zed")),
+      nexInstalled: hasNexMcpEntry(join(home, ".config", "zed", "settings.json"), "nex"),
+      pluginSupport: false,
+      configPath: join(home, ".config", "zed", "settings.json"),
+      configFormat: "zed",
+    },
+    {
+      id: "continue",
+      displayName: "Continue.dev",
+      detected: exists(join(cwd, ".continue")) || exists(join(home, ".continue")),
+      nexInstalled: false, // YAML check would be complex — just report not installed
+      pluginSupport: false,
+      configPath: exists(join(cwd, ".continue"))
+        ? join(cwd, ".continue", "config.yaml")
+        : join(home, ".continue", "config.yaml"),
+      configFormat: "continue",
+    },
+    {
+      id: "kilocode",
+      displayName: "Kilo Code",
+      detected: exists(join(cwd, ".kilocode")),
+      nexInstalled: hasNexMcpEntry(join(cwd, ".kilocode", "mcp.json")),
+      pluginSupport: false,
+      configPath: join(cwd, ".kilocode", "mcp.json"),
+      configFormat: "standard",
+    },
+    {
+      id: "opencode",
+      displayName: "OpenCode",
+      detected: exists(join(home, ".config", "opencode")),
+      nexInstalled: hasNexMcpEntry(join(home, ".config", "opencode", "opencode.json")),
+      pluginSupport: false,
+      configPath: join(home, ".config", "opencode", "opencode.json"),
+      configFormat: "standard",
+    },
+  ];
+
+  return platforms;
+}
+
+export function getDetectedPlatforms(): Platform[] {
+  return detectPlatforms().filter((p) => p.detected);
+}
+
+export function getPlatformById(id: string): Platform | undefined {
+  return detectPlatforms().find((p) => p.id === id);
+}
+
+export const VALID_PLATFORM_IDS = [
+  "claude-code",
+  "claude-desktop",
+  "cursor",
+  "vscode",
+  "windsurf",
+  "cline",
+  "continue",
+  "zed",
+  "kilocode",
+  "opencode",
+];

--- a/cli/src/lib/project-config.ts
+++ b/cli/src/lib/project-config.ts
@@ -176,7 +176,7 @@ const DEFAULT_TOML = `# .nex.toml — Nex project configuration
 # depth = 2
 
 # [mcp]
-# enabled = false             # Set to true by \`nex-ai setup --with-mcp\`
+# enabled = false             # Set to true by \`nex setup --with-mcp\`
 
 # [output]
 # format = "text"             # "text" | "json"

--- a/cli/src/lib/project-config.ts
+++ b/cli/src/lib/project-config.ts
@@ -1,0 +1,196 @@
+/**
+ * .nex.toml project config reader/writer.
+ *
+ * Resolution: CLI flags > .nex.toml > env vars > ~/.nex/config.json > defaults
+ */
+
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+// --- Minimal TOML parser (read-only, no dependency) ---
+// Handles flat keys, dotted keys, strings, numbers, booleans, arrays.
+// Good enough for .nex.toml — not a full TOML spec parser.
+
+function parseLine(
+  line: string,
+  obj: Record<string, unknown>,
+  currentSection: string[],
+): void {
+  const trimmed = line.trim();
+  if (!trimmed || trimmed.startsWith("#")) return;
+
+  // Section header: [hooks.recall]
+  const sectionMatch = trimmed.match(/^\[([^\]]+)\]$/);
+  if (sectionMatch) {
+    currentSection.length = 0;
+    currentSection.push(...sectionMatch[1].split("."));
+    return;
+  }
+
+  // Key = value
+  const kvMatch = trimmed.match(/^([a-zA-Z_][a-zA-Z0-9_.]*)\s*=\s*(.+)$/);
+  if (!kvMatch) return;
+
+  const key = kvMatch[1].trim();
+  const rawValue = kvMatch[2].trim();
+  const value = parseValue(rawValue);
+
+  // Build nested path
+  const path = [...currentSection, ...key.split(".")];
+  let target: Record<string, unknown> = obj;
+  for (let i = 0; i < path.length - 1; i++) {
+    if (!(path[i] in target) || typeof target[path[i]] !== "object") {
+      target[path[i]] = {};
+    }
+    target = target[path[i]] as Record<string, unknown>;
+  }
+  target[path[path.length - 1]] = value;
+}
+
+function parseValue(raw: string): unknown {
+  // Boolean
+  if (raw === "true") return true;
+  if (raw === "false") return false;
+
+  // Number
+  if (/^-?\d+(\.\d+)?$/.test(raw)) return Number(raw);
+
+  // String (quoted)
+  if ((raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))) {
+    return raw.slice(1, -1);
+  }
+
+  // Array
+  if (raw.startsWith("[") && raw.endsWith("]")) {
+    const inner = raw.slice(1, -1).trim();
+    if (!inner) return [];
+    return inner.split(",").map((item) => parseValue(item.trim()));
+  }
+
+  // Bare string fallback
+  return raw;
+}
+
+export function parseToml(content: string): Record<string, unknown> {
+  const obj: Record<string, unknown> = {};
+  const currentSection: string[] = [];
+  for (const line of content.split("\n")) {
+    parseLine(line, obj, currentSection);
+  }
+  return obj;
+}
+
+// --- Project config interface ---
+
+export interface HookConfig {
+  enabled?: boolean;
+  debounce_ms?: number;
+  min_length?: number;
+  max_length?: number;
+}
+
+export interface ProjectConfig {
+  auth?: { api_key?: string };
+  hooks?: {
+    enabled?: boolean;
+    recall?: HookConfig;
+    capture?: HookConfig;
+    session_start?: HookConfig;
+  };
+  scan?: {
+    enabled?: boolean;
+    extensions?: string[];
+    ignore_dirs?: string[];
+    max_files?: number;
+    max_file_size?: number;
+    depth?: number;
+  };
+  mcp?: { enabled?: boolean };
+  output?: { format?: string; timeout?: number };
+}
+
+/**
+ * Find and parse .nex.toml from the given directory (defaults to cwd).
+ * Returns undefined if no .nex.toml is found.
+ */
+export function loadProjectConfig(dir?: string): ProjectConfig | undefined {
+  const configPath = join(dir ?? process.cwd(), ".nex.toml");
+  if (!existsSync(configPath)) return undefined;
+
+  try {
+    const content = readFileSync(configPath, "utf-8");
+    return parseToml(content) as ProjectConfig;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Check if a specific hook is enabled in .nex.toml.
+ * Returns true by default (hooks are opt-out, not opt-in).
+ */
+export function isHookEnabled(
+  hookName: "recall" | "capture" | "session_start",
+  dir?: string,
+): boolean {
+  const config = loadProjectConfig(dir);
+  if (!config) return true;
+
+  // Master kill switch
+  if (config.hooks?.enabled === false) return false;
+
+  // Per-hook setting
+  const hookConfig = config.hooks?.[hookName];
+  if (hookConfig?.enabled === false) return false;
+
+  return true;
+}
+
+const DEFAULT_TOML = `# .nex.toml — Nex project configuration
+# All settings are optional. Defaults shown in comments.
+
+# [auth]
+# api_key = "sk-..."          # Prefer NEX_API_KEY env var or ~/.nex/config.json
+
+# [hooks]
+# enabled = true              # Master kill switch for all hooks
+
+# [hooks.recall]
+# enabled = true              # Auto-recall context on each prompt
+# debounce_ms = 30000
+
+# [hooks.capture]
+# enabled = true              # Auto-capture on conversation stop
+# min_length = 20
+# max_length = 50000
+
+# [hooks.session_start]
+# enabled = true              # Load context on session start
+
+# [scan]
+# enabled = true
+# extensions = [".md", ".txt", ".csv", ".json", ".yaml", ".yml"]
+# ignore_dirs = ["node_modules", ".git", "dist", "build", "__pycache__"]
+# max_files = 5
+# max_file_size = 100000
+# depth = 2
+
+# [mcp]
+# enabled = false             # Set to true by \`nex-ai setup --with-mcp\`
+
+# [output]
+# format = "text"             # "text" | "json"
+# timeout = 120000
+`;
+
+/**
+ * Write a default .nex.toml to the given directory.
+ * Returns false if the file already exists.
+ */
+export function writeDefaultProjectConfig(dir?: string): boolean {
+  const configPath = join(dir ?? process.cwd(), ".nex.toml");
+  if (existsSync(configPath)) return false;
+
+  writeFileSync(configPath, DEFAULT_TOML, "utf-8");
+  return true;
+}

--- a/cli/src/lib/prompt.ts
+++ b/cli/src/lib/prompt.ts
@@ -1,0 +1,22 @@
+/**
+ * Minimal interactive prompt helpers using readline.
+ */
+
+import { createInterface } from "node:readline";
+
+export async function confirm(message: string, defaultYes = true): Promise<boolean> {
+  const suffix = defaultYes ? "[Y/n]" : "[y/N]";
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+
+  return new Promise((resolve) => {
+    rl.question(`${message} ${suffix} `, (answer) => {
+      rl.close();
+      const trimmed = answer.trim().toLowerCase();
+      if (!trimmed) {
+        resolve(defaultYes);
+      } else {
+        resolve(trimmed === "y" || trimmed === "yes");
+      }
+    });
+  });
+}

--- a/cli/src/lib/prompt.ts
+++ b/cli/src/lib/prompt.ts
@@ -20,3 +20,22 @@ export async function confirm(message: string, defaultYes = true): Promise<boole
     });
   });
 }
+
+export async function ask(message: string, required = false): Promise<string> {
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+
+  return new Promise((resolve) => {
+    const prompt = () => {
+      rl.question(`${message} `, (answer) => {
+        const trimmed = answer.trim();
+        if (required && !trimmed) {
+          prompt();
+          return;
+        }
+        rl.close();
+        resolve(trimmed);
+      });
+    };
+    prompt();
+  });
+}

--- a/cli/src/plugin/auto-capture.ts
+++ b/cli/src/plugin/auto-capture.ts
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+/**
+ * Claude Code Stop hook — auto-capture conversation to Nex + plan file ingestion.
+ *
+ * Reads { last_assistant_message, session_id } from stdin,
+ * filters and sends to Nex for ingestion. Also checks .claude/plans/
+ * for changed plan files and ingests up to 2.
+ *
+ * On ANY error: outputs {} and exits 0 (graceful degradation).
+ */
+
+import { readdirSync, statSync, readFileSync } from "node:fs";
+import { join, extname } from "node:path";
+import { loadConfig, loadScanConfig, isHookEnabled } from "./config.js";
+import { NexClient } from "./nex-client.js";
+import { captureFilter } from "./capture-filter.js";
+import { RateLimiter } from "./rate-limiter.js";
+import { readManifest, writeManifest, isChanged, markIngested } from "./file-manifest.js";
+
+/** Ingest timeout — 3s leaves buffer within hook timeout */
+const INGEST_TIMEOUT_MS = 3_000;
+const MAX_PLAN_FILES = 2;
+
+const rateLimiter = new RateLimiter();
+
+interface HookInput {
+  last_assistant_message?: string;
+  session_id?: string;
+}
+
+/**
+ * Scan .claude/plans/ for changed .md files and ingest up to MAX_PLAN_FILES.
+ */
+async function ingestPlanFiles(client: NexClient): Promise<void> {
+  const scanConfig = loadScanConfig();
+  if (!scanConfig.enabled) return;
+
+  const plansDir = join(process.cwd(), ".claude", "plans");
+
+  let entries;
+  try {
+    entries = readdirSync(plansDir, { withFileTypes: true });
+  } catch {
+    return; // No .claude/plans/ dir — normal, skip silently
+  }
+
+  const manifest = readManifest();
+  let ingested = 0;
+
+  for (const entry of entries) {
+    if (ingested >= MAX_PLAN_FILES) break;
+    if (!entry.isFile()) continue;
+    if (extname(entry.name).toLowerCase() !== ".md") continue;
+
+    const fullPath = join(plansDir, entry.name);
+    try {
+      const stat = statSync(fullPath);
+      if (!isChanged(fullPath, stat, manifest)) continue;
+
+      if (!rateLimiter.canProceed()) {
+        process.stderr.write("[nex-capture] Rate limited — skipping plan file ingest\n");
+        break;
+      }
+
+      let content = readFileSync(fullPath, "utf-8");
+      if (content.length > 100_000) {
+        content = content.slice(0, 100_000) + "\n[...truncated]";
+      }
+
+      const context = `claude-code-plan:${entry.name}`;
+      await client.ingest(content, context, INGEST_TIMEOUT_MS);
+      markIngested(fullPath, stat, context, manifest);
+      ingested++;
+    } catch (err) {
+      process.stderr.write(
+        `[nex-capture] Plan file ingest failed (${entry.name}): ${err instanceof Error ? err.message : String(err)}\n`
+      );
+    }
+  }
+
+  if (ingested > 0) {
+    writeManifest(manifest);
+  }
+}
+
+async function main(): Promise<void> {
+  try {
+    // Read stdin
+    const chunks: Buffer[] = [];
+    for await (const chunk of process.stdin) {
+      chunks.push(chunk as Buffer);
+    }
+    const raw = Buffer.concat(chunks).toString("utf-8");
+
+    // Check .nex.toml kill switch
+    if (!isHookEnabled("capture")) {
+      process.stdout.write("{}");
+      return;
+    }
+
+    let input: HookInput;
+    try {
+      input = JSON.parse(raw) as HookInput;
+    } catch {
+      process.stdout.write("{}");
+      return;
+    }
+
+    let cfg;
+    try {
+      cfg = loadConfig();
+    } catch {
+      process.stdout.write("{}");
+      return;
+    }
+
+    const client = new NexClient(cfg.apiKey, cfg.baseUrl);
+
+    // --- Conversation capture (existing behavior) ---
+    const message = input.last_assistant_message?.trim();
+    if (message) {
+      const filterResult = captureFilter(message);
+
+      if (!filterResult.skipped) {
+        if (rateLimiter.canProceed()) {
+          try {
+            await client.ingest(filterResult.text, "claude-code-conversation", INGEST_TIMEOUT_MS);
+          } catch (err) {
+            process.stderr.write(
+              `[nex-capture] Ingest failed: ${err instanceof Error ? err.message : String(err)}\n`
+            );
+          }
+        } else {
+          process.stderr.write("[nex-capture] Rate limited — skipping conversation ingest\n");
+        }
+      }
+    }
+
+    // --- Plan file ingestion ---
+    try {
+      await ingestPlanFiles(client);
+    } catch (err) {
+      process.stderr.write(
+        `[nex-capture] Plan file scan error: ${err instanceof Error ? err.message : String(err)}\n`
+      );
+    }
+
+    process.stdout.write("{}");
+  } catch (err) {
+    process.stderr.write(
+      `[nex-capture] Unexpected error: ${err instanceof Error ? err.message : String(err)}\n`
+    );
+    process.stdout.write("{}");
+  }
+}
+
+main().then(() => process.exit(0)).catch(() => process.exit(0));

--- a/cli/src/plugin/auto-recall.ts
+++ b/cli/src/plugin/auto-recall.ts
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+/**
+ * Claude Code UserPromptSubmit hook — auto-recall from Nex.
+ *
+ * Reads the user's prompt from stdin, runs it through the recall filter
+ * to decide if recall is needed, queries Nex for relevant context,
+ * and outputs { additionalContext: "..." } to inject into the conversation.
+ *
+ * On ANY error: outputs {} and exits 0 (graceful degradation).
+ */
+
+import { loadConfig, isHookEnabled } from "./config.js";
+import { NexClient } from "./nex-client.js";
+import { formatNexContext } from "./context-format.js";
+import { SessionStore } from "./session-store.js";
+import { shouldRecall, recordRecall } from "./recall-filter.js";
+
+const sessions = new SessionStore();
+
+interface HookInput {
+  prompt?: string;
+  session_id?: string;
+}
+
+/**
+ * Check if this is the first prompt for this session.
+ * A session with no stored Nex session ID is considered "first prompt"
+ * (SessionStart may have already set one, but that's fine — it means
+ * baseline context was loaded, and first user prompt still gets recall).
+ */
+function isFirstPrompt(sessionKey: string | undefined): boolean {
+  if (!sessionKey) return true;
+  return !sessions.get(sessionKey);
+}
+
+async function main(): Promise<void> {
+  try {
+    // Read stdin
+    const chunks: Buffer[] = [];
+    for await (const chunk of process.stdin) {
+      chunks.push(chunk as Buffer);
+    }
+    const raw = Buffer.concat(chunks).toString("utf-8");
+
+    let input: HookInput;
+    try {
+      input = JSON.parse(raw) as HookInput;
+    } catch {
+      process.stderr.write("[nex-recall] Failed to parse stdin JSON\n");
+      process.stdout.write("{}");
+      return;
+    }
+
+    // Check .nex.toml kill switch
+    if (!isHookEnabled("recall")) {
+      process.stdout.write("{}");
+      return;
+    }
+
+    const prompt = input.prompt?.trim();
+    if (!prompt || prompt.length < 5) {
+      process.stdout.write("{}");
+      return;
+    }
+
+    // Skip slash commands
+    if (prompt.startsWith("/")) {
+      process.stdout.write("{}");
+      return;
+    }
+
+    // --- Recall filter: decide if this prompt needs memory recall ---
+    const decision = shouldRecall(prompt, isFirstPrompt(input.session_id));
+    if (!decision.shouldRecall) {
+      process.stdout.write("{}");
+      return;
+    }
+
+    let cfg;
+    try {
+      cfg = loadConfig();
+    } catch (err) {
+      process.stderr.write(
+        `[nex-recall] Config error: ${err instanceof Error ? err.message : String(err)}\n`
+      );
+      process.stdout.write("{}");
+      return;
+    }
+
+    const client = new NexClient(cfg.apiKey, cfg.baseUrl);
+
+    // Resolve session ID for multi-turn continuity
+    const sessionKey = input.session_id;
+    const nexSessionId = sessionKey ? sessions.get(sessionKey) : undefined;
+
+    const result = await client.ask(prompt, nexSessionId, 10_000);
+
+    if (!result.answer) {
+      process.stdout.write("{}");
+      return;
+    }
+
+    // Store session ID for future turns
+    if (result.session_id && sessionKey) {
+      sessions.set(sessionKey, result.session_id);
+    }
+
+    // Record successful recall for debounce
+    recordRecall(result.session_id);
+
+    const entityCount = result.entity_references?.length ?? 0;
+    const context = formatNexContext({
+      answer: result.answer,
+      entityCount,
+      sessionId: result.session_id,
+    });
+
+    // Use hookSpecificOutput for discrete context injection (not shown in transcript)
+    const output = JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "UserPromptSubmit",
+        additionalContext: context,
+      },
+    });
+    process.stdout.write(output);
+  } catch (err) {
+    process.stderr.write(
+      `[nex-recall] Unexpected error: ${err instanceof Error ? err.message : String(err)}\n`
+    );
+    process.stdout.write("{}");
+  }
+}
+
+main().then(() => process.exit(0)).catch(() => process.exit(0));

--- a/cli/src/plugin/auto-register.ts
+++ b/cli/src/plugin/auto-register.ts
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+/**
+ * Registration entry point — creates a Nex account and persists the API key.
+ *
+ * Usage: node dist/auto-register.js <email> [name] [company]
+ *
+ * On success: prints API key and saves to ~/.nex-mcp.json (shared with MCP server).
+ * If already registered (API key exists): prints status and exits.
+ */
+
+import { loadMcpConfig, persistRegistration, loadBaseUrl, MCP_CONFIG_PATH } from "./config.js";
+import { NexClient } from "./nex-client.js";
+
+async function main(): Promise<void> {
+  const email = process.argv[2];
+  const name = process.argv[3];
+  const company = process.argv[4];
+
+  if (!email) {
+    console.error("Usage: auto-register.js <email> [name] [company]");
+    process.exit(1);
+  }
+
+  // Check if already registered
+  const existing = loadMcpConfig();
+  if (existing.api_key) {
+    console.log("Already registered.");
+    console.log(`  API key: ${existing.api_key.slice(0, 12)}...`);
+    console.log(`  Config: ${MCP_CONFIG_PATH}`);
+    console.log("\nTo re-register, delete ~/.nex-mcp.json first.");
+    return;
+  }
+
+  const baseUrl = loadBaseUrl();
+  console.log(`Registering ${email} at ${baseUrl} ...`);
+
+  try {
+    const result = await NexClient.register(baseUrl, email, name, company);
+
+    if (!result.api_key) {
+      console.error("Registration succeeded but no API key returned.");
+      console.error("Response:", JSON.stringify(result, null, 2));
+      process.exit(1);
+    }
+
+    // Persist to shared config
+    persistRegistration(result as Record<string, unknown>);
+
+    console.log("Registration successful!");
+    console.log(`  API key: ${result.api_key.slice(0, 12)}...`);
+    if (result.workspace_slug) console.log(`  Workspace: ${result.workspace_slug}`);
+    console.log(`  Saved to: ${MCP_CONFIG_PATH}`);
+    console.log("\nAll Nex memory features are now active. No restart needed.");
+  } catch (err) {
+    console.error(`Registration failed: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/cli/src/plugin/auto-scan.ts
+++ b/cli/src/plugin/auto-scan.ts
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+/**
+ * Standalone entry point for the /scan slash command.
+ *
+ * Reads optional directory from argv[2] or stdin, scans for project files,
+ * and ingests changed ones into Nex. Prints results to stdout.
+ *
+ * Usage: node dist/auto-scan.js [directory]
+ */
+
+import { loadConfig, loadScanConfig } from "./config.js";
+import { NexClient } from "./nex-client.js";
+import { RateLimiter } from "./rate-limiter.js";
+import { scanAndIngest } from "./file-scanner.js";
+
+async function main(): Promise<void> {
+  try {
+    // Determine target directory: argv[2] > cwd
+    const targetDir = process.argv[2] || process.cwd();
+
+    let cfg;
+    try {
+      cfg = loadConfig();
+    } catch (err) {
+      console.error(`Config error: ${err instanceof Error ? err.message : String(err)}`);
+      process.exit(1);
+    }
+
+    const scanConfig = loadScanConfig();
+    if (!scanConfig.enabled) {
+      console.log("File scanning is disabled (NEX_SCAN_ENABLED=false).");
+      return;
+    }
+
+    const client = new NexClient(cfg.apiKey, cfg.baseUrl);
+    const rateLimiter = new RateLimiter();
+
+    console.log(`Scanning ${targetDir} ...`);
+    const result = await scanAndIngest(client, rateLimiter, targetDir, scanConfig);
+
+    console.log(`Scan complete:`);
+    console.log(`  Scanned: ${result.scanned} files`);
+    console.log(`  Ingested: ${result.ingested} files`);
+    console.log(`  Skipped: ${result.skipped} files (unchanged)`);
+    if (result.errors > 0) {
+      console.log(`  Errors: ${result.errors}`);
+    }
+  } catch (err) {
+    console.error(`Scan failed: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/cli/src/plugin/auto-session-start.ts
+++ b/cli/src/plugin/auto-session-start.ts
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+/**
+ * Claude Code SessionStart hook — bulk context load from Nex + file scan.
+ *
+ * Fires once when a new Claude Code session begins. Queries Nex for
+ * a baseline context summary and injects it so the agent "already knows"
+ * relevant business context from the first message.
+ *
+ * On startup/clear: also scans project files and ingests changed ones.
+ * On compact/resume: skips file scan (files already ingested, just re-query summary).
+ *
+ * On ANY error: outputs {} and exits 0 (graceful degradation).
+ */
+
+import { loadConfig, loadScanConfig, ConfigError, isHookEnabled } from "./config.js";
+import { NexClient } from "./nex-client.js";
+import { RateLimiter } from "./rate-limiter.js";
+import { formatNexContext } from "./context-format.js";
+import { SessionStore } from "./session-store.js";
+import { recordRecall } from "./recall-filter.js";
+import { scanAndIngest } from "./file-scanner.js";
+import { ingestContextFiles } from "./context-files.js";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const sessions = new SessionStore();
+
+interface HookInput {
+  session_id?: string;
+  source?: string; // "startup" | "resume" | "clear" | "compact"
+}
+
+const SESSION_START_QUERY = "Summarize the key active context, recent interactions, and important updates for this user.";
+
+async function main(): Promise<void> {
+  try {
+    // Read stdin
+    const chunks: Buffer[] = [];
+    for await (const chunk of process.stdin) {
+      chunks.push(chunk as Buffer);
+    }
+    const raw = Buffer.concat(chunks).toString("utf-8");
+
+    // Check .nex.toml kill switch
+    if (!isHookEnabled("session_start")) {
+      process.stdout.write("{}");
+      return;
+    }
+
+    let input: HookInput = {};
+    try {
+      input = JSON.parse(raw) as HookInput;
+    } catch {
+      process.stderr.write("[nex-session-start] Failed to parse stdin JSON, continuing with defaults\n");
+    }
+
+    let cfg;
+    try {
+      cfg = loadConfig();
+    } catch (err) {
+      if (err instanceof ConfigError) {
+        // No API key — inject registration prompt so Claude handles it
+        const pluginDir = dirname(fileURLToPath(import.meta.url));
+        const registerScript = join(pluginDir, "auto-register.js");
+        const registrationPrompt = [
+          "[Nex Memory Plugin] No API key configured. Registration is required to enable persistent memory.",
+          "",
+          "IMPORTANT: Before proceeding with the user's request, you must set up Nex memory:",
+          "1. Ask the user for their email address to register for a Nex account",
+          "2. Run the registration command: node " + registerScript + " <email> [name] [company]",
+          "3. Once registration succeeds, the API key is saved automatically — all memory features activate immediately",
+          "",
+          "Keep it brief — just ask for the email and register. No restart needed after registration.",
+        ].join("\n");
+
+        const output = JSON.stringify({
+          hookSpecificOutput: {
+            hookEventName: "SessionStart",
+            additionalContext: registrationPrompt,
+          },
+        });
+        process.stdout.write(output);
+        return;
+      }
+      process.stderr.write(
+        `[nex-session-start] Config error: ${err instanceof Error ? err.message : String(err)}\n`
+      );
+      process.stdout.write("{}");
+      return;
+    }
+
+    const client = new NexClient(cfg.apiKey, cfg.baseUrl);
+    const contextParts: string[] = [];
+
+    // --- File scan on startup or clear ---
+    const source = input.source ?? "startup";
+    const shouldScan = source === "startup" || source === "clear";
+
+    if (shouldScan) {
+      const rateLimiter = new RateLimiter();
+      const cwd = process.cwd();
+
+      // --- Ingest CLAUDE.md + memory files (highest priority) ---
+      try {
+        const ctxResult = await ingestContextFiles(client, rateLimiter, cwd);
+        if (ctxResult.ingested > 0) {
+          contextParts.push(
+            `[Context files: ${ctxResult.ingested} ingested (${ctxResult.files.join(", ")})]`
+          );
+        }
+      } catch (err) {
+        process.stderr.write(
+          `[nex-session-start] Context files error: ${err instanceof Error ? err.message : String(err)}\n`
+        );
+      }
+
+      // --- Project file scan ---
+      try {
+        const scanConfig = loadScanConfig();
+        if (scanConfig.enabled) {
+          const scanResult = await scanAndIngest(client, rateLimiter, cwd, scanConfig);
+
+          if (scanResult.ingested > 0) {
+            contextParts.push(
+              `[File scan: ${scanResult.ingested} file${scanResult.ingested === 1 ? "" : "s"} ingested, ${scanResult.scanned} scanned]`
+            );
+          }
+        }
+      } catch (err) {
+        process.stderr.write(
+          `[nex-session-start] File scan error: ${err instanceof Error ? err.message : String(err)}\n`
+        );
+      }
+    }
+
+    // --- Nex context query ---
+    const result = await client.ask(SESSION_START_QUERY, undefined, 10_000);
+
+    if (!result.answer && contextParts.length === 0) {
+      process.stdout.write("{}");
+      return;
+    }
+
+    // Store session mapping
+    if (result.session_id && input.session_id) {
+      sessions.set(input.session_id, result.session_id);
+    }
+
+    // Record this as a successful recall for debounce
+    recordRecall(result.session_id);
+
+    const entityCount = result.entity_references?.length ?? 0;
+    const context = formatNexContext({
+      answer: result.answer,
+      entityCount,
+      sessionId: result.session_id,
+    });
+
+    // Append scan summary if any
+    const fullContext = contextParts.length > 0
+      ? `${context}\n${contextParts.join("\n")}`
+      : context;
+
+    const output = JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "SessionStart",
+        additionalContext: fullContext,
+      },
+    });
+    process.stdout.write(output);
+  } catch (err) {
+    process.stderr.write(
+      `[nex-session-start] Unexpected error: ${err instanceof Error ? err.message : String(err)}\n`
+    );
+    process.stdout.write("{}");
+  }
+}
+
+main().then(() => process.exit(0)).catch(() => process.exit(0));

--- a/cli/src/plugin/capture-filter.ts
+++ b/cli/src/plugin/capture-filter.ts
@@ -1,0 +1,48 @@
+/**
+ * Capture filtering for Claude Code — decides what content to send to Nex.
+ * Adapted from openclaw-plugin for plain string input.
+ */
+
+import { stripNexContext } from "./context-format.js";
+
+const MIN_LENGTH = 20;
+const MAX_LENGTH = 50_000;
+
+export interface CaptureResult {
+  text: string;
+  skipped: false;
+}
+
+export interface CaptureSkip {
+  reason: string;
+  skipped: true;
+}
+
+/**
+ * Filter text for capture eligibility.
+ * Works with plain strings (Claude Code messages).
+ *
+ * Note: Deduplication is handled server-side by the Nex extraction pipeline.
+ * Since hooks are short-lived processes (new process per invocation), in-memory
+ * dedup caches would be empty on each run and provide no value.
+ */
+export function captureFilter(text: string): CaptureResult | CaptureSkip {
+  if (!text || text.trim().length === 0) {
+    return { skipped: true, reason: "empty text" };
+  }
+
+  // Strip injected context blocks (prevent feedback loop)
+  const cleaned = stripNexContext(text);
+
+  // Skip too short
+  if (cleaned.length < MIN_LENGTH) {
+    return { skipped: true, reason: `too short (${cleaned.length} chars)` };
+  }
+
+  // Skip too long
+  if (cleaned.length > MAX_LENGTH) {
+    return { skipped: true, reason: `too long (${cleaned.length} chars)` };
+  }
+
+  return { skipped: false, text: cleaned };
+}

--- a/cli/src/plugin/config.ts
+++ b/cli/src/plugin/config.ts
@@ -1,0 +1,225 @@
+/**
+ * Plugin configuration — reads from environment variables,
+ * with fallback to ~/.nex-mcp.json (shared with MCP server).
+ */
+
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { homedir } from "node:os";
+
+export interface NexConfig {
+  apiKey: string;
+  baseUrl: string;
+}
+
+export interface ScanConfig {
+  extensions: string[];
+  maxFileSize: number;
+  maxFilesPerScan: number;
+  scanDepth: number;
+  ignoreDirs: string[];
+  enabled: boolean;
+}
+
+export class ConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ConfigError";
+  }
+}
+
+/** Shared config file with MCP server — stores registration data. */
+const MCP_CONFIG_PATH = join(homedir(), ".nex-mcp.json");
+
+export { MCP_CONFIG_PATH };
+
+interface McpConfig {
+  api_key?: string;
+  base_url?: string;
+  workspace_id?: string;
+  workspace_slug?: string;
+}
+
+/** Read ~/.nex-mcp.json (shared with MCP server registration). */
+export function loadMcpConfig(): McpConfig {
+  try {
+    const raw = readFileSync(MCP_CONFIG_PATH, "utf-8");
+    return JSON.parse(raw) as McpConfig;
+  } catch {
+    return {};
+  }
+}
+
+/** Write registration data to ~/.nex-mcp.json. */
+export function persistRegistration(data: Record<string, unknown>): void {
+  const existing = loadMcpConfig() as Record<string, unknown>;
+  if (typeof data.api_key === "string") existing.api_key = data.api_key;
+  if (typeof data.workspace_id === "string" || typeof data.workspace_id === "number") {
+    existing.workspace_id = String(data.workspace_id);
+  }
+  if (typeof data.workspace_slug === "string") existing.workspace_slug = data.workspace_slug;
+  mkdirSync(dirname(MCP_CONFIG_PATH), { recursive: true });
+  writeFileSync(MCP_CONFIG_PATH, JSON.stringify(existing, null, 2) + "\n", "utf-8");
+}
+
+/**
+ * Load config from environment variables, with fallback to ~/.nex-mcp.json.
+ *
+ * Priority: NEX_API_KEY env > ~/.nex-mcp.json api_key
+ * If neither is set, throws ConfigError with registration instructions.
+ */
+export function loadConfig(): NexConfig {
+  let apiKey = process.env.NEX_API_KEY;
+
+  if (!apiKey) {
+    // Fallback to shared MCP config
+    const mcpConfig = loadMcpConfig();
+    apiKey = mcpConfig.api_key;
+  }
+
+  if (!apiKey) {
+    throw new ConfigError(
+      "No API key found. Set NEX_API_KEY or run /register to create an account."
+    );
+  }
+
+  let baseUrl = process.env.NEX_API_BASE_URL ?? "https://app.nex.ai";
+  // Strip trailing slash
+  baseUrl = baseUrl.replace(/\/+$/, "");
+
+  return { apiKey, baseUrl };
+}
+
+/**
+ * Load base URL without requiring an API key.
+ * Used for registration (which doesn't need auth).
+ */
+export function loadBaseUrl(): string {
+  let baseUrl = process.env.NEX_API_BASE_URL ?? "https://app.nex.ai";
+  return baseUrl.replace(/\/+$/, "");
+}
+
+// --- .nex.toml project config support ---
+
+interface HookTomlConfig {
+  enabled?: boolean;
+  debounce_ms?: number;
+  min_length?: number;
+  max_length?: number;
+}
+
+interface ProjectTomlConfig {
+  hooks?: {
+    enabled?: boolean;
+    recall?: HookTomlConfig;
+    capture?: HookTomlConfig;
+    session_start?: HookTomlConfig;
+  };
+}
+
+function parseTomlValue(raw: string): unknown {
+  if (raw === "true") return true;
+  if (raw === "false") return false;
+  if (/^-?\d+(\.\d+)?$/.test(raw)) return Number(raw);
+  if ((raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))) {
+    return raw.slice(1, -1);
+  }
+  if (raw.startsWith("[") && raw.endsWith("]")) {
+    const inner = raw.slice(1, -1).trim();
+    if (!inner) return [];
+    return inner.split(",").map((item) => parseTomlValue(item.trim()));
+  }
+  return raw;
+}
+
+function parseToml(content: string): Record<string, unknown> {
+  const obj: Record<string, unknown> = {};
+  const currentSection: string[] = [];
+
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+
+    const sectionMatch = trimmed.match(/^\[([^\]]+)\]$/);
+    if (sectionMatch) {
+      currentSection.length = 0;
+      currentSection.push(...sectionMatch[1].split("."));
+      continue;
+    }
+
+    const kvMatch = trimmed.match(/^([a-zA-Z_][a-zA-Z0-9_.]*)\s*=\s*(.+)$/);
+    if (!kvMatch) continue;
+
+    const path = [...currentSection, ...kvMatch[1].trim().split(".")];
+    const value = parseTomlValue(kvMatch[2].trim());
+
+    let target: Record<string, unknown> = obj;
+    for (let i = 0; i < path.length - 1; i++) {
+      if (!(path[i] in target) || typeof target[path[i]] !== "object") {
+        target[path[i]] = {};
+      }
+      target = target[path[i]] as Record<string, unknown>;
+    }
+    target[path[path.length - 1]] = value;
+  }
+  return obj;
+}
+
+/**
+ * Check if a specific hook is enabled in .nex.toml.
+ * Returns true by default (hooks are opt-out).
+ */
+export function isHookEnabled(hookName: "recall" | "capture" | "session_start"): boolean {
+  try {
+    const tomlPath = join(process.cwd(), ".nex.toml");
+    const content = readFileSync(tomlPath, "utf-8");
+    const config = parseToml(content) as ProjectTomlConfig;
+
+    // Master kill switch
+    if (config.hooks?.enabled === false) return false;
+
+    // Per-hook setting
+    const hookConfig = config.hooks?.[hookName];
+    if (hookConfig?.enabled === false) return false;
+
+    return true;
+  } catch {
+    return true; // No .nex.toml or read error → hooks enabled by default
+  }
+}
+
+const DEFAULT_SCAN_EXTENSIONS = [".md", ".txt", ".csv", ".json", ".yaml", ".yml"];
+const DEFAULT_IGNORE_DIRS = [
+  "node_modules", ".git", "dist", "build", ".next", "__pycache__",
+  "vendor", ".venv", ".claude", "coverage", ".turbo", ".cache",
+];
+
+/**
+ * Load scan config from NEX_SCAN_* environment variables.
+ * All fields have sensible defaults; NEX_SCAN_ENABLED=false is the kill switch.
+ */
+export function loadScanConfig(): ScanConfig {
+  const enabled = (process.env.NEX_SCAN_ENABLED ?? "true").toLowerCase() !== "false";
+
+  const extensions = process.env.NEX_SCAN_EXTENSIONS
+    ? process.env.NEX_SCAN_EXTENSIONS.split(",").map((e) => e.trim())
+    : DEFAULT_SCAN_EXTENSIONS;
+
+  const maxFileSize = process.env.NEX_SCAN_MAX_FILE_SIZE
+    ? parseInt(process.env.NEX_SCAN_MAX_FILE_SIZE, 10)
+    : 100_000;
+
+  const maxFilesPerScan = process.env.NEX_SCAN_MAX_FILES
+    ? parseInt(process.env.NEX_SCAN_MAX_FILES, 10)
+    : 5;
+
+  const scanDepth = process.env.NEX_SCAN_DEPTH
+    ? parseInt(process.env.NEX_SCAN_DEPTH, 10)
+    : 2;
+
+  const ignoreDirs = process.env.NEX_SCAN_IGNORE_DIRS
+    ? process.env.NEX_SCAN_IGNORE_DIRS.split(",").map((d) => d.trim())
+    : DEFAULT_IGNORE_DIRS;
+
+  return { extensions, maxFileSize, maxFilesPerScan, scanDepth, ignoreDirs, enabled };
+}

--- a/cli/src/plugin/context-files.ts
+++ b/cli/src/plugin/context-files.ts
@@ -1,0 +1,128 @@
+/**
+ * Ingests Claude Code context files (CLAUDE.md + memory files) into Nex.
+ *
+ * Reads from both global and project-level locations:
+ * - ~/.claude/CLAUDE.md (global instructions)
+ * - {cwd}/CLAUDE.md (project instructions)
+ * - ~/.claude/projects/{project-key}/memory/MEMORY.md (auto-memory)
+ * - ~/.claude/projects/{project-key}/memory/*.md (topic memory files)
+ *
+ * Uses the file manifest for change detection — unchanged files are skipped.
+ */
+
+import { existsSync, readdirSync, statSync, readFileSync } from "node:fs";
+import { join, extname, basename } from "node:path";
+import { homedir } from "node:os";
+import type { NexClient } from "./nex-client.js";
+import type { RateLimiter } from "./rate-limiter.js";
+import { readManifest, writeManifest, isChanged, markIngested } from "./file-manifest.js";
+
+const CLAUDE_DIR = join(homedir(), ".claude");
+const INGEST_TIMEOUT_MS = 10_000;
+const MAX_FILE_SIZE = 100_000;
+
+export interface ContextFilesResult {
+  ingested: number;
+  skipped: number;
+  errors: number;
+  files: string[]; // context tags of ingested files
+}
+
+/**
+ * Derive the Claude Code project key from a cwd path.
+ * e.g. /Users/foo/bar → -Users-foo-bar
+ */
+function projectKey(cwd: string): string {
+  return cwd.replace(/\//g, "-");
+}
+
+/**
+ * Collect all context file paths to check.
+ */
+function collectContextFiles(cwd: string): Array<{ path: string; contextTag: string }> {
+  const files: Array<{ path: string; contextTag: string }> = [];
+  const key = projectKey(cwd);
+
+  // 1. Global CLAUDE.md
+  const globalClaude = join(CLAUDE_DIR, "CLAUDE.md");
+  if (existsSync(globalClaude)) {
+    files.push({ path: globalClaude, contextTag: "claude-md:global" });
+  }
+
+  // 2. Project CLAUDE.md
+  const projectClaude = join(cwd, "CLAUDE.md");
+  if (existsSync(projectClaude)) {
+    files.push({ path: projectClaude, contextTag: "claude-md:project" });
+  }
+
+  // 3. Memory files: ~/.claude/projects/{key}/memory/*.md
+  const memoryDir = join(CLAUDE_DIR, "projects", key, "memory");
+  if (existsSync(memoryDir)) {
+    try {
+      const entries = readdirSync(memoryDir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isFile()) continue;
+        if (extname(entry.name).toLowerCase() !== ".md") continue;
+        const fullPath = join(memoryDir, entry.name);
+        const name = basename(entry.name, ".md");
+        files.push({ path: fullPath, contextTag: `claude-memory:${name}` });
+      }
+    } catch {
+      // memoryDir unreadable — skip silently
+    }
+  }
+
+  return files;
+}
+
+/**
+ * Ingest changed CLAUDE.md and memory files into Nex.
+ */
+export async function ingestContextFiles(
+  client: NexClient,
+  rateLimiter: RateLimiter,
+  cwd: string
+): Promise<ContextFilesResult> {
+  const result: ContextFilesResult = { ingested: 0, skipped: 0, errors: 0, files: [] };
+  const manifest = readManifest();
+  const candidates = collectContextFiles(cwd);
+  let dirty = false;
+
+  for (const { path, contextTag } of candidates) {
+    try {
+      const stat = statSync(path);
+      if (!isChanged(path, stat, manifest)) {
+        result.skipped++;
+        continue;
+      }
+
+      if (!rateLimiter.canProceed()) {
+        process.stderr.write("[nex-context-files] Rate limited — stopping context file ingest\n");
+        result.skipped += candidates.length - result.ingested - result.skipped - result.errors;
+        break;
+      }
+
+      let content = readFileSync(path, "utf-8");
+      if (content.length > MAX_FILE_SIZE) {
+        content = content.slice(0, MAX_FILE_SIZE) + "\n[...truncated]";
+      }
+
+      await client.ingest(content, contextTag, INGEST_TIMEOUT_MS);
+      markIngested(path, stat, contextTag, manifest);
+      result.ingested++;
+      result.files.push(contextTag);
+      dirty = true;
+    } catch (err) {
+      process.stderr.write(
+        `[nex-context-files] Failed to ingest ${contextTag}: ${err instanceof Error ? err.message : String(err)}\n`
+      );
+      result.errors++;
+    }
+  }
+
+  if (dirty) {
+    writeManifest(manifest);
+  }
+
+  return result;
+}

--- a/cli/src/plugin/context-format.ts
+++ b/cli/src/plugin/context-format.ts
@@ -1,0 +1,45 @@
+/**
+ * XML context formatting and stripping for recall injection.
+ * Wraps Nex answers in <nex-context> tags and strips them before capture.
+ */
+
+const OPEN_TAG = "<nex-context>";
+const CLOSE_TAG = "</nex-context>";
+
+export interface NexRecallResult {
+  answer: string;
+  entityCount: number;
+  sessionId?: string;
+}
+
+/**
+ * Format a Nex /ask response as an XML block for context injection.
+ */
+export function formatNexContext(result: NexRecallResult): string {
+  const parts: string[] = [
+    OPEN_TAG,
+    "The following is relevant context from the user's knowledge base. Use it to inform your response, but do not mention this block directly.",
+  ];
+
+  if (result.entityCount > 0) {
+    parts.push(`[${result.entityCount} related entities found]`);
+  }
+
+  parts.push("");
+  parts.push(result.answer);
+  parts.push(CLOSE_TAG);
+
+  return parts.join("\n");
+}
+
+/**
+ * Strip all <nex-context>...</nex-context> blocks from text.
+ * Also handles unclosed tags (strips from open tag to end of text).
+ */
+export function stripNexContext(text: string): string {
+  // First: strip complete blocks
+  let result = text.replace(/<nex-context>[\s\S]*?<\/nex-context>/g, "");
+  // Then: strip unclosed tags (open tag without matching close)
+  result = result.replace(/<nex-context>[\s\S]*/g, "");
+  return result.trim();
+}

--- a/cli/src/plugin/file-manifest.ts
+++ b/cli/src/plugin/file-manifest.ts
@@ -1,0 +1,67 @@
+/**
+ * Persistent file manifest — tracks which files have been ingested
+ * using mtime + size as change detection.
+ *
+ * Stored at ~/.nex/file-scan-manifest.json. Follows session-store.ts pattern.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, type Stats } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+export interface FileManifestEntry {
+  mtime: number;      // fs.statSync().mtimeMs
+  size: number;       // fs.statSync().size
+  ingestedAt: number; // Date.now()
+  context: string;    // context tag used for ingest
+}
+
+export interface FileManifest {
+  version: 1;
+  files: Record<string, FileManifestEntry>; // key = absolute path
+}
+
+const DATA_DIR = join(homedir(), ".nex");
+const MANIFEST_PATH = join(DATA_DIR, "file-scan-manifest.json");
+
+export function readManifest(): FileManifest {
+  try {
+    const raw = readFileSync(MANIFEST_PATH, "utf-8");
+    const data = JSON.parse(raw);
+    if (data && data.version === 1 && data.files) {
+      return data as FileManifest;
+    }
+    return { version: 1, files: {} };
+  } catch {
+    return { version: 1, files: {} };
+  }
+}
+
+export function writeManifest(manifest: FileManifest): void {
+  try {
+    mkdirSync(DATA_DIR, { recursive: true });
+    writeFileSync(MANIFEST_PATH, JSON.stringify(manifest, null, 2), "utf-8");
+  } catch {
+    // Best-effort — if we can't write, next scan re-ingests
+  }
+}
+
+export function isChanged(path: string, stat: Stats, manifest: FileManifest): boolean {
+  const entry = manifest.files[path];
+  if (!entry) return true;
+  return entry.mtime !== stat.mtimeMs || entry.size !== stat.size;
+}
+
+export function markIngested(
+  path: string,
+  stat: Stats,
+  context: string,
+  manifest: FileManifest
+): void {
+  manifest.files[path] = {
+    mtime: stat.mtimeMs,
+    size: stat.size,
+    ingestedAt: Date.now(),
+    context,
+  };
+}

--- a/cli/src/plugin/file-scanner.ts
+++ b/cli/src/plugin/file-scanner.ts
@@ -1,0 +1,128 @@
+/**
+ * Core file scanner — walks project directories, detects changed files,
+ * and ingests them into Nex via the developer API.
+ *
+ * No new dependencies — uses only Node.js built-ins.
+ */
+
+import { readdirSync, statSync, readFileSync } from "node:fs";
+import { join, relative, extname } from "node:path";
+import type { Stats } from "node:fs";
+import type { NexClient } from "./nex-client.js";
+import type { RateLimiter } from "./rate-limiter.js";
+import type { ScanConfig } from "./config.js";
+import { readManifest, writeManifest, isChanged, markIngested } from "./file-manifest.js";
+
+export interface ScanResult {
+  scanned: number;
+  ingested: number;
+  skipped: number;
+  errors: number;
+}
+
+interface CandidateFile {
+  absolutePath: string;
+  relativePath: string;
+  stat: Stats;
+}
+
+/**
+ * Recursively collect candidate files up to scanDepth levels.
+ */
+function walkDir(
+  dir: string,
+  cwd: string,
+  config: ScanConfig,
+  depth: number,
+  results: CandidateFile[]
+): void {
+  if (depth > config.scanDepth) return;
+
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return; // Permission denied or missing — skip silently
+  }
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      if (config.ignoreDirs.includes(entry.name)) continue;
+      walkDir(fullPath, cwd, config, depth + 1, results);
+    } else if (entry.isFile()) {
+      const ext = extname(entry.name).toLowerCase();
+      if (!config.extensions.includes(ext)) continue;
+
+      try {
+        const stat = statSync(fullPath);
+        results.push({
+          absolutePath: fullPath,
+          relativePath: relative(cwd, fullPath),
+          stat,
+        });
+      } catch {
+        // stat failed — skip
+      }
+    }
+  }
+}
+
+/**
+ * Scan project directory for text files and ingest changed ones into Nex.
+ */
+export async function scanAndIngest(
+  client: NexClient,
+  rateLimiter: RateLimiter,
+  cwd: string,
+  config: ScanConfig
+): Promise<ScanResult> {
+  const result: ScanResult = { scanned: 0, ingested: 0, skipped: 0, errors: 0 };
+
+  if (!config.enabled) return result;
+
+  const manifest = readManifest();
+  const candidates: CandidateFile[] = [];
+  walkDir(cwd, cwd, config, 0, candidates);
+
+  result.scanned = candidates.length;
+
+  // Filter to changed files, sort by mtime descending (newest first)
+  const changed = candidates
+    .filter((f) => isChanged(f.absolutePath, f.stat, manifest))
+    .sort((a, b) => b.stat.mtimeMs - a.stat.mtimeMs)
+    .slice(0, config.maxFilesPerScan);
+
+  result.skipped = candidates.length - changed.length;
+
+  for (const file of changed) {
+    if (!rateLimiter.canProceed()) {
+      process.stderr.write(`[nex-scan] Rate limited — stopping after ${result.ingested} files\n`);
+      result.skipped += changed.length - result.ingested - result.errors;
+      break;
+    }
+
+    try {
+      let content = readFileSync(file.absolutePath, "utf-8");
+
+      // Truncate large files
+      if (content.length > config.maxFileSize) {
+        content = content.slice(0, config.maxFileSize) + "\n[...truncated]";
+      }
+
+      const context = `file-scan:${file.relativePath}`;
+      await client.ingest(content, context, 10_000);
+      markIngested(file.absolutePath, file.stat, context, manifest);
+      result.ingested++;
+    } catch (err) {
+      process.stderr.write(
+        `[nex-scan] Failed to ingest ${file.relativePath}: ${err instanceof Error ? err.message : String(err)}\n`
+      );
+      result.errors++;
+    }
+  }
+
+  writeManifest(manifest);
+  return result;
+}

--- a/cli/src/plugin/nex-client.ts
+++ b/cli/src/plugin/nex-client.ts
@@ -1,0 +1,176 @@
+/**
+ * HTTP client for the Nex Developer API.
+ * Adapted from openclaw-plugin — uses native fetch with timeout.
+ */
+
+// --- Error types ---
+
+export class NexAuthError extends Error {
+  constructor(message = "Invalid or missing API key") {
+    super(message);
+    this.name = "NexAuthError";
+  }
+}
+
+export class NexRateLimitError extends Error {
+  public retryAfterMs: number;
+
+  constructor(retryAfterMs = 60_000) {
+    super(`Rate limited — retry after ${retryAfterMs}ms`);
+    this.name = "NexRateLimitError";
+    this.retryAfterMs = retryAfterMs;
+  }
+}
+
+export class NexServerError extends Error {
+  public status: number;
+
+  constructor(status: number, body?: string) {
+    super(`Nex API error ${status}${body ? `: ${body}` : ""}`);
+    this.name = "NexServerError";
+    this.status = status;
+  }
+}
+
+// --- Response types ---
+
+export interface RegisterResponse {
+  api_key: string;
+  workspace_id?: string | number;
+  workspace_slug?: string;
+  [key: string]: unknown;
+}
+
+export interface IngestResponse {
+  artifact_id: string;
+}
+
+export interface EntityReference {
+  id?: number;
+  name: string;
+  type: string;
+  count?: number;
+}
+
+export interface AskResponse {
+  answer: string;
+  session_id?: string;
+  entity_references?: EntityReference[];
+}
+
+// --- Client ---
+
+export class NexClient {
+  private apiKey: string;
+  private baseUrl: string;
+
+  constructor(apiKey: string, baseUrl: string) {
+    this.apiKey = apiKey;
+    this.baseUrl = baseUrl;
+  }
+
+  private async request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+    timeoutMs = 10_000
+  ): Promise<T> {
+    const url = `${this.baseUrl}/api/developers${path}`;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      const headers: Record<string, string> = {
+        Authorization: `Bearer ${this.apiKey}`,
+      };
+      if (body !== undefined) {
+        headers["Content-Type"] = "application/json";
+      }
+
+      const res = await fetch(url, {
+        method,
+        headers,
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+        signal: controller.signal,
+      });
+
+      if (res.status === 401 || res.status === 403) {
+        throw new NexAuthError();
+      }
+
+      if (res.status === 429) {
+        const retryAfter = res.headers.get("retry-after");
+        const ms = retryAfter ? parseInt(retryAfter, 10) * 1000 : 60_000;
+        throw new NexRateLimitError(ms);
+      }
+
+      if (!res.ok) {
+        let errorBody: string | undefined;
+        try {
+          errorBody = await res.text();
+        } catch {
+          // ignore
+        }
+        throw new NexServerError(res.status, errorBody);
+      }
+
+      const text = await res.text();
+      if (!text || !text.trim()) return {} as T;
+      return JSON.parse(text) as T;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /**
+   * Register a new account and get an API key.
+   * Does NOT require an existing API key — uses the public registration endpoint.
+   */
+  static async register(
+    baseUrl: string,
+    email: string,
+    name?: string,
+    companyName?: string,
+  ): Promise<RegisterResponse> {
+    const url = `${baseUrl}/api/v1/agents/register`;
+    const body: Record<string, string> = { email, source: "claude-code" };
+    if (name) body.name = name;
+    if (companyName) body.company_name = companyName;
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 30_000);
+
+    try {
+      const res = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+
+      if (!res.ok) {
+        let errorBody: string | undefined;
+        try { errorBody = await res.text(); } catch { /* ignore */ }
+        throw new NexServerError(res.status, errorBody);
+      }
+
+      return await res.json() as RegisterResponse;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /** Ingest text content into the Nex knowledge graph. */
+  async ingest(content: string, context?: string, timeoutMs?: number): Promise<IngestResponse> {
+    const body: Record<string, string> = { content };
+    if (context) body.context = context;
+    return this.request<IngestResponse>("POST", "/v1/context/text", body, timeoutMs ?? 60_000);
+  }
+
+  /** Ask a question against the Nex knowledge graph. */
+  async ask(query: string, sessionId?: string, timeoutMs?: number): Promise<AskResponse> {
+    const body: Record<string, unknown> = { query };
+    if (sessionId) body.session_id = sessionId;
+    return this.request<AskResponse>("POST", "/v1/context/ask", body, timeoutMs);
+  }
+}

--- a/cli/src/plugin/rate-limiter.ts
+++ b/cli/src/plugin/rate-limiter.ts
@@ -1,0 +1,79 @@
+/**
+ * File-based sliding window rate limiter.
+ * Designed for Nex /text endpoint (10 req/min).
+ *
+ * Since Claude Code hooks are short-lived processes (start, run, exit),
+ * in-memory state is lost between invocations. This implementation persists
+ * timestamps to a JSON file so rate limits are respected across invocations.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+export interface RateLimiterConfig {
+  maxRequests: number;
+  windowMs: number;
+  dataDir: string;
+}
+
+const DEFAULTS: RateLimiterConfig = {
+  maxRequests: 10,
+  windowMs: 60_000,
+  dataDir: join(homedir(), ".nex"),
+};
+
+export class RateLimiter {
+  private config: RateLimiterConfig;
+  private filePath: string;
+
+  constructor(config?: Partial<RateLimiterConfig>) {
+    this.config = { ...DEFAULTS, ...config };
+    this.filePath = join(this.config.dataDir, "rate-limiter.json");
+    mkdirSync(this.config.dataDir, { recursive: true });
+  }
+
+  private readTimestamps(): number[] {
+    try {
+      const raw = readFileSync(this.filePath, "utf-8");
+      const data = JSON.parse(raw);
+      if (Array.isArray(data)) return data;
+      return [];
+    } catch {
+      return [];
+    }
+  }
+
+  private writeTimestamps(timestamps: number[]): void {
+    try {
+      writeFileSync(this.filePath, JSON.stringify(timestamps), "utf-8");
+    } catch {
+      // Best-effort — if we can't write, proceed without rate limiting
+    }
+  }
+
+  /**
+   * Check if a request can proceed, and if so, record the timestamp.
+   * Returns true if the request is allowed, false if rate limited.
+   */
+  canProceed(): boolean {
+    const now = Date.now();
+    const timestamps = this.readTimestamps().filter(
+      (t) => now - t < this.config.windowMs
+    );
+
+    if (timestamps.length >= this.config.maxRequests) {
+      // Write back pruned timestamps
+      this.writeTimestamps(timestamps);
+      return false;
+    }
+
+    timestamps.push(now);
+    this.writeTimestamps(timestamps);
+    return true;
+  }
+
+  get pending(): number {
+    return 0;
+  }
+}

--- a/cli/src/plugin/recall-filter.ts
+++ b/cli/src/plugin/recall-filter.ts
@@ -1,0 +1,120 @@
+/**
+ * Smart prompt classifier for selective recall.
+ *
+ * Determines whether a prompt is likely knowledge-seeking (needs recall)
+ * or a pure coding directive (skip recall). Also handles debounce —
+ * skips recall if a successful recall happened within the debounce window,
+ * unless the current prompt contains question words.
+ *
+ * Persistence: last-recall timestamp stored in ~/.nex/recall-state.json
+ */
+
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const DATA_DIR = join(homedir(), ".nex");
+const STATE_FILE = join(DATA_DIR, "recall-state.json");
+const DEBOUNCE_MS = 30_000; // 30 seconds
+
+// --- Question words that signal knowledge-seeking intent ---
+const QUESTION_WORDS = /\b(who|what|when|where|why|how|which|tell|explain|describe|summarize|summarise|list|find|show|get|any|does|did|is|are|was|were|have|has|do|can|could|should|would|will)\b/i;
+
+// --- Tool/action commands that are pure coding directives ---
+const TOOL_COMMANDS = /^\s*(run|build|test|lint|format|deploy|install|uninstall|start|stop|restart|commit|push|pull|merge|rebase|checkout|fetch|init|fix|refactor|rename|move|delete|remove|add|create|update|upgrade|downgrade|migrate|generate|scaffold|compile|bundle|watch|serve|debug|profile|bench|clean|reset|undo|redo|revert|squash|cherry-pick|tag|release|publish|npm|npx|yarn|pnpm|bun|pip|cargo|go|make|docker|kubectl|terraform|git|gh|cd|ls|cat|grep|find|mkdir|rm|cp|mv|touch|echo|export|source|chmod|chown|curl|wget|ssh|scp)\b/i;
+
+// --- File reference pattern (paths, extensions) ---
+const FILE_REF = /(?:[\w./\\-]+\.\w{1,10}|src\/|lib\/|dist\/|node_modules\/|\.\/|\.\.\/)/;
+
+// --- Code-heavy: >50% non-alpha characters (brackets, operators, etc.) ---
+function isCodeHeavy(text: string): boolean {
+  const alpha = text.replace(/[^a-zA-Z]/g, "").length;
+  return alpha < text.length * 0.5;
+}
+
+export interface RecallDecision {
+  shouldRecall: boolean;
+  reason: string;
+}
+
+interface RecallState {
+  lastRecallAt: number; // epoch ms
+  lastRecallSessionId?: string;
+}
+
+function readState(): RecallState {
+  try {
+    const raw = readFileSync(STATE_FILE, "utf-8");
+    return JSON.parse(raw) as RecallState;
+  } catch {
+    return { lastRecallAt: 0 };
+  }
+}
+
+function writeState(state: RecallState): void {
+  try {
+    mkdirSync(DATA_DIR, { recursive: true });
+    writeFileSync(STATE_FILE, JSON.stringify(state), "utf-8");
+  } catch {
+    // best-effort
+  }
+}
+
+/**
+ * Record that a successful recall just happened.
+ * Call this after a non-empty /ask response.
+ */
+export function recordRecall(sessionId?: string): void {
+  writeState({ lastRecallAt: Date.now(), lastRecallSessionId: sessionId });
+}
+
+/**
+ * Determine whether this prompt should trigger a Nex /ask recall.
+ */
+export function shouldRecall(prompt: string, isFirstPrompt: boolean): RecallDecision {
+  const trimmed = prompt.trim();
+
+  // Always recall on first prompt of session
+  if (isFirstPrompt) {
+    return { shouldRecall: true, reason: "first-prompt" };
+  }
+
+  // Explicit opt-out: prompt starts with !
+  if (trimmed.startsWith("!")) {
+    return { shouldRecall: false, reason: "opt-out" };
+  }
+
+  // Too short — likely a directive like "yes", "ok", "done"
+  if (trimmed.length < 15) {
+    return { shouldRecall: false, reason: "too-short" };
+  }
+
+  // Has question words — likely knowledge-seeking
+  const hasQuestion = QUESTION_WORDS.test(trimmed);
+
+  // Check debounce: skip if recent successful recall, unless question
+  if (!hasQuestion) {
+    const state = readState();
+    if (state.lastRecallAt > 0 && Date.now() - state.lastRecallAt < DEBOUNCE_MS) {
+      return { shouldRecall: false, reason: "debounce" };
+    }
+  }
+
+  // Tool/action commands — pure coding directives
+  if (TOOL_COMMANDS.test(trimmed) && !hasQuestion) {
+    return { shouldRecall: false, reason: "tool-command" };
+  }
+
+  // Code-heavy with file references and no question words
+  if (isCodeHeavy(trimmed) && FILE_REF.test(trimmed) && !hasQuestion) {
+    return { shouldRecall: false, reason: "code-prompt" };
+  }
+
+  // Has question words — always recall
+  if (hasQuestion) {
+    return { shouldRecall: true, reason: "question" };
+  }
+
+  // Default: recall (err on the side of providing context)
+  return { shouldRecall: true, reason: "default" };
+}

--- a/cli/src/plugin/session-store.ts
+++ b/cli/src/plugin/session-store.ts
@@ -1,0 +1,89 @@
+/**
+ * File-based session store mapping Claude Code session IDs to Nex session IDs.
+ *
+ * Since Claude Code hooks are short-lived processes (start, run, exit),
+ * in-memory state is lost between invocations. This implementation persists
+ * session mappings to a JSON file so multi-turn continuity works.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const DEFAULT_MAX = 100;
+const DEFAULT_DATA_DIR = join(homedir(), ".nex");
+
+export interface SessionStoreConfig {
+  maxSize: number;
+  dataDir: string;
+}
+
+export class SessionStore {
+  private filePath: string;
+  private maxSize: number;
+
+  constructor(config?: Partial<SessionStoreConfig>) {
+    const dataDir = config?.dataDir ?? DEFAULT_DATA_DIR;
+    this.maxSize = config?.maxSize ?? DEFAULT_MAX;
+    this.filePath = join(dataDir, "claude-sessions.json");
+    mkdirSync(dataDir, { recursive: true });
+  }
+
+  private readStore(): Record<string, string> {
+    try {
+      const raw = readFileSync(this.filePath, "utf-8");
+      const data = JSON.parse(raw);
+      if (data && typeof data === "object" && !Array.isArray(data)) {
+        return data as Record<string, string>;
+      }
+      return {};
+    } catch {
+      return {};
+    }
+  }
+
+  private writeStore(store: Record<string, string>): void {
+    try {
+      writeFileSync(this.filePath, JSON.stringify(store), "utf-8");
+    } catch {
+      // Best-effort — if we can't write, session continuity degrades gracefully
+    }
+  }
+
+  get(sessionKey: string): string | undefined {
+    const store = this.readStore();
+    return store[sessionKey];
+  }
+
+  set(sessionKey: string, nexSessionId: string): void {
+    const store = this.readStore();
+    store[sessionKey] = nexSessionId;
+
+    // Evict oldest entries if over max size
+    const keys = Object.keys(store);
+    while (keys.length > this.maxSize) {
+      const oldest = keys.shift()!;
+      delete store[oldest];
+    }
+
+    this.writeStore(store);
+  }
+
+  delete(sessionKey: string): boolean {
+    const store = this.readStore();
+    if (sessionKey in store) {
+      delete store[sessionKey];
+      this.writeStore(store);
+      return true;
+    }
+    return false;
+  }
+
+  get size(): number {
+    return Object.keys(this.readStore()).length;
+  }
+
+  clear(): void {
+    this.writeStore({});
+  }
+}

--- a/cli/tests/lib/recall-filter.test.ts
+++ b/cli/tests/lib/recall-filter.test.ts
@@ -1,8 +1,20 @@
-import { describe, it } from "node:test";
+import { describe, it, beforeEach } from "node:test";
 import assert from "node:assert/strict";
+import { writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
 import { shouldRecall } from "../../src/lib/recall-filter.js";
 
+const DATA_DIR = join(homedir(), ".nex");
+const STATE_FILE = join(DATA_DIR, "recall-state.json");
+
 describe("shouldRecall", () => {
+  // Reset recall state before each test to avoid debounce interference
+  beforeEach(() => {
+    mkdirSync(DATA_DIR, { recursive: true });
+    writeFileSync(STATE_FILE, JSON.stringify({ lastRecallAt: 0 }), "utf-8");
+  });
+
   it("always recalls on first prompt", () => {
     const result = shouldRecall("anything at all", true);
     assert.equal(result.shouldRecall, true);

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -11,6 +11,7 @@ import { registerNoteTools } from "./tools/notes.js";
 import { registerInsightTools } from "./tools/insights.js";
 import { registerRegistrationTools } from "./tools/register.js";
 import { registerScanTools } from "./tools/scan.js";
+import { registerIntegrationTools } from "./tools/integrations.js";
 
 export function createServer(apiKey?: string): McpServer {
   const server = new McpServer({
@@ -31,6 +32,7 @@ export function createServer(apiKey?: string): McpServer {
   registerNoteTools(server, client);
   registerInsightTools(server, client);
   registerScanTools(server, client);
+  registerIntegrationTools(server, client);
 
   return server;
 }

--- a/mcp/src/tools/integrations.ts
+++ b/mcp/src/tools/integrations.ts
@@ -1,0 +1,56 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { NexApiClient } from "../client.js";
+
+export function registerIntegrationTools(server: McpServer, client: NexApiClient) {
+  server.tool(
+    "list_integrations",
+    "List all available third-party integrations (Gmail, Slack, Salesforce, etc.) and their connection status for the current workspace.",
+    {},
+    { readOnlyHint: true },
+    async () => {
+      const result = await client.get("/v1/integrations/");
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "connect_integration",
+    "Start connecting a third-party integration via OAuth. Returns an auth_url to open in the browser and a connect_id to poll for status.",
+    {
+      type: z.enum(["email", "calendar", "crm", "messaging"]).describe("Integration type"),
+      provider: z.enum(["google", "microsoft", "attio", "slack", "salesforce", "hubspot"]).describe("Integration provider"),
+    },
+    { readOnlyHint: false },
+    async ({ type, provider }) => {
+      const result = await client.post(`/v1/integrations/${encodeURIComponent(type)}/${encodeURIComponent(provider)}/connect`);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "get_connect_status",
+    "Check the status of an in-progress OAuth connection. Poll this after connect_integration until status is 'connected'.",
+    {
+      connect_id: z.string().describe("Connect ID returned from connect_integration"),
+    },
+    { readOnlyHint: true },
+    async ({ connect_id }) => {
+      const result = await client.get(`/v1/integrations/connect/${encodeURIComponent(connect_id)}/status`);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "disconnect_integration",
+    "Disconnect a third-party integration by connection ID.",
+    {
+      connection_id: z.string().describe("Connection ID to disconnect"),
+    },
+    { readOnlyHint: false, destructiveHint: true },
+    async ({ connection_id }) => {
+      const result = await client.delete(`/v1/integrations/connections/${encodeURIComponent(connection_id)}`);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}

--- a/mcp/src/tools/integrations.ts
+++ b/mcp/src/tools/integrations.ts
@@ -5,7 +5,7 @@ import { NexApiClient } from "../client.js";
 export function registerIntegrationTools(server: McpServer, client: NexApiClient) {
   server.tool(
     "list_integrations",
-    "List all available third-party integrations (Gmail, Slack, Salesforce, etc.) and their connection status for the current workspace.",
+    "List all available third-party integrations (Gmail, Slack, Salesforce, etc.) and their connection status. To connect a new integration, use the connect_integration tool. To disconnect, use disconnect_integration with the connection ID shown in the results.",
     {},
     { readOnlyHint: true },
     async () => {
@@ -43,7 +43,7 @@ export function registerIntegrationTools(server: McpServer, client: NexApiClient
 
   server.tool(
     "disconnect_integration",
-    "Disconnect a third-party integration by connection ID.",
+    "Disconnect a third-party integration by connection ID. Get connection IDs from list_integrations.",
     {
       connection_id: z.string().describe("Connection ID to disconnect"),
     },

--- a/openclaw-plugin/src/config.ts
+++ b/openclaw-plugin/src/config.ts
@@ -58,7 +58,9 @@ export function parseConfig(raw?: Record<string, unknown>): NexPluginConfig {
     );
   }
 
-  const baseUrl = process.env.NEX_DEV_URL ?? "https://app.nex.ai";
+  let baseUrl = process.env.NEX_DEV_URL
+    ?? (typeof cfg.baseUrl === "string" ? resolveEnvVars(cfg.baseUrl).replace(/\/+$/, "") : undefined)
+    ?? DEFAULTS.baseUrl;
 
   const captureMode = cfg.captureMode as string | undefined;
   if (captureMode !== undefined && captureMode !== "last_turn" && captureMode !== "full_session") {

--- a/openclaw-plugin/src/index.ts
+++ b/openclaw-plugin/src/index.ts
@@ -389,6 +389,67 @@ const plugin = {
       },
     });
 
+    // --- Integration tools ---
+
+    const ListIntegrationsParams = Type.Object({});
+
+    api.registerTool({
+      name: "nex_list_integrations",
+      label: "List Integrations",
+      description: "List available third-party integrations and their connection status",
+      parameters: ListIntegrationsParams,
+      async execute(_toolCallId, _params) {
+        const result = await client.get("/v1/integrations/");
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
+      },
+    });
+
+    const ConnectIntegrationParams = Type.Object({
+      type: Type.String({ description: "Integration type: email, calendar, crm, messaging" }),
+      provider: Type.String({ description: "Provider: google, microsoft, attio, slack, salesforce, hubspot" }),
+    });
+
+    api.registerTool({
+      name: "nex_connect_integration",
+      label: "Connect Integration",
+      description: "Start connecting a third-party integration via OAuth. Returns an auth_url for the user to open.",
+      parameters: ConnectIntegrationParams,
+      async execute(_toolCallId, params) {
+        const { type, provider } = params as Static<typeof ConnectIntegrationParams>;
+        const result = await client.post(
+          `/v1/integrations/${encodeURIComponent(type)}/${encodeURIComponent(provider)}/connect`
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
+      },
+    });
+
+    const DisconnectIntegrationParams = Type.Object({
+      connection_id: Type.String({ description: "Connection ID to disconnect" }),
+    });
+
+    api.registerTool({
+      name: "nex_disconnect_integration",
+      label: "Disconnect Integration",
+      description: "Disconnect a third-party integration",
+      parameters: DisconnectIntegrationParams,
+      async execute(_toolCallId, params) {
+        const { connection_id } = params as Static<typeof DisconnectIntegrationParams>;
+        const result = await client.delete(
+          `/v1/integrations/connections/${encodeURIComponent(connection_id)}`
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
+      },
+    });
+
     // --- Commands ---
 
     api.registerCommand({

--- a/openclaw-plugin/src/index.ts
+++ b/openclaw-plugin/src/index.ts
@@ -450,6 +450,878 @@ const plugin = {
       },
     });
 
+    // --- Schema tools ---
+
+    const ListObjectsParams = Type.Object({
+      include_attributes: Type.Optional(Type.Boolean({ description: "Include attribute definitions in the response" })),
+    });
+
+    api.registerTool({
+      name: "nex_list_objects",
+      label: "List Object Types",
+      description: "List all object type definitions in the workspace. Call this first to discover available object types and their schemas.",
+      parameters: ListObjectsParams,
+      async execute(_toolCallId, params) {
+        const { include_attributes } = params as Static<typeof ListObjectsParams>;
+        const qs = new URLSearchParams();
+        if (include_attributes) qs.set("include_attributes", "true");
+        const q = qs.toString();
+        const result = await client.get(`/v1/objects${q ? `?${q}` : ""}`);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
+    const GetObjectParams = Type.Object({
+      slug: Type.String({ description: "Object type slug (e.g. 'person', 'company', 'deal')" }),
+    });
+
+    api.registerTool({
+      name: "nex_get_object",
+      label: "Get Object Type",
+      description: "Get a single object type definition with its attributes.",
+      parameters: GetObjectParams,
+      async execute(_toolCallId, params) {
+        const { slug } = params as Static<typeof GetObjectParams>;
+        const result = await client.get(`/v1/objects/${encodeURIComponent(slug)}`);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
+    const CreateObjectParams = Type.Object({
+      name: Type.String({ description: "Display name for the object type" }),
+      slug: Type.String({ description: "URL-safe identifier (lowercase, hyphens)" }),
+      name_plural: Type.Optional(Type.String({ description: "Plural display name" })),
+      description: Type.Optional(Type.String({ description: "Description of the object type" })),
+      type: Type.Optional(Type.String({ description: "Object category: person, company, custom, deal (default: custom)" })),
+    });
+
+    api.registerTool({
+      name: "nex_create_object",
+      label: "Create Object Type",
+      description: "Create a new custom object type definition (e.g. 'Project', 'Deal').",
+      parameters: CreateObjectParams,
+      async execute(_toolCallId, params) {
+        const { name, slug, name_plural, description, type } = params as Static<typeof CreateObjectParams>;
+        const body: Record<string, unknown> = { name, slug };
+        if (name_plural !== undefined) body.name_plural = name_plural;
+        if (description !== undefined) body.description = description;
+        if (type !== undefined) body.type = type;
+        const result = await client.post("/v1/objects", body);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
+    const UpdateObjectParams = Type.Object({
+      slug: Type.String({ description: "Object type slug to update" }),
+      name: Type.Optional(Type.String({ description: "New display name" })),
+      name_plural: Type.Optional(Type.String({ description: "New plural display name" })),
+      description: Type.Optional(Type.String({ description: "New description" })),
+    });
+
+    api.registerTool({
+      name: "nex_update_object",
+      label: "Update Object Type",
+      description: "Update an existing object type definition (name, description, plural name).",
+      parameters: UpdateObjectParams,
+      async execute(_toolCallId, params) {
+        const { slug, name, name_plural, description } = params as Static<typeof UpdateObjectParams>;
+        const body: Record<string, unknown> = {};
+        if (name !== undefined) body.name = name;
+        if (name_plural !== undefined) body.name_plural = name_plural;
+        if (description !== undefined) body.description = description;
+        const result = await client.patch(`/v1/objects/${encodeURIComponent(slug)}`, body);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
+    const DeleteObjectParams = Type.Object({
+      slug: Type.String({ description: "Object type slug to delete" }),
+    });
+
+    api.registerTool({
+      name: "nex_delete_object",
+      label: "Delete Object Type",
+      description: "Delete an object type definition and ALL its records. This is destructive and cannot be undone.",
+      parameters: DeleteObjectParams,
+      async execute(_toolCallId, params) {
+        const { slug } = params as Static<typeof DeleteObjectParams>;
+        const result = await client.delete(`/v1/objects/${encodeURIComponent(slug)}`);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
+    const CreateAttributeParams = Type.Object({
+      object_slug: Type.String({ description: "Object type slug to add the attribute to" }),
+      name: Type.String({ description: "Display name for the attribute" }),
+      slug: Type.String({ description: "URL-safe identifier for the attribute" }),
+      type: Type.String({ description: "Attribute data type: text, number, email, phone, url, date, boolean, currency, location, select, social_profile, domain, full_name" }),
+      description: Type.Optional(Type.String({ description: "Description of the attribute" })),
+      options: Type.Optional(Type.Object({
+        is_required: Type.Optional(Type.Boolean()),
+        is_unique: Type.Optional(Type.Boolean()),
+        is_multi_value: Type.Optional(Type.Boolean()),
+        use_raw_format: Type.Optional(Type.Boolean()),
+        is_whole_number: Type.Optional(Type.Boolean()),
+        select_options: Type.Optional(Type.Array(Type.Object({ name: Type.String() }))),
+      })),
+    });
+
+    api.registerTool({
+      name: "nex_create_attribute",
+      label: "Create Attribute",
+      description: "Add a new attribute (field) to an object type. Supports types: text, number, email, phone, url, date, boolean, currency, location, select, social_profile, domain, full_name.",
+      parameters: CreateAttributeParams,
+      async execute(_toolCallId, params) {
+        const { object_slug, name, slug, type, description, options } = params as Static<typeof CreateAttributeParams>;
+        const body: Record<string, unknown> = { name, slug, type };
+        if (description !== undefined) body.description = description;
+        if (options) body.options = options;
+        const result = await client.post(`/v1/objects/${encodeURIComponent(object_slug)}/attributes`, body);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
+    const UpdateAttributeParams = Type.Object({
+      object_slug: Type.String({ description: "Object type slug" }),
+      attribute_id: Type.String({ description: "Attribute ID to update" }),
+      name: Type.Optional(Type.String({ description: "New display name" })),
+      description: Type.Optional(Type.String({ description: "New description" })),
+      options: Type.Optional(Type.Object({
+        is_required: Type.Optional(Type.Boolean()),
+        select_options: Type.Optional(Type.Array(Type.Object({ name: Type.String() }))),
+        use_raw_format: Type.Optional(Type.Boolean()),
+        is_whole_number: Type.Optional(Type.Boolean()),
+      })),
+    });
+
+    api.registerTool({
+      name: "nex_update_attribute",
+      label: "Update Attribute",
+      description: "Update an existing attribute definition on an object type.",
+      parameters: UpdateAttributeParams,
+      async execute(_toolCallId, params) {
+        const { object_slug, attribute_id, name, description, options } = params as Static<typeof UpdateAttributeParams>;
+        const body: Record<string, unknown> = {};
+        if (name !== undefined) body.name = name;
+        if (description !== undefined) body.description = description;
+        if (options) body.options = options;
+        const result = await client.patch(`/v1/objects/${encodeURIComponent(object_slug)}/attributes/${encodeURIComponent(attribute_id)}`, body);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
+    const DeleteAttributeParams = Type.Object({
+      object_slug: Type.String({ description: "Object type slug" }),
+      attribute_id: Type.String({ description: "Attribute ID to delete" }),
+    });
+
+    api.registerTool({
+      name: "nex_delete_attribute",
+      label: "Delete Attribute",
+      description: "Delete an attribute from an object type. Removes the field and its data from all records. Cannot be undone.",
+      parameters: DeleteAttributeParams,
+      async execute(_toolCallId, params) {
+        const { object_slug, attribute_id } = params as Static<typeof DeleteAttributeParams>;
+        const result = await client.delete(`/v1/objects/${encodeURIComponent(object_slug)}/attributes/${encodeURIComponent(attribute_id)}`);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
+    // --- Record tools ---
+
+    const CreateRecordParams = Type.Object({
+      object_slug: Type.String({ description: "Object type slug (e.g. 'person', 'company')" }),
+      attributes: Type.Record(Type.String(), Type.Unknown(), { description: "Record attributes — must include 'name'" }),
+    });
+
+    api.registerTool({
+      name: "nex_create_record",
+      label: "Create Record",
+      description: "Create a new record for an object type. Use only when you have clean, structured data with known attribute slugs.",
+      parameters: CreateRecordParams,
+      async execute(_toolCallId, params) {
+        const { object_slug, attributes } = params as Static<typeof CreateRecordParams>;
+        const result = await client.post(`/v1/objects/${encodeURIComponent(object_slug)}`, { attributes });
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
+    const UpsertRecordParams = Type.Object({
+      object_slug: Type.String({ description: "Object type slug (e.g. 'person', 'company')" }),
+      matching_attribute: Type.String({ description: "Attribute slug or ID to match on for dedup (e.g. 'email')" }),
+      attributes: Type.Record(Type.String(), Type.Unknown(), { description: "Record attributes — must include 'name' when creating" }),
+    });
+
+    api.registerTool({
+      name: "nex_upsert_record",
+      label: "Upsert Record",
+      description: "Create a record if it doesn't exist, or update it if a match is found on the specified attribute. Useful for deduplication.",
+      parameters: UpsertRecordParams,
+      async execute(_toolCallId, params) {
+        const { object_slug, matching_attribute, attributes } = params as Static<typeof UpsertRecordParams>;
+        const result = await client.put(`/v1/objects/${encodeURIComponent(object_slug)}`, { matching_attribute, attributes });
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
+    const ListRecordsParams = Type.Object({
+      object_slug: Type.String({ description: "Object type slug (e.g. 'person', 'company')" }),
+      attributes: Type.Optional(Type.Union([
+        Type.String({ description: "'all', 'primary', or 'none'" }),
+        Type.Record(Type.String(), Type.Unknown()),
+      ])),
+      limit: Type.Optional(Type.Number({ description: "Number of records to return" })),
+      offset: Type.Optional(Type.Number({ description: "Pagination offset" })),
+      sort: Type.Optional(Type.Object({
+        attribute: Type.String({ description: "Attribute slug to sort by" }),
+        direction: Type.String({ description: "Sort direction: asc or desc" }),
+      })),
+    });
+
+    api.registerTool({
+      name: "nex_list_records",
+      label: "List Records",
+      description: "List records for an object type with optional filtering, sorting, and pagination.",
+      parameters: ListRecordsParams,
+      async execute(_toolCallId, params) {
+        const { object_slug, attributes, limit, offset, sort } = params as Static<typeof ListRecordsParams>;
+        const body: Record<string, unknown> = {};
+        if (attributes !== undefined) body.attributes = attributes;
+        if (limit !== undefined) body.limit = limit;
+        if (offset !== undefined) body.offset = offset;
+        if (sort) body.sort = sort;
+        const result = await client.post(`/v1/objects/${encodeURIComponent(object_slug)}/records`, body);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
+    const GetRecordParams = Type.Object({
+      record_id: Type.String({ description: "Record ID" }),
+    });
+
+    api.registerTool({
+      name: "nex_get_record",
+      label: "Get Record",
+      description: "Retrieve a specific record by its ID, including all its attributes.",
+      parameters: GetRecordParams,
+      async execute(_toolCallId, params) {
+        const { record_id } = params as Static<typeof GetRecordParams>;
+        const result = await client.get(`/v1/records/${encodeURIComponent(record_id)}`);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
+    const UpdateRecordParams = Type.Object({
+      record_id: Type.String({ description: "Record ID to update" }),
+      attributes: Type.Record(Type.String(), Type.Unknown(), { description: "Attributes to update (only provided fields are changed)" }),
+    });
+
+    api.registerTool({
+      name: "nex_update_record",
+      label: "Update Record",
+      description: "Update specific attributes on an existing record. Only the provided attributes are changed.",
+      parameters: UpdateRecordParams,
+      async execute(_toolCallId, params) {
+        const { record_id, attributes } = params as Static<typeof UpdateRecordParams>;
+        const result = await client.patch(`/v1/records/${encodeURIComponent(record_id)}`, { attributes });
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
+    const DeleteRecordParams = Type.Object({
+      record_id: Type.String({ description: "Record ID to delete" }),
+    });
+
+    api.registerTool({
+      name: "nex_delete_record",
+      label: "Delete Record",
+      description: "Permanently delete a record. This cannot be undone.",
+      parameters: DeleteRecordParams,
+      async execute(_toolCallId, params) {
+        const { record_id } = params as Static<typeof DeleteRecordParams>;
+        const result = await client.delete(`/v1/records/${encodeURIComponent(record_id)}`);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
+    const GetRecordTimelineParams = Type.Object({
+      record_id: Type.String({ description: "Record ID" }),
+      limit: Type.Optional(Type.Number({ description: "Max events (1-100, default: 50)" })),
+      cursor: Type.Optional(Type.String({ description: "Pagination cursor from previous response" })),
+    });
+
+    api.registerTool({
+      name: "nex_get_record_timeline",
+      label: "Get Record Timeline",
+      description: "Get paginated timeline events for a record (tasks, notes, attribute changes, etc.).",
+      parameters: GetRecordTimelineParams,
+      async execute(_toolCallId, params) {
+        const { record_id, limit, cursor } = params as Static<typeof GetRecordTimelineParams>;
+        const qs = new URLSearchParams();
+        if (limit !== undefined) qs.set("limit", String(limit));
+        if (cursor) qs.set("cursor", cursor);
+        const q = qs.toString();
+        const result = await client.get(`/v1/records/${encodeURIComponent(record_id)}/timeline${q ? `?${q}` : ""}`);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
+    // --- Search tools ---
+
+    const SearchRecordsParams = Type.Object({
+      query: Type.String({ description: "Search query (1-500 characters)" }),
+    });
+
+    api.registerTool({
+      name: "nex_search_records",
+      label: "Search Records",
+      description: "Search records by name across all object types. Returns matches grouped by object type with relevance scores.",
+      parameters: SearchRecordsParams,
+      async execute(_toolCallId, params) {
+        const { query } = params as Static<typeof SearchRecordsParams>;
+        const result = await client.post("/v1/search", { query });
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
+    // --- Relationship tools ---
+
+    const ListRelationshipDefsParams = Type.Object({});
+
+    api.registerTool({
+      name: "nex_list_relationship_defs",
+      label: "List Relationship Definitions",
+      description: "List all relationship type definitions in the workspace.",
+      parameters: ListRelationshipDefsParams,
+      async execute(_toolCallId, _params) {
+        const result = await client.get("/v1/relationships");
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
+    const CreateRelationshipDefParams = Type.Object({
+      type: Type.String({ description: "Relationship cardinality: one_to_one, one_to_many, many_to_many" }),
+      entity_definition_1_id: Type.String({ description: "First object definition ID" }),
+      entity_definition_2_id: Type.String({ description: "Second object definition ID" }),
+      entity_1_to_2_predicate: Type.Optional(Type.String({ description: "Label for 1→2 direction (e.g. 'works at')" })),
+      entity_2_to_1_predicate: Type.Optional(Type.String({ description: "Label for 2→1 direction (e.g. 'employs')" })),
+    });
+
+    api.registerTool({
+      name: "nex_create_relationship_def",
+      label: "Create Relationship Definition",
+      description: "Define a new relationship type between two object types (e.g. person 'works at' company).",
+      parameters: CreateRelationshipDefParams,
+      async execute(_toolCallId, params) {
+        const { type, entity_definition_1_id, entity_definition_2_id, entity_1_to_2_predicate, entity_2_to_1_predicate } = params as Static<typeof CreateRelationshipDefParams>;
+        const body: Record<string, unknown> = { type, entity_definition_1_id, entity_definition_2_id };
+        if (entity_1_to_2_predicate !== undefined) body.entity_1_to_2_predicate = entity_1_to_2_predicate;
+        if (entity_2_to_1_predicate !== undefined) body.entity_2_to_1_predicate = entity_2_to_1_predicate;
+        const result = await client.post("/v1/relationships", body);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
+    const DeleteRelationshipDefParams = Type.Object({
+      id: Type.String({ description: "Relationship definition ID to delete" }),
+    });
+
+    api.registerTool({
+      name: "nex_delete_relationship_def",
+      label: "Delete Relationship Definition",
+      description: "Delete a relationship type definition. Removes all instances of this relationship. Cannot be undone.",
+      parameters: DeleteRelationshipDefParams,
+      async execute(_toolCallId, params) {
+        const { id } = params as Static<typeof DeleteRelationshipDefParams>;
+        const result = await client.delete(`/v1/relationships/${encodeURIComponent(id)}`);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
+    const CreateRelationshipParams = Type.Object({
+      record_id: Type.String({ description: "Record ID to create the relationship from" }),
+      definition_id: Type.String({ description: "Relationship definition ID" }),
+      entity_1_id: Type.String({ description: "First record ID" }),
+      entity_2_id: Type.String({ description: "Second record ID" }),
+    });
+
+    api.registerTool({
+      name: "nex_create_relationship",
+      label: "Create Relationship",
+      description: "Link two records using an existing relationship definition.",
+      parameters: CreateRelationshipParams,
+      async execute(_toolCallId, params) {
+        const { record_id, definition_id, entity_1_id, entity_2_id } = params as Static<typeof CreateRelationshipParams>;
+        const result = await client.post(`/v1/records/${encodeURIComponent(record_id)}/relationships`, {
+          definition_id,
+          entity_1_id,
+          entity_2_id,
+        });
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
+    const DeleteRelationshipParams = Type.Object({
+      record_id: Type.String({ description: "Record ID" }),
+      relationship_id: Type.String({ description: "Relationship instance ID to delete" }),
+    });
+
+    api.registerTool({
+      name: "nex_delete_relationship",
+      label: "Delete Relationship",
+      description: "Remove a relationship between two records. Cannot be undone.",
+      parameters: DeleteRelationshipParams,
+      async execute(_toolCallId, params) {
+        const { record_id, relationship_id } = params as Static<typeof DeleteRelationshipParams>;
+        const result = await client.delete(`/v1/records/${encodeURIComponent(record_id)}/relationships/${encodeURIComponent(relationship_id)}`);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
+    // --- List tools ---
+
+    const ListListsParams = Type.Object({
+      object_slug: Type.String({ description: "Object type slug (e.g. 'person', 'company')" }),
+      include_attributes: Type.Optional(Type.Boolean({ description: "Include attribute definitions" })),
+    });
+
+    api.registerTool({
+      name: "nex_list_lists",
+      label: "List Object Lists",
+      description: "Get all lists associated with an object type.",
+      parameters: ListListsParams,
+      async execute(_toolCallId, params) {
+        const { object_slug, include_attributes } = params as Static<typeof ListListsParams>;
+        const qs = new URLSearchParams();
+        if (include_attributes) qs.set("include_attributes", "true");
+        const q = qs.toString();
+        const result = await client.get(`/v1/objects/${encodeURIComponent(object_slug)}/lists${q ? `?${q}` : ""}`);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
+    const CreateListParams = Type.Object({
+      object_slug: Type.String({ description: "Object type slug" }),
+      name: Type.String({ description: "List display name" }),
+      slug: Type.String({ description: "URL-safe identifier" }),
+      name_plural: Type.Optional(Type.String({ description: "Plural name" })),
+      description: Type.Optional(Type.String({ description: "List description" })),
+    });
+
+    api.registerTool({
+      name: "nex_create_list",
+      label: "Create List",
+      description: "Create a new list under an object type.",
+      parameters: CreateListParams,
+      async execute(_toolCallId, params) {
+        const { object_slug, name, slug, name_plural, description } = params as Static<typeof CreateListParams>;
+        const body: Record<string, unknown> = { name, slug };
+        if (name_plural !== undefined) body.name_plural = name_plural;
+        if (description !== undefined) body.description = description;
+        const result = await client.post(`/v1/objects/${encodeURIComponent(object_slug)}/lists`, body);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
+    const GetListParams = Type.Object({
+      list_id: Type.String({ description: "List ID" }),
+    });
+
+    api.registerTool({
+      name: "nex_get_list",
+      label: "Get List",
+      description: "Get a list definition by ID.",
+      parameters: GetListParams,
+      async execute(_toolCallId, params) {
+        const { list_id } = params as Static<typeof GetListParams>;
+        const result = await client.get(`/v1/lists/${encodeURIComponent(list_id)}`);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
+    const DeleteListParams = Type.Object({
+      list_id: Type.String({ description: "List ID to delete" }),
+    });
+
+    api.registerTool({
+      name: "nex_delete_list",
+      label: "Delete List",
+      description: "Delete a list definition. Cannot be undone.",
+      parameters: DeleteListParams,
+      async execute(_toolCallId, params) {
+        const { list_id } = params as Static<typeof DeleteListParams>;
+        const result = await client.delete(`/v1/lists/${encodeURIComponent(list_id)}`);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
+    const AddListMemberParams = Type.Object({
+      list_id: Type.String({ description: "List ID" }),
+      parent_id: Type.String({ description: "ID of the existing record to add" }),
+      attributes: Type.Optional(Type.Record(Type.String(), Type.Unknown(), { description: "List-specific attribute values" })),
+    });
+
+    api.registerTool({
+      name: "nex_add_list_member",
+      label: "Add List Member",
+      description: "Add an existing record to a list with optional list-specific attributes.",
+      parameters: AddListMemberParams,
+      async execute(_toolCallId, params) {
+        const { list_id, parent_id, attributes } = params as Static<typeof AddListMemberParams>;
+        const body: Record<string, unknown> = { parent_id };
+        if (attributes) body.attributes = attributes;
+        const result = await client.post(`/v1/lists/${encodeURIComponent(list_id)}`, body);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
+    const UpsertListMemberParams = Type.Object({
+      list_id: Type.String({ description: "List ID" }),
+      parent_id: Type.String({ description: "ID of the record" }),
+      attributes: Type.Optional(Type.Record(Type.String(), Type.Unknown(), { description: "List-specific attribute values" })),
+    });
+
+    api.registerTool({
+      name: "nex_upsert_list_member",
+      label: "Upsert List Member",
+      description: "Add a record to a list, or update its list-specific attributes if already a member.",
+      parameters: UpsertListMemberParams,
+      async execute(_toolCallId, params) {
+        const { list_id, parent_id, attributes } = params as Static<typeof UpsertListMemberParams>;
+        const body: Record<string, unknown> = { parent_id };
+        if (attributes) body.attributes = attributes;
+        const result = await client.put(`/v1/lists/${encodeURIComponent(list_id)}`, body);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
+    const ListListRecordsParams = Type.Object({
+      list_id: Type.String({ description: "List ID" }),
+      attributes: Type.Optional(Type.Union([
+        Type.String({ description: "'all', 'primary', or 'none'" }),
+        Type.Record(Type.String(), Type.Unknown()),
+      ])),
+      limit: Type.Optional(Type.Number({ description: "Number of records to return" })),
+      offset: Type.Optional(Type.Number({ description: "Pagination offset" })),
+      sort: Type.Optional(Type.Object({
+        attribute: Type.String({ description: "Attribute slug to sort by" }),
+        direction: Type.String({ description: "Sort direction: asc or desc" }),
+      })),
+    });
+
+    api.registerTool({
+      name: "nex_list_list_records",
+      label: "List List Records",
+      description: "Get paginated records from a specific list.",
+      parameters: ListListRecordsParams,
+      async execute(_toolCallId, params) {
+        const { list_id, attributes, limit, offset, sort } = params as Static<typeof ListListRecordsParams>;
+        const body: Record<string, unknown> = {};
+        if (attributes !== undefined) body.attributes = attributes;
+        if (limit !== undefined) body.limit = limit;
+        if (offset !== undefined) body.offset = offset;
+        if (sort) body.sort = sort;
+        const result = await client.post(`/v1/lists/${encodeURIComponent(list_id)}/records`, body);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
+    const UpdateListRecordParams = Type.Object({
+      list_id: Type.String({ description: "List ID" }),
+      record_id: Type.String({ description: "Record ID within the list" }),
+      attributes: Type.Record(Type.String(), Type.Unknown(), { description: "Attributes to update" }),
+    });
+
+    api.registerTool({
+      name: "nex_update_list_record",
+      label: "Update List Record",
+      description: "Update list-specific attributes for a record within a list.",
+      parameters: UpdateListRecordParams,
+      async execute(_toolCallId, params) {
+        const { list_id, record_id, attributes } = params as Static<typeof UpdateListRecordParams>;
+        const result = await client.patch(`/v1/lists/${encodeURIComponent(list_id)}/records/${encodeURIComponent(record_id)}`, { attributes });
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
+    const RemoveListRecordParams = Type.Object({
+      list_id: Type.String({ description: "List ID" }),
+      record_id: Type.String({ description: "Record ID to remove from the list" }),
+    });
+
+    api.registerTool({
+      name: "nex_remove_list_record",
+      label: "Remove List Record",
+      description: "Remove a record from a list. The record itself is not deleted.",
+      parameters: RemoveListRecordParams,
+      async execute(_toolCallId, params) {
+        const { list_id, record_id } = params as Static<typeof RemoveListRecordParams>;
+        const result = await client.delete(`/v1/lists/${encodeURIComponent(list_id)}/records/${encodeURIComponent(record_id)}`);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
+    // --- Task tools ---
+
+    const CreateTaskParams = Type.Object({
+      title: Type.String({ description: "Task title" }),
+      description: Type.Optional(Type.String({ description: "Task description" })),
+      priority: Type.Optional(Type.String({ description: "Task priority: low, medium, high, urgent" })),
+      due_date: Type.Optional(Type.String({ description: "Due date in RFC3339 format" })),
+      entity_ids: Type.Optional(Type.Array(Type.String({ description: "Record ID" }))),
+      assignee_ids: Type.Optional(Type.Array(Type.String({ description: "User ID" }))),
+    });
+
+    api.registerTool({
+      name: "nex_create_task",
+      label: "Create Task",
+      description: "Create a new task, optionally linked to records and assigned to users.",
+      parameters: CreateTaskParams,
+      async execute(_toolCallId, params) {
+        const { title, description, priority, due_date, entity_ids, assignee_ids } = params as Static<typeof CreateTaskParams>;
+        const body: Record<string, unknown> = { title };
+        if (description !== undefined) body.description = description;
+        if (priority !== undefined) body.priority = priority;
+        if (due_date !== undefined) body.due_date = due_date;
+        if (entity_ids) body.entity_ids = entity_ids;
+        if (assignee_ids) body.assignee_ids = assignee_ids;
+        const result = await client.post("/v1/tasks", body);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
+    const ListTasksParams = Type.Object({
+      entity_id: Type.Optional(Type.String({ description: "Filter by associated record ID" })),
+      assignee_id: Type.Optional(Type.String({ description: "Filter by assignee user ID" })),
+      search: Type.Optional(Type.String({ description: "Search task titles" })),
+      is_completed: Type.Optional(Type.Boolean({ description: "Filter by completion status" })),
+      limit: Type.Optional(Type.Number({ description: "Max results (1-500, default: 100)" })),
+      offset: Type.Optional(Type.Number({ description: "Pagination offset" })),
+    });
+
+    api.registerTool({
+      name: "nex_list_tasks",
+      label: "List Tasks",
+      description: "List tasks with optional filtering by record, assignee, completion status, or search query.",
+      parameters: ListTasksParams,
+      async execute(_toolCallId, params) {
+        const { entity_id, assignee_id, search, is_completed, limit, offset } = params as Static<typeof ListTasksParams>;
+        const qs = new URLSearchParams();
+        if (entity_id) qs.set("entity_id", entity_id);
+        if (assignee_id) qs.set("assignee_id", assignee_id);
+        if (search) qs.set("search", search);
+        if (is_completed !== undefined) qs.set("is_completed", String(is_completed));
+        if (limit !== undefined) qs.set("limit", String(limit));
+        if (offset !== undefined) qs.set("offset", String(offset));
+        const q = qs.toString();
+        const result = await client.get(`/v1/tasks${q ? `?${q}` : ""}`);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
+    const GetTaskParams = Type.Object({
+      task_id: Type.String({ description: "Task ID" }),
+    });
+
+    api.registerTool({
+      name: "nex_get_task",
+      label: "Get Task",
+      description: "Get a single task by ID.",
+      parameters: GetTaskParams,
+      async execute(_toolCallId, params) {
+        const { task_id } = params as Static<typeof GetTaskParams>;
+        const result = await client.get(`/v1/tasks/${encodeURIComponent(task_id)}`);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
+    const UpdateTaskParams = Type.Object({
+      task_id: Type.String({ description: "Task ID to update" }),
+      title: Type.Optional(Type.String({ description: "New title" })),
+      description: Type.Optional(Type.String({ description: "New description" })),
+      priority: Type.Optional(Type.String({ description: "New priority" })),
+      due_date: Type.Optional(Type.String({ description: "New due date in RFC3339 format" })),
+      is_completed: Type.Optional(Type.Boolean({ description: "Mark complete/incomplete" })),
+      entity_ids: Type.Optional(Type.Array(Type.String({ description: "Record ID" }))),
+      assignee_ids: Type.Optional(Type.Array(Type.String({ description: "User ID" }))),
+    });
+
+    api.registerTool({
+      name: "nex_update_task",
+      label: "Update Task",
+      description: "Update a task's fields. All fields are optional — only provided fields are changed.",
+      parameters: UpdateTaskParams,
+      async execute(_toolCallId, params) {
+        const { task_id, title, description, priority, due_date, is_completed, entity_ids, assignee_ids } = params as Static<typeof UpdateTaskParams>;
+        const body: Record<string, unknown> = {};
+        if (title !== undefined) body.title = title;
+        if (description !== undefined) body.description = description;
+        if (priority !== undefined) body.priority = priority;
+        if (due_date !== undefined) body.due_date = due_date;
+        if (is_completed !== undefined) body.is_completed = is_completed;
+        if (entity_ids !== undefined) body.entity_ids = entity_ids;
+        if (assignee_ids !== undefined) body.assignee_ids = assignee_ids;
+        const result = await client.patch(`/v1/tasks/${encodeURIComponent(task_id)}`, body);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
+    const DeleteTaskParams = Type.Object({
+      task_id: Type.String({ description: "Task ID to delete" }),
+    });
+
+    api.registerTool({
+      name: "nex_delete_task",
+      label: "Delete Task",
+      description: "Archive a task (soft delete). Cannot be undone via API.",
+      parameters: DeleteTaskParams,
+      async execute(_toolCallId, params) {
+        const { task_id } = params as Static<typeof DeleteTaskParams>;
+        const result = await client.delete(`/v1/tasks/${encodeURIComponent(task_id)}`);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
+    // --- Note tools ---
+
+    const CreateNoteParams = Type.Object({
+      title: Type.String({ description: "Note title" }),
+      content: Type.Optional(Type.String({ description: "Note body text" })),
+      entity_id: Type.Optional(Type.String({ description: "Associated record ID" })),
+    });
+
+    api.registerTool({
+      name: "nex_create_note",
+      label: "Create Note",
+      description: "Create a new note, optionally linked to a record.",
+      parameters: CreateNoteParams,
+      async execute(_toolCallId, params) {
+        const { title, content, entity_id } = params as Static<typeof CreateNoteParams>;
+        const body: Record<string, unknown> = { title };
+        if (content !== undefined) body.content = content;
+        if (entity_id !== undefined) body.entity_id = entity_id;
+        const result = await client.post("/v1/notes", body);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
+    const ListNotesParams = Type.Object({
+      entity_id: Type.Optional(Type.String({ description: "Filter notes by associated record ID" })),
+    });
+
+    api.registerTool({
+      name: "nex_list_notes",
+      label: "List Notes",
+      description: "List notes, optionally filtered by associated record.",
+      parameters: ListNotesParams,
+      async execute(_toolCallId, params) {
+        const { entity_id } = params as Static<typeof ListNotesParams>;
+        const qs = new URLSearchParams();
+        if (entity_id) qs.set("entity_id", entity_id);
+        const q = qs.toString();
+        const result = await client.get(`/v1/notes${q ? `?${q}` : ""}`);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
+    const GetNoteParams = Type.Object({
+      note_id: Type.String({ description: "Note ID" }),
+    });
+
+    api.registerTool({
+      name: "nex_get_note",
+      label: "Get Note",
+      description: "Get a single note by ID.",
+      parameters: GetNoteParams,
+      async execute(_toolCallId, params) {
+        const { note_id } = params as Static<typeof GetNoteParams>;
+        const result = await client.get(`/v1/notes/${encodeURIComponent(note_id)}`);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
+    const UpdateNoteParams = Type.Object({
+      note_id: Type.String({ description: "Note ID to update" }),
+      title: Type.Optional(Type.String({ description: "New title" })),
+      content: Type.Optional(Type.String({ description: "New content" })),
+      entity_id: Type.Optional(Type.String({ description: "Change associated record" })),
+    });
+
+    api.registerTool({
+      name: "nex_update_note",
+      label: "Update Note",
+      description: "Update a note's fields. All fields are optional — only provided fields are changed.",
+      parameters: UpdateNoteParams,
+      async execute(_toolCallId, params) {
+        const { note_id, title, content, entity_id } = params as Static<typeof UpdateNoteParams>;
+        const body: Record<string, unknown> = {};
+        if (title !== undefined) body.title = title;
+        if (content !== undefined) body.content = content;
+        if (entity_id !== undefined) body.entity_id = entity_id;
+        const result = await client.patch(`/v1/notes/${encodeURIComponent(note_id)}`, body);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
+    const DeleteNoteParams = Type.Object({
+      note_id: Type.String({ description: "Note ID to delete" }),
+    });
+
+    api.registerTool({
+      name: "nex_delete_note",
+      label: "Delete Note",
+      description: "Archive a note (soft delete). Cannot be undone via API.",
+      parameters: DeleteNoteParams,
+      async execute(_toolCallId, params) {
+        const { note_id } = params as Static<typeof DeleteNoteParams>;
+        const result = await client.delete(`/v1/notes/${encodeURIComponent(note_id)}`);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
+    // --- Context tools ---
+
+    const GetArtifactStatusParams = Type.Object({
+      artifact_id: Type.String({ description: "The artifact ID returned by nex_remember or add_context" }),
+    });
+
+    api.registerTool({
+      name: "nex_get_artifact_status",
+      label: "Get Artifact Status",
+      description: "Check the processing status and results of a previously submitted text artifact. Poll until status is 'completed' or 'failed'.",
+      parameters: GetArtifactStatusParams,
+      async execute(_toolCallId, params) {
+        const { artifact_id } = params as Static<typeof GetArtifactStatusParams>;
+        const result = await client.get(`/v1/context/artifacts/${encodeURIComponent(artifact_id)}`);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
+    const GetInsightsParams = Type.Object({
+      last: Type.Optional(Type.String({ description: "Duration window, e.g. '30m', '2h', '1h30m'" })),
+      from: Type.Optional(Type.String({ description: "Start of time range in RFC3339 format" })),
+      to: Type.Optional(Type.String({ description: "End of time range in RFC3339 format" })),
+      limit: Type.Optional(Type.Number({ description: "Max results (default: 20, max: 100)" })),
+    });
+
+    api.registerTool({
+      name: "nex_get_insights",
+      label: "Get Insights",
+      description: "Query insights by time window. Returns discovered opportunities, risks, relationship changes, milestones, and other insights.",
+      parameters: GetInsightsParams,
+      async execute(_toolCallId, params) {
+        const { last, from, to, limit } = params as Static<typeof GetInsightsParams>;
+        const qs = new URLSearchParams();
+        if (last) qs.set("last", last);
+        if (from) qs.set("from", from);
+        if (to) qs.set("to", to);
+        if (limit !== undefined) qs.set("limit", String(limit));
+        const q = qs.toString();
+        const result = await client.get(`/v1/insights${q ? `?${q}` : ""}`);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+      },
+    });
+
     // --- Commands ---
 
     api.registerCommand({

--- a/openclaw-plugin/src/index.ts
+++ b/openclaw-plugin/src/index.ts
@@ -396,7 +396,7 @@ const plugin = {
     api.registerTool({
       name: "nex_list_integrations",
       label: "List Integrations",
-      description: "List available third-party integrations and their connection status",
+      description: "List available third-party integrations and their connection status. Use nex_connect_integration to connect new ones, or nex_disconnect_integration with a connection ID to remove.",
       parameters: ListIntegrationsParams,
       async execute(_toolCallId, _params) {
         const result = await client.get("/v1/integrations/");
@@ -415,7 +415,7 @@ const plugin = {
     api.registerTool({
       name: "nex_connect_integration",
       label: "Connect Integration",
-      description: "Start connecting a third-party integration via OAuth. Returns an auth_url for the user to open.",
+      description: "Start connecting a third-party integration via OAuth. Returns an auth_url for the user to open in their browser. Types: email, calendar, crm, messaging. Providers: google, microsoft, attio, slack, salesforce, hubspot.",
       parameters: ConnectIntegrationParams,
       async execute(_toolCallId, params) {
         const { type, provider } = params as Static<typeof ConnectIntegrationParams>;
@@ -436,7 +436,7 @@ const plugin = {
     api.registerTool({
       name: "nex_disconnect_integration",
       label: "Disconnect Integration",
-      description: "Disconnect a third-party integration",
+      description: "Disconnect a third-party integration by connection ID. Get connection IDs from nex_list_integrations.",
       parameters: DisconnectIntegrationParams,
       async execute(_toolCallId, params) {
         const { connection_id } = params as Static<typeof DisconnectIntegrationParams>;

--- a/openclaw-plugin/src/nex-client.ts
+++ b/openclaw-plugin/src/nex-client.ts
@@ -115,6 +115,21 @@ export class NexClient {
     }
   }
 
+  /** Generic GET request. */
+  async get<T = unknown>(path: string, timeoutMs?: number): Promise<T> {
+    return this.request<T>("GET", path, undefined, timeoutMs);
+  }
+
+  /** Generic POST request. */
+  async post<T = unknown>(path: string, body?: unknown, timeoutMs?: number): Promise<T> {
+    return this.request<T>("POST", path, body, timeoutMs);
+  }
+
+  /** Generic DELETE request. */
+  async delete<T = unknown>(path: string, timeoutMs?: number): Promise<T> {
+    return this.request<T>("DELETE", path, undefined, timeoutMs);
+  }
+
   /** Ingest text content into the Nex knowledge graph. */
   async ingest(content: string, context?: string): Promise<IngestResponse> {
     const body: Record<string, string> = { content };

--- a/openclaw-plugin/src/nex-client.ts
+++ b/openclaw-plugin/src/nex-client.ts
@@ -130,6 +130,16 @@ export class NexClient {
     return this.request<T>("DELETE", path, undefined, timeoutMs);
   }
 
+  /** Generic PATCH request. */
+  async patch<T = unknown>(path: string, body?: unknown, timeoutMs?: number): Promise<T> {
+    return this.request<T>("PATCH", path, body, timeoutMs);
+  }
+
+  /** Generic PUT request. */
+  async put<T = unknown>(path: string, body?: unknown, timeoutMs?: number): Promise<T> {
+    return this.request<T>("PUT", path, body, timeoutMs);
+  }
+
   /** Ingest text content into the Nex knowledge graph. */
   async ingest(content: string, context?: string): Promise<IngestResponse> {
     const body: Record<string, string> = { content };

--- a/openclaw-plugin/tests/index.test.ts
+++ b/openclaw-plugin/tests/index.test.ts
@@ -18,7 +18,7 @@ describe("config", () => {
   it("parses valid config", () => {
     const cfg = parseConfig({ apiKey: "sk-test-123" });
     expect(cfg.apiKey).toBe("sk-test-123");
-    expect(cfg.baseUrl).toBe("https://api.nex-crm.com");
+    expect(cfg.baseUrl).toBe("https://app.nex.ai");
     expect(cfg.autoRecall).toBe(true);
     expect(cfg.autoCapture).toBe(true);
     expect(cfg.captureMode).toBe("last_turn");


### PR DESCRIPTION
## Summary

- **OpenClaw plugin**: Add 42 new tools (schema, records, search, relationships, lists, tasks, notes, context/insights), bringing total from 7 to 49. Add `patch()`/`put()` to NexClient. Fix `baseUrl` config resolution bug.
- **Claude Code plugin**: Add 20 new slash commands covering all API groups (schema, records, search, relationships, lists, tasks, notes, insights, artifact status)
- **SKILL.md**: Add Integrations section with list/connect/status/disconnect endpoint docs
- **CLI**: Integration commands (`nex integrate list|connect|disconnect`), `nex setup` with multi-platform support, Claude Code plugin bundling
- **MCP server**: Integration tools for OAuth flows

## Test plan

- [x] `openclaw-plugin`: `npm run build` — tsc clean, `npm test` — 38/38 pass
- [x] `cli`: `npm run build` — tsc clean, `npm test` — 65/65 pass
- [x] `mcp`: `npm run build` — tsc clean
- [ ] Manual: `nex setup` installs 26 slash commands to `~/.claude/commands/`
- [ ] Manual: Test `/schema`, `/search`, `/create-task`, `/insights` in Claude Code
- [ ] Manual: Verify OpenClaw plugin loads with 49 tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)