### PR TITLE
feat: add 20 Claude Code slash commands for full API parity

### DIFF
--- a/cli/plugin-commands/add-field.md
+++ b/cli/plugin-commands/add-field.md
@@ -1,0 +1,12 @@
+---
+description: Add a field (attribute) to an object type
+---
+Add a field to an object type: $ARGUMENTS
+
+If insufficient arguments, respond: "Usage: /add-field <object_slug> <field_name> <field_type> [--required] [--label <label>]"
+
+Supported field types: text, number, email, phone, url, date, datetime, boolean, select, multi_select, currency, rich_text.
+
+Parse the object slug, field name, type, and optional flags from arguments.
+Use the `mcp__nex__create_attribute` tool with the parsed parameters.
+Confirm the field was added successfully.

--- a/cli/plugin-commands/artifact.md
+++ b/cli/plugin-commands/artifact.md
@@ -1,0 +1,14 @@
+---
+description: Check processing status of an ingested artifact
+---
+Check artifact status: $ARGUMENTS
+
+If no artifact ID provided, respond: "Usage: /artifact <artifact_id>"
+
+Use the `mcp__nex__get_artifact_status` tool with the provided artifact_id.
+
+Show:
+- **Status**: processing state (pending, processing, completed, failed)
+- **Extracted entities**: list if available
+- **Relationships**: list if available
+- **Error**: details if status is failed

--- a/cli/plugin-commands/create-note.md
+++ b/cli/plugin-commands/create-note.md
@@ -1,0 +1,10 @@
+---
+description: Create a new note
+---
+Create a note: $ARGUMENTS
+
+If no title provided, respond: "Usage: /create-note <title> [--content <body>] [--entity <entity_id>]"
+
+Parse the title and optional content/entity from arguments.
+Use the `mcp__nex__create_note` tool with the parsed parameters.
+Confirm creation with the note ID and details.

--- a/cli/plugin-commands/create-object.md
+++ b/cli/plugin-commands/create-object.md
@@ -1,0 +1,10 @@
+---
+description: Create a new object type definition
+---
+Create a new object type: $ARGUMENTS
+
+If no name provided, respond: "Usage: /create-object <object name> [--plural <plural name>] [--description <description>]"
+
+Parse the arguments for the object name, optional plural name, and description.
+Use the `mcp__nex__create_object` tool with the parsed parameters.
+Confirm creation with the returned slug and details.

--- a/cli/plugin-commands/create-record.md
+++ b/cli/plugin-commands/create-record.md
@@ -1,0 +1,11 @@
+---
+description: Create a new record
+---
+Create a new record: $ARGUMENTS
+
+If insufficient arguments, respond: "Usage: /create-record <object_slug> <field=value> [field=value ...]"
+Example: /create-record contacts name="Jane Doe" email="jane@example.com"
+
+Parse the object slug and field key=value pairs from arguments.
+Use the `mcp__nex__create_record` tool with object_slug and the attributes object.
+Confirm creation with the returned record ID and details.

--- a/cli/plugin-commands/create-task.md
+++ b/cli/plugin-commands/create-task.md
@@ -1,0 +1,10 @@
+---
+description: Create a new task
+---
+Create a task: $ARGUMENTS
+
+If no title provided, respond: "Usage: /create-task <title> [--due <date>] [--priority <low|medium|high>] [--entity <entity_id>]"
+
+Parse the title and optional flags from arguments.
+Use the `mcp__nex__create_task` tool with the parsed parameters.
+Confirm creation with the task ID and details.

--- a/cli/plugin-commands/insights.md
+++ b/cli/plugin-commands/insights.md
@@ -1,0 +1,13 @@
+---
+description: Get recent insights from the context graph
+---
+Get insights: $ARGUMENTS
+
+Use the `mcp__nex__get_insights` tool. If $ARGUMENTS specifies a time window (e.g. "2h", "1d", "30m"), use it as the `last` parameter. Default to "1h" if not specified.
+
+Format each insight as:
+- **Type**: insight content
+  - Confidence: X% | Source entities
+  - Timestamp
+
+If no insights found, respond: "No recent insights found in the specified time window."

--- a/cli/plugin-commands/link-records.md
+++ b/cli/plugin-commands/link-records.md
@@ -1,0 +1,10 @@
+---
+description: Link two records with a relationship
+---
+Link records: $ARGUMENTS
+
+If insufficient arguments, respond: "Usage: /link-records <definition_id> <source_record_id> <target_record_id>"
+
+Parse the relationship definition ID, source record ID, and target record ID from arguments.
+Use the `mcp__nex__create_relationship` tool with the parsed parameters.
+Confirm the relationship was created.

--- a/cli/plugin-commands/list-members.md
+++ b/cli/plugin-commands/list-members.md
@@ -1,0 +1,15 @@
+---
+description: View records in a list
+---
+Show list members: $ARGUMENTS
+
+If no list ID provided, respond: "Usage: /list-members <list_id>"
+
+Use the `mcp__nex__list_list_records` tool with the provided list_id.
+
+Format results as a table showing:
+- Record name/title
+- Key attributes
+- Date added to list
+
+If no members found, respond: "This list has no members."

--- a/cli/plugin-commands/lists.md
+++ b/cli/plugin-commands/lists.md
@@ -1,0 +1,14 @@
+---
+description: View lists for an object type
+---
+Show lists for: $ARGUMENTS
+
+If no object slug provided, respond: "Usage: /lists <object_slug>"
+
+Use the `mcp__nex__list_object_lists` tool with the provided object_slug.
+
+Format each list as:
+- **List Name** (ID: `list_id`)
+  - Description and member count if available
+
+If no lists found, respond: "No lists found for this object type."

--- a/cli/plugin-commands/notes.md
+++ b/cli/plugin-commands/notes.md
@@ -1,0 +1,13 @@
+---
+description: List notes, optionally for a specific record
+---
+List notes: $ARGUMENTS
+
+Use the `mcp__nex__list_notes` tool. If $ARGUMENTS is provided, use it as an entity_id filter to show notes for that specific record.
+
+Format each note as:
+- **Title** (ID: `note_id`, Created: date)
+  - Content preview (first 100 chars)
+  - Linked entity if applicable
+
+If no notes found, respond: "No notes found."

--- a/cli/plugin-commands/record.md
+++ b/cli/plugin-commands/record.md
@@ -1,0 +1,12 @@
+---
+description: Get a record by ID
+---
+Get record: $ARGUMENTS
+
+If no record ID provided, respond: "Usage: /record <record_id>"
+
+Use the `mcp__nex__get_record` tool with the provided record_id.
+Format the record as:
+- **Name** (Type: `object_type`)
+- All attributes in a readable key-value list
+- Show created_at and updated_at timestamps

--- a/cli/plugin-commands/relationships.md
+++ b/cli/plugin-commands/relationships.md
@@ -1,0 +1,12 @@
+---
+description: View relationship definitions in the workspace
+---
+List relationship definitions: $ARGUMENTS
+
+Use the `mcp__nex__list_relationship_definitions` tool.
+
+Format each relationship as:
+- **Name**: source_object → target_object (cardinality)
+  - Description if available
+
+If no relationships defined, respond: "No relationship definitions found in this workspace."

--- a/cli/plugin-commands/schema.md
+++ b/cli/plugin-commands/schema.md
@@ -1,0 +1,12 @@
+---
+description: View workspace schema (object types and their fields)
+---
+$ARGUMENTS
+
+If a specific object slug is provided, use the `mcp__nex__get_object` tool with that slug to show its details and attributes.
+
+Otherwise, use `mcp__nex__list_objects` with include_attributes=true to list all object types.
+
+Format each object type as:
+- **Object Name** (`slug`) — description
+  - Fields: list each attribute with name, type, and whether required

--- a/cli/plugin-commands/search.md
+++ b/cli/plugin-commands/search.md
@@ -1,0 +1,12 @@
+---
+description: Search CRM records by name across all types
+---
+Search for: $ARGUMENTS
+
+If no query provided, respond: "Usage: /search <query>"
+
+Use the `mcp__nex__search_records` tool with the query.
+Format results grouped by object type. For each result show:
+- **Name** (ID: `record_id`) — object type
+- Key attributes if available
+If no results found, respond: "No records found matching your query."

--- a/cli/plugin-commands/tasks.md
+++ b/cli/plugin-commands/tasks.md
@@ -1,0 +1,13 @@
+---
+description: List tasks, optionally filtered
+---
+List tasks: $ARGUMENTS
+
+Use the `mcp__nex__list_tasks` tool. If $ARGUMENTS is provided, use it as a search filter.
+
+Format each task as:
+- [ ] or [x] **Title** (Priority: X, Due: date)
+  - Status, assignee if set
+  - Brief description if available
+
+If no tasks found, respond: "No tasks found."

--- a/cli/plugin-commands/timeline.md
+++ b/cli/plugin-commands/timeline.md
@@ -1,0 +1,12 @@
+---
+description: View timeline events for a record
+---
+Show timeline for record: $ARGUMENTS
+
+If no record ID provided, respond: "Usage: /timeline <record_id>"
+
+Use the `mcp__nex__get_record_timeline` tool with the provided record_id.
+Format timeline entries chronologically, showing for each:
+- Timestamp
+- Event type
+- Summary of what changed

--- a/cli/plugin-commands/update-field.md
+++ b/cli/plugin-commands/update-field.md
@@ -1,0 +1,10 @@
+---
+description: Update a field (attribute) on an object type
+---
+Update a field: $ARGUMENTS
+
+If insufficient arguments, respond: "Usage: /update-field <object_slug> <attribute_slug> [--label <label>] [--required true|false] [--description <desc>]"
+
+Parse the object slug, attribute slug, and fields to update from arguments.
+Use the `mcp__nex__update_attribute` tool with the parsed parameters.
+Confirm the update with the returned details.

--- a/cli/plugin-commands/update-record.md
+++ b/cli/plugin-commands/update-record.md
@@ -1,0 +1,11 @@
+---
+description: Update an existing record
+---
+Update record: $ARGUMENTS
+
+If insufficient arguments, respond: "Usage: /update-record <record_id> <field=value> [field=value ...]"
+Example: /update-record rec_123 email="new@example.com" phone="+1234567890"
+
+Parse the record ID and field key=value pairs from arguments.
+Use the `mcp__nex__update_record` tool with the record_id and attributes object.
+Confirm the update with the returned details.

--- a/cli/plugin-commands/upsert-record.md
+++ b/cli/plugin-commands/upsert-record.md
@@ -1,0 +1,13 @@
+---
+description: Create or update a record (upsert)
+---
+Upsert record: $ARGUMENTS
+
+If insufficient arguments, respond: "Usage: /upsert-record <object_slug> --match <attribute> <field=value> [field=value ...]"
+Example: /upsert-record contacts --match email name="Jane Doe" email="jane@example.com"
+
+The `--match` flag specifies the matching_attribute used to find existing records. If a record with the same value for that attribute exists, it will be updated; otherwise a new record is created.
+
+Parse the object slug, matching attribute, and field key=value pairs.
+Use the `mcp__nex__upsert_record` tool with object_slug, matching_attribute, and attributes.
+Report whether the record was created or updated.


### PR DESCRIPTION
## Summary

- Add 20 new Claude Code slash command files in `cli/plugin-commands/` covering all remaining API groups
- The OpenClaw plugin (42 tools), SKILL.md integrations section, and NexClient changes were already merged via the developer-api-oauth PR

### New slash commands

| Command | API Group | MCP Tool |
|---------|-----------|----------|
| `/schema` | Schema | `list_objects` / `get_object` |
| `/create-object` | Schema | `create_object` |
| `/add-field` | Schema | `create_attribute` |
| `/update-field` | Schema | `update_attribute` |
| `/search` | Search | `search_records` |
| `/record` | Records | `get_record` |
| `/create-record` | Records | `create_record` |
| `/update-record` | Records | `update_record` |
| `/upsert-record` | Records | `upsert_record` |
| `/timeline` | Records | `get_record_timeline` |
| `/tasks` | Tasks | `list_tasks` |
| `/create-task` | Tasks | `create_task` |
| `/notes` | Notes | `list_notes` |
| `/create-note` | Notes | `create_note` |
| `/relationships` | Relationships | `list_relationship_definitions` |
| `/link-records` | Relationships | `create_relationship` |
| `/lists` | Lists | `list_object_lists` |
| `/list-members` | Lists | `list_list_records` |
| `/insights` | Context | `get_insights` |
| `/artifact` | Context | `get_artifact_status` |

## Test plan

- [x] `cli`: `npm run build` — tsc clean, `npm test` — 65/65 pass
- [ ] Manual: `nex setup` installs all 26 slash commands to `~/.claude/commands/`
- [ ] Manual: Test `/schema`, `/search`, `/create-task`, `/insights` in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)