### PR TITLE
feat: CLI TUI polish + search/ask clarification

### DIFF
--- a/cli/plugin-commands/recall.md
+++ b/cli/plugin-commands/recall.md
@@ -1,5 +1,5 @@
 ---
-description: Recall relevant memories from Nex knowledge base
+description: Query the Nex context graph with AI (recommended for most lookups)
 ---
 Search the nex knowledge base for: $ARGUMENTS
 Use the mcp__nex__context_ask tool to query and return formatted results with sources.

--- a/cli/plugin-commands/search.md
+++ b/cli/plugin-commands/search.md
@@ -1,5 +1,5 @@
 ---
-description: Search CRM records by name across all types
+description: Fuzzy keyword search to find specific named records (use /recall for AI-powered queries)
 ---
 Search for: $ARGUMENTS
 

--- a/cli/src/commands/context.ts
+++ b/cli/src/commands/context.ts
@@ -7,6 +7,7 @@ import { NexClient } from "../lib/client.js";
 import { resolveApiKey, resolveFormat, resolveTimeout } from "../lib/config.js";
 import { printOutput } from "../lib/output.js";
 import type { Format } from "../lib/output.js";
+import { box, keyValue, style, sym, isTTY } from "../lib/tui.js";
 import { shouldRecall, recordRecall } from "../lib/recall-filter.js";
 import { formatNexContext } from "../lib/context-format.js";
 import type { NexRecallResult } from "../lib/context-format.js";
@@ -30,9 +31,59 @@ async function readStdin(): Promise<string | undefined> {
   return text || undefined;
 }
 
+interface AskResult {
+  answer?: string;
+  entityCount?: number;
+  sessionId?: string;
+  [k: string]: unknown;
+}
+
+function formatAskText(data: unknown): string | undefined {
+  const d = data as AskResult;
+  if (!d || typeof d !== "object" || !d.answer) return undefined;
+
+  if (!isTTY) {
+    // Clean text output — just the answer
+    return d.answer;
+  }
+
+  // Rich TTY output — boxed answer with metadata
+  const lines: string[] = [];
+  lines.push(box("Context Answer", d.answer));
+
+  const meta: [string, string][] = [];
+  if (d.entityCount !== undefined && d.entityCount > 0) {
+    meta.push(["Entities", String(d.entityCount)]);
+  }
+  if (meta.length > 0) {
+    lines.push(keyValue(meta));
+  }
+
+  return lines.join("\n");
+}
+
+interface RememberResult {
+  artifact_id?: string;
+  status?: string;
+  [k: string]: unknown;
+}
+
+function formatRememberText(data: unknown): string | undefined {
+  const d = data as RememberResult;
+  if (!d || typeof d !== "object") return undefined;
+
+  if (d.status === "completed" || d.artifact_id) {
+    return `${sym.success} Stored${d.artifact_id ? style.dim(` (artifact: ${d.artifact_id})`) : ""}`;
+  }
+  if (d.status) {
+    return `${sym.info} ${d.status}${d.artifact_id ? style.dim(` (artifact: ${d.artifact_id})`) : ""}`;
+  }
+  return undefined;
+}
+
 program
   .command("ask")
-  .description("Ask a question against your Nex context")
+  .description("Query your context graph with AI (recommended for most lookups)")
   .argument("[query]", "The question to ask")
   .action(async (query?: string) => {
     const input = query ?? (await readStdin());
@@ -49,12 +100,12 @@ program
     }
 
     const result = await client.post("/v1/context/ask", body);
-    printOutput(result, format);
+    printOutput(result, format, formatAskText);
   });
 
 program
   .command("remember")
-  .description("Store content in your Nex context")
+  .description("Store a note, fact, or observation in your context graph")
   .argument("[content]", "The content to remember")
   .option("--context <context>", "Additional context")
   .action(async (content: string | undefined, opts: { context?: string }) => {
@@ -70,7 +121,7 @@ program
     }
 
     const result = await client.post("/v1/context/text", body);
-    printOutput(result, format);
+    printOutput(result, format, formatRememberText);
   });
 
 program
@@ -85,7 +136,7 @@ program
 
 program
   .command("recall")
-  .description("Recall context for injection into LLM prompts")
+  .description("Recall context for LLM prompt injection (used by hooks — prefer 'ask' for direct use)")
   .argument("[query]", "The query to recall context for")
   .option("--first-prompt", "Treat as first prompt in session")
   .action(async (query?: string, opts?: { firstPrompt?: boolean }) => {
@@ -121,7 +172,7 @@ program
 
 program
   .command("capture")
-  .description("Capture content into Nex context with filtering and rate limiting")
+  .description("Auto-capture content with filtering and rate limiting (used by hooks — prefer 'remember' for direct use)")
   .argument("[content]", "The content to capture")
   .action(async (content?: string) => {
     const input = content ?? (await readStdin());

--- a/cli/src/commands/integrate.ts
+++ b/cli/src/commands/integrate.ts
@@ -9,10 +9,7 @@ import { resolveApiKey, resolveFormat, resolveTimeout } from "../lib/config.js";
 import { AuthError } from "../lib/errors.js";
 import { printOutput, printError } from "../lib/output.js";
 import type { Format } from "../lib/output.js";
-
-function padRight(str: string, len: number): string {
-  return str.length >= len ? str : str + " ".repeat(len - str.length);
-}
+import { style, sym, badge, isTTY } from "../lib/tui.js";
 
 function getClient(): { client: NexClient; format: Format } {
   const opts = program.opts();
@@ -78,8 +75,8 @@ async function pollForConnection(
   existingIds: Set<number>,
   format: Format,
 ): Promise<void> {
-  process.stderr.write("Waiting for OAuth completion...\n");
-  process.stderr.write("Complete the OAuth flow in your browser, then return here.\n\n");
+  process.stderr.write(`\n${sym.info} Waiting for OAuth completion...\n`);
+  process.stderr.write(`  ${style.dim("Complete the OAuth flow in your browser, then return here.")}\n\n`);
 
   const maxWaitMs = 5 * 60 * 1000;
   const pollIntervalMs = 3000;
@@ -101,7 +98,7 @@ async function pollForConnection(
       // Check for new connection ID
       for (const conn of connections) {
         if (!existingIds.has(conn.id)) {
-          process.stderr.write("\n\nConnected successfully!\n");
+          process.stderr.write(`\n\n${sym.success} Connected successfully!\n`);
           printOutput({ status: "connected", connection_id: conn.id }, format);
           return;
         }
@@ -111,7 +108,7 @@ async function pollForConnection(
       // the connection count matches (reconnect/refresh scenario), report success
       if (connections.length > 0 && (existingIds.size === 0 || pollCount >= 3)) {
         // Connection exists — OAuth likely refreshed an existing connection (same ID)
-        process.stderr.write("\n\nConnected successfully!\n");
+        process.stderr.write(`\n\n${sym.success} Connected successfully!\n`);
         printOutput({ status: "connected", connection_id: connections[0].id }, format);
         return;
       }
@@ -134,12 +131,125 @@ const integrate = program
   .command("integrate")
   .description("Manage third-party integrations (Gmail, Slack, Salesforce, etc.)");
 
+interface FullIntegrationEntry {
+  type: string;
+  provider: string;
+  display_name: string;
+  description: string;
+  connections: Array<{ id: number; status: string; identifier: string }>;
+}
+
+function renderList(items: FullIntegrationEntry[], selected: number, expanded: boolean): string {
+  const lines: string[] = [];
+
+  lines.push(`${style.bold("Integrations")}  ${style.dim("(arrow keys to navigate, enter to expand, q to quit)")}`);
+  lines.push("");
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    const isSelected = i === selected;
+    const pointer = isSelected ? sym.pointer : " ";
+    const connected = item.connections.length > 0;
+    const status = connected ? badge("connected", "success") : badge("not connected", "dim");
+    const name = isSelected ? style.bold(item.display_name) : item.display_name;
+
+    lines.push(`  ${pointer} ${name}  ${status}`);
+
+    if (isSelected && expanded) {
+      lines.push(`    ${style.dim(item.description)}`);
+      if (connected) {
+        for (const conn of item.connections) {
+          lines.push(`    ${style.green("\u2514")} ${conn.identifier}  ${style.dim(`(ID: ${conn.id}, status: ${conn.status})`)}`);
+        }
+        lines.push(`    ${style.dim("Disconnect: nex integrate disconnect <id>")}`);
+      } else {
+        const shortcut = Object.entries(INTEGRATIONS).find(
+          ([, v]) => v.type === item.type && v.provider === item.provider
+        );
+        if (shortcut) {
+          lines.push(`    ${style.dim(`Connect: nex integrate connect ${shortcut[0]}`)}`);
+        }
+      }
+    }
+  }
+
+  lines.push("");
+  return lines.join("\n");
+}
+
+function interactiveList(items: FullIntegrationEntry[]): Promise<void> {
+  return new Promise((resolve) => {
+    let selected = 0;
+    let expanded = false;
+
+    const draw = () => {
+      // Clear screen and move cursor to top
+      process.stdout.write("\x1b[2J\x1b[H");
+      process.stdout.write(renderList(items, selected, expanded));
+    };
+
+    if (!process.stdin.isTTY) {
+      // Non-interactive: print simple list and exit
+      for (const item of items) {
+        const connected = item.connections.length > 0;
+        const status = connected ? badge("connected", "success") : badge("not connected", "dim");
+        process.stdout.write(`${item.display_name}  ${status}\n`);
+        if (connected) {
+          for (const conn of item.connections) {
+            process.stdout.write(`  \u2514 ${conn.identifier} (ID: ${conn.id})\n`);
+          }
+        }
+      }
+      resolve();
+      return;
+    }
+
+    process.stdin.setRawMode(true);
+    process.stdin.resume();
+    process.stdin.setEncoding("utf-8");
+
+    draw();
+
+    const onData = (key: string) => {
+      if (key === "q" || key === "\x03") {
+        // q or Ctrl+C
+        process.stdin.setRawMode(false);
+        process.stdin.removeListener("data", onData);
+        process.stdin.pause();
+        process.stdout.write("\x1b[2J\x1b[H");
+        resolve();
+        return;
+      }
+
+      if (key === "\x1b[A") {
+        // Up arrow
+        selected = Math.max(0, selected - 1);
+        expanded = false;
+      } else if (key === "\x1b[B") {
+        // Down arrow
+        selected = Math.min(items.length - 1, selected + 1);
+        expanded = false;
+      } else if (key === "\r" || key === "\x1b[C") {
+        // Enter or Right arrow
+        expanded = !expanded;
+      } else if (key === "\x1b[D") {
+        // Left arrow
+        expanded = false;
+      }
+
+      draw();
+    };
+
+    process.stdin.on("data", onData);
+  });
+}
+
 integrate
   .command("list")
   .description("List all available integrations and their connection status")
   .action(async () => {
     const { client, format } = getClient();
-    const result = await client.get<IntegrationEntry[]>("/v1/integrations/");
+    const result = await client.get<FullIntegrationEntry[]>("/v1/integrations/");
 
     if (format === "json") {
       printOutput(result, "json");
@@ -151,33 +261,7 @@ integrate
       return;
     }
 
-    const lines: string[] = [];
-    lines.push("Integrations");
-    lines.push("\u2500".repeat(50));
-
-    for (const integration of result) {
-      const type = String(integration.type ?? "");
-      const provider = String(integration.provider ?? "");
-      const label = `${type} / ${provider}`;
-      const connections = integration.connections;
-
-      if (connections && connections.length > 0) {
-        for (const conn of connections) {
-          const displayName = (conn as Record<string, unknown>).display_name ?? (conn as Record<string, unknown>).email ?? "";
-          lines.push(
-            `${padRight(label, 25)} \u25CF connected     ${displayName}     (ID: ${conn.id})`
-          );
-        }
-      } else {
-        lines.push(`${padRight(label, 25)} \u25CB not connected`);
-      }
-    }
-
-    lines.push("");
-    lines.push(`Connect:     nex integrate connect <name>  (${INTEGRATION_NAMES})`);
-    lines.push("Disconnect:  nex integrate disconnect <id>");
-
-    process.stdout.write(lines.join("\n") + "\n");
+    await interactiveList(result);
   });
 
 integrate
@@ -225,5 +309,5 @@ integrate
     const { client, format } = getClient();
     const result = await client.delete(`/v1/integrations/connections/${encodeURIComponent(connectionId)}`);
     printOutput(result, format);
-    process.stderr.write("Disconnected successfully.\n");
+    process.stderr.write(`${sym.success} Disconnected successfully.\n`);
   });

--- a/cli/src/commands/scan.ts
+++ b/cli/src/commands/scan.ts
@@ -8,6 +8,59 @@ import { NexClient } from "../lib/client.js";
 import { printOutput, printError } from "../lib/output.js";
 import { scanFiles, loadScanConfig, isScanEnabled } from "../lib/file-scanner.js";
 import type { Format } from "../lib/output.js";
+import { spinner as createSpinner, table, style, sym, isTTY } from "../lib/tui.js";
+
+interface ScanFileEntry {
+  path?: string;
+  status?: string;
+  [k: string]: unknown;
+}
+
+interface ScanOutput {
+  scanned?: number;
+  skipped?: number;
+  errors?: number;
+  files?: ScanFileEntry[];
+  dry_run?: boolean;
+  would_scan?: number;
+  would_skip?: number;
+  [k: string]: unknown;
+}
+
+function formatScanTTY(data: unknown): string | undefined {
+  const d = data as ScanOutput;
+  if (!d || typeof d !== "object") return undefined;
+
+  const lines: string[] = [];
+
+  if (d.dry_run) {
+    lines.push(`  ${sym.info} Dry run — no files ingested`);
+    lines.push(`  Would scan: ${d.would_scan ?? 0}, Would skip: ${d.would_skip ?? 0}`);
+  }
+
+  const files = d.files;
+  if (files && Array.isArray(files) && files.length > 0) {
+    const headers = ["FILE", "STATUS"];
+    const rows = files.map((f) => [
+      String(f.path ?? ""),
+      String(f.status ?? ""),
+    ]);
+    lines.push(table({ headers, rows }));
+    lines.push("");
+  }
+
+  if (!d.dry_run) {
+    const parts: string[] = [];
+    if (d.scanned) parts.push(`${d.scanned} ingested`);
+    if (d.skipped) parts.push(`${d.skipped} skipped`);
+    if (d.errors) parts.push(`${d.errors} errors`);
+    if (parts.length > 0) {
+      lines.push(`  ${style.dim(parts.join(", "))}`);
+    }
+  }
+
+  return lines.length > 0 ? lines.join("\n") : undefined;
+}
 
 program
   .command("scan")
@@ -53,30 +106,48 @@ program
 
       const client = new NexClient(apiKey, resolveTimeout(globalOpts.timeout));
 
-      const result = await scanFiles(dir, scanOpts, async (content, context) => {
-        return client.post("/v1/context/text", { content, context });
-      });
+      // Show spinner for TTY text output
+      const showSpinner = isTTY && format === "text" && !opts.dryRun;
+      const spin = showSpinner ? createSpinner("Scanning project files...") : null;
 
-      if (opts.dryRun) {
-        printOutput(
-          {
-            dry_run: true,
-            would_scan: result.scanned,
-            would_skip: result.skipped,
-            files: result.files,
-          },
-          format,
-        );
-      } else {
-        printOutput(
-          {
-            scanned: result.scanned,
-            skipped: result.skipped,
-            errors: result.errors,
-            files: result.files,
-          },
-          format,
-        );
+      try {
+        const result = await scanFiles(dir, scanOpts, async (content, context) => {
+          return client.post("/v1/context/text", { content, context });
+        });
+
+        if (spin) {
+          spin.succeed("Scan complete");
+          process.stderr.write("\n");
+        }
+
+        if (opts.dryRun) {
+          printOutput(
+            {
+              dry_run: true,
+              would_scan: result.scanned,
+              would_skip: result.skipped,
+              files: result.files,
+            },
+            format,
+            formatScanTTY,
+          );
+        } else {
+          printOutput(
+            {
+              scanned: result.scanned,
+              skipped: result.skipped,
+              errors: result.errors,
+              files: result.files,
+            },
+            format,
+            formatScanTTY,
+          );
+        }
+      } catch (err) {
+        if (spin) {
+          spin.fail("Scan failed");
+        }
+        throw err;
       }
     },
   );

--- a/cli/src/commands/search.ts
+++ b/cli/src/commands/search.ts
@@ -1,5 +1,5 @@
 /**
- * nex search — search across your Nex context.
+ * nex search — fuzzy keyword search across CRM records by name.
  */
 
 import { program } from "../cli.js";
@@ -7,6 +7,7 @@ import { NexClient } from "../lib/client.js";
 import { resolveApiKey, resolveFormat, resolveTimeout } from "../lib/config.js";
 import { printOutput } from "../lib/output.js";
 import type { Format } from "../lib/output.js";
+import { heading, table, style, sym } from "../lib/tui.js";
 
 function getClient(): { client: NexClient; format: Format } {
   const opts = program.opts();
@@ -14,12 +15,62 @@ function getClient(): { client: NexClient; format: Format } {
   return { client, format: resolveFormat(opts.format) as Format };
 }
 
+interface SearchResult {
+  results?: Array<{ name?: string; type?: string; id?: string | number; [k: string]: unknown }>;
+  errored_search_types?: string[];
+  [k: string]: unknown;
+}
+
+function formatSearchTTY(data: unknown): string | undefined {
+  const d = data as SearchResult;
+  if (!d || typeof d !== "object") return undefined;
+
+  const lines: string[] = [];
+
+  // Check for partial errors
+  if (d.errored_search_types && d.errored_search_types.length > 0) {
+    lines.push(`  ${sym.warning} Search partially failed for: ${d.errored_search_types.join(", ")}`);
+    lines.push("");
+  }
+
+  const results = d.results;
+  if (!results || !Array.isArray(results) || results.length === 0) {
+    lines.push(`  ${style.dim("No records found.")}`);
+    lines.push(`  ${style.dim("Tip: use 'nex ask <query>' for AI-powered context lookups.")}`);
+    return lines.join("\n");
+  }
+
+  // Build table
+  const headers = ["NAME", "TYPE", "ID"];
+  const rows = results.map((r) => [
+    String(r.name ?? ""),
+    String(r.type ?? ""),
+    String(r.id ?? ""),
+  ]);
+
+  lines.push(table({ headers, rows }));
+  lines.push("");
+  lines.push(`  ${style.dim(`${results.length} result${results.length !== 1 ? "s" : ""} found`)}`);
+
+  return lines.join("\n");
+}
+
 program
   .command("search")
-  .description("Search across your Nex context")
+  .description("Fuzzy keyword search across CRM records by name (use 'ask' for AI-powered queries)")
   .argument("<query>", "Search query")
   .action(async (query: string) => {
     const { client, format } = getClient();
-    const result = await client.post("/v1/search", { query });
-    printOutput(result, format);
+    try {
+      const result = await client.post("/v1/search", { query });
+      if (format === "text") {
+        process.stdout.write(`${heading(`Search: "${query}"`)}\n\n`);
+      }
+      printOutput(result, format, formatSearchTTY);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`\n${sym.error} Search failed: ${message}\n`);
+      process.stderr.write(`  ${style.dim("Tip: use 'nex ask <query>' for AI-powered context lookups.")}\n\n`);
+      process.exit(1);
+    }
   });

--- a/cli/src/commands/setup.ts
+++ b/cli/src/commands/setup.ts
@@ -17,6 +17,18 @@ import { NexClient } from "../lib/client.js";
 import { printOutput, printError } from "../lib/output.js";
 import { confirm, ask, choose } from "../lib/prompt.js";
 import type { Format } from "../lib/output.js";
+import { heading, keyValue, tree, badge, style, sym } from "../lib/tui.js";
+
+const INTEGRATIONS_MAP: Record<string, { type: string; provider: string }> = {
+  gmail: { type: "email", provider: "google" },
+  "google-calendar": { type: "calendar", provider: "google" },
+  outlook: { type: "email", provider: "microsoft" },
+  "outlook-calendar": { type: "calendar", provider: "microsoft" },
+  slack: { type: "messaging", provider: "slack" },
+  salesforce: { type: "crm", provider: "salesforce" },
+  hubspot: { type: "crm", provider: "hubspot" },
+  attio: { type: "crm", provider: "attio" },
+};
 import { detectPlatforms, getPlatformById, VALID_PLATFORM_IDS } from "../lib/platform-detect.js";
 import type { Platform } from "../lib/platform-detect.js";
 import { installMcpServer, installClaudeCodePlugin, syncApiKeyToMcpConfig } from "../lib/installers.js";
@@ -65,43 +77,43 @@ async function showStatus(format: Format, overrideApiKey?: string): Promise<void
 
   // Text format
   const lines: string[] = [];
-  lines.push("Nex Setup Status");
-  lines.push("================");
+  lines.push(heading("Nex Setup Status"));
   lines.push("");
 
   // Auth
+  const authEntries: [string, string][] = [];
   if (apiKey) {
-    lines.push(`Auth: Configured (${maskKey(apiKey)})`);
+    authEntries.push(["Auth", maskKey(apiKey)]);
   } else {
-    lines.push("Auth: Not configured — run `nex register` first");
+    authEntries.push(["Auth", style.yellow("Not configured") + style.dim(" — run `nex register` first")]);
   }
-  lines.push("");
-
-  // Platforms
-  lines.push("Platforms:");
-  for (const p of platforms) {
-    if (!p.detected) {
-      lines.push(`  ${padRight(p.displayName, 20)} Not found`);
-      continue;
-    }
-
-    const parts = [`  ${padRight(p.displayName, 20)} Detected`];
-
-    if (p.pluginSupport) {
-      parts.push(`   Plugin: ${p.nexInstalled ? "installed" : "not installed"}`);
-    }
-
-    // MCP status
-    if (p.id !== "claude-code") {
-      parts.push(`   MCP: ${p.nexInstalled ? "installed" : "not installed"}`);
-    }
-
-    lines.push(parts.join(""));
-  }
+  lines.push(keyValue(authEntries));
   lines.push("");
 
   // Project config
-  lines.push(`Project Config: ${projectConfigExists() ? ".nex.toml found" : ".nex.toml not found"}`);
+  lines.push(keyValue([
+    ["Project Config", projectConfigExists() ? style.green(".nex.toml found") : style.dim(".nex.toml not found")],
+  ]));
+  lines.push("");
+
+  // Platforms
+  lines.push(`  ${style.bold("Platforms")}`);
+  const platformItems = platforms.map((p) => {
+    let statusLabel: string;
+    if (!p.detected) {
+      statusLabel = `${p.displayName}     ${badge("not detected", "dim")}`;
+      return { label: statusLabel };
+    }
+    const children: string[] = [];
+    if (p.pluginSupport) {
+      children.push(p.nexInstalled ? badge("hooks installed", "success") : badge("not installed", "dim"));
+    }
+    if (p.id !== "claude-code") {
+      children.push(p.nexInstalled ? badge("MCP installed", "success") : badge("not installed", "dim"));
+    }
+    return { label: `${p.displayName}`, children };
+  });
+  lines.push(tree(platformItems));
   lines.push("");
 
   // Integrations (short timeout — don't block setup)
@@ -110,25 +122,34 @@ async function showStatus(format: Format, overrideApiKey?: string): Promise<void
       const client = new NexClient(apiKey, 5_000);
       const integrations = await client.get<Record<string, unknown>[]>("/v1/integrations/");
       if (Array.isArray(integrations) && integrations.length > 0) {
-        lines.push("Connections:");
-        for (const integration of integrations) {
+        lines.push(`  ${style.bold("Connections")}`);
+        const connItems = integrations.map((integration) => {
           const type = String(integration.type ?? "");
           const provider = String(integration.provider ?? "");
           const label = `${type} / ${provider}`;
           const connections = integration.connections as Array<Record<string, unknown>> | undefined;
 
           if (connections && connections.length > 0) {
-            for (const conn of connections) {
-              const displayName = conn.display_name ?? conn.email ?? "";
-              lines.push(`  ${padRight(label, 25)} \u25CF connected     ${displayName}     (ID: ${conn.id})`);
-            }
-          } else {
-            lines.push(`  ${padRight(label, 25)} \u25CB not connected \u2192 nex integrate connect ${type} ${provider}`);
+            const children = connections.map((conn) => {
+              const displayName = String(conn.display_name ?? conn.email ?? "");
+              return `${badge("connected", "success")}  ${displayName}  ${style.dim(`(ID: ${conn.id})`)}`;
+            });
+            return { label, children };
           }
-        }
+
+          // Find shortcut name for connect command
+          const shortcut = Object.entries(INTEGRATIONS_MAP).find(
+            ([, v]) => v.type === type && v.provider === provider
+          );
+          const connectHint = shortcut
+            ? style.dim(`→ nex integrate connect ${shortcut[0]}`)
+            : "";
+          return { label: `${label}     ${badge("not connected", "dim")} ${connectHint}` };
+        });
+        lines.push(tree(connItems));
       }
     } catch {
-      lines.push("Connections: Could not fetch (check auth)");
+      lines.push(`  ${style.dim("Connections: Could not fetch (check auth)")}`);
     }
   }
 
@@ -350,9 +371,6 @@ function maskKey(key: string): string {
   return key.slice(0, 4) + "****" + key.slice(-4);
 }
 
-function padRight(str: string, len: number): string {
-  return str.length >= len ? str : str + " ".repeat(len - str.length);
-}
 
 function projectConfigExists(): boolean {
   return existsSync(join(process.cwd(), ".nex.toml"));

--- a/cli/src/commands/task.ts
+++ b/cli/src/commands/task.ts
@@ -7,11 +7,51 @@ import { NexClient } from "../lib/client.js";
 import { resolveApiKey, resolveFormat, resolveTimeout } from "../lib/config.js";
 import { printOutput } from "../lib/output.js";
 import type { Format } from "../lib/output.js";
+import { heading, style } from "../lib/tui.js";
 
 function getClient(): { client: NexClient; format: Format } {
   const opts = program.opts();
   const client = new NexClient(resolveApiKey(opts.apiKey), resolveTimeout(opts.timeout));
   return { client, format: resolveFormat(opts.format) as Format };
+}
+
+interface TaskEntry {
+  id?: string | number;
+  title?: string;
+  is_completed?: boolean;
+  priority?: string;
+  due_date?: string;
+  [k: string]: unknown;
+}
+
+function formatTaskListTTY(data: unknown): string | undefined {
+  if (!Array.isArray(data)) return undefined;
+  const tasks = data as TaskEntry[];
+
+  if (tasks.length === 0) {
+    return `  ${style.dim("No tasks found.")}`;
+  }
+
+  const lines: string[] = [];
+  lines.push(heading("Tasks"));
+  lines.push("");
+
+  for (const t of tasks) {
+    const check = t.is_completed ? style.dim("\u2611") : "\u2610";
+    const title = t.is_completed ? style.dim(t.title ?? "") : (t.title ?? "");
+    const parts = [`  ${check} ${title}`];
+
+    if (t.due_date) parts.push(`  ${style.dim("due: " + t.due_date)}`);
+    if (t.priority) parts.push(`  ${style.dim("priority: " + t.priority)}`);
+
+    lines.push(parts.join(""));
+  }
+
+  const completed = tasks.filter((t) => t.is_completed).length;
+  lines.push("");
+  lines.push(`  ${style.dim(`${tasks.length} task${tasks.length !== 1 ? "s" : ""} (${completed} completed)`)}`);
+
+  return lines.join("\n");
 }
 
 const task = program.command("task").description("Manage tasks");
@@ -34,7 +74,7 @@ task
     if (opts.limit) params.set("limit", opts.limit);
     const qs = params.toString();
     const result = await client.get(`/v1/tasks${qs ? `?${qs}` : ""}`);
-    printOutput(result, format);
+    printOutput(result, format, formatTaskListTTY);
   });
 
 task

--- a/cli/src/lib/output.ts
+++ b/cli/src/lib/output.ts
@@ -2,6 +2,8 @@
  * Output formatter: json / text / quiet.
  */
 
+import { isTTY, sym, style } from "./tui.js";
+
 export type Format = "json" | "text" | "quiet";
 
 function flattenForText(data: unknown, indent = 0): string {
@@ -42,13 +44,37 @@ export function formatOutput(data: unknown, format: Format): string | undefined 
   }
 }
 
-export function printOutput(data: unknown, format: Format): void {
-  const output = formatOutput(data, format);
-  if (output !== undefined) {
+export function printOutput(
+  data: unknown,
+  format: Format,
+  ttyFormatter?: (data: unknown) => string | undefined,
+): void {
+  if (format === "json") {
+    process.stdout.write(JSON.stringify(data, null, 2) + "\n");
+    return;
+  }
+  if (format === "quiet") return;
+
+  // text format: try formatter first (works in both TTY and piped output)
+  if (ttyFormatter) {
+    const result = ttyFormatter(data);
+    if (result !== undefined) {
+      process.stdout.write(result + "\n");
+      return;
+    }
+  }
+
+  // fallback to flattenForText
+  const output = flattenForText(data);
+  if (output) {
     process.stdout.write(output + "\n");
   }
 }
 
-export function printError(message: string): void {
-  process.stderr.write(`Error: ${message}\n`);
+export function printError(message: string, hint?: string): void {
+  process.stderr.write(`\n${sym.error} ${message}\n`);
+  if (hint) {
+    process.stderr.write(`  ${style.dim(hint)}\n`);
+  }
+  process.stderr.write("\n");
 }

--- a/cli/src/lib/prompt.ts
+++ b/cli/src/lib/prompt.ts
@@ -3,6 +3,7 @@
  */
 
 import { createInterface } from "node:readline";
+import { isTTY, style, sym } from "./tui.js";
 
 export async function confirm(message: string, defaultYes = true): Promise<boolean> {
   const suffix = defaultYes ? "[Y/n]" : "[y/N]";
@@ -22,26 +23,85 @@ export async function confirm(message: string, defaultYes = true): Promise<boole
 }
 
 export async function choose(message: string, options: string[]): Promise<number> {
-  const rl = createInterface({ input: process.stdin, output: process.stderr });
-
-  for (let i = 0; i < options.length; i++) {
-    process.stderr.write(`  ${i + 1}) ${options[i]}\n`);
+  if (!isTTY) {
+    // Non-TTY fallback: numbered list
+    const rl = createInterface({ input: process.stdin, output: process.stderr });
+    for (let i = 0; i < options.length; i++) {
+      process.stderr.write(`  ${i + 1}) ${options[i]}\n`);
+    }
+    return new Promise((resolve) => {
+      const prompt = () => {
+        rl.question(`${message} `, (answer) => {
+          const num = parseInt(answer.trim(), 10);
+          if (num >= 1 && num <= options.length) {
+            rl.close();
+            resolve(num - 1);
+            return;
+          }
+          process.stderr.write(`  Please enter 1-${options.length}\n`);
+          prompt();
+        });
+      };
+      prompt();
+    });
   }
 
+  // TTY: arrow-key selection
   return new Promise((resolve) => {
-    const prompt = () => {
-      rl.question(`${message} `, (answer) => {
-        const num = parseInt(answer.trim(), 10);
-        if (num >= 1 && num <= options.length) {
-          rl.close();
-          resolve(num - 1);
-          return;
-        }
-        process.stderr.write(`  Please enter 1-${options.length}\n`);
-        prompt();
-      });
+    let selected = 0;
+    const totalLines = options.length + 2; // title + blank + options
+
+    const draw = (initial = false) => {
+      if (!initial) {
+        process.stderr.write(`\x1b[${totalLines}A\x1b[J`);
+      }
+      process.stderr.write(`  ${message}\n\n`);
+      for (let i = 0; i < options.length; i++) {
+        const isSelected = i === selected;
+        const pointer = isSelected ? sym.pointer : " ";
+        const label = isSelected ? style.bold(options[i]) : options[i];
+        process.stderr.write(`  ${pointer} ${label}\n`);
+      }
     };
-    prompt();
+
+    process.stdin.setRawMode(true);
+    process.stdin.resume();
+    process.stdin.setEncoding("utf-8");
+
+    draw(true);
+
+    const onData = (key: string) => {
+      if (key === "\x03") {
+        // Ctrl+C
+        cleanup();
+        process.exit(130);
+        return;
+      }
+      if (key === "\r") {
+        // Enter
+        cleanup();
+        // Clear the selection UI
+        process.stderr.write(`\x1b[${totalLines}A\x1b[J`);
+        process.stderr.write(`  ${message}\n`);
+        process.stderr.write(`  ${sym.success} ${options[selected]}\n\n`);
+        resolve(selected);
+        return;
+      }
+      if (key === "\x1b[A") {
+        selected = Math.max(0, selected - 1);
+      } else if (key === "\x1b[B") {
+        selected = Math.min(options.length - 1, selected + 1);
+      }
+      draw();
+    };
+
+    const cleanup = () => {
+      process.stdin.setRawMode(false);
+      process.stdin.removeListener("data", onData);
+      process.stdin.pause();
+    };
+
+    process.stdin.on("data", onData);
   });
 }
 

--- a/cli/src/lib/tui.ts
+++ b/cli/src/lib/tui.ts
@@ -1,0 +1,320 @@
+/**
+ * Zero-dependency TUI primitives for the Nex CLI.
+ *
+ * Respects NO_COLOR, TERM=dumb, and non-TTY pipes.
+ * Ephemeral output (spinners) goes to stderr; structured output to stdout.
+ */
+
+// --- Environment ---
+
+export const isTTY: boolean =
+  !!process.stdout.isTTY &&
+  !process.env.NO_COLOR &&
+  process.env.TERM !== "dumb";
+
+const ANSI_RE = /\x1b\[[0-9;]*m/g;
+
+export function stripAnsi(s: string): string {
+  return s.replace(ANSI_RE, "");
+}
+
+export function visibleLength(s: string): number {
+  return stripAnsi(s).length;
+}
+
+// --- Style primitives ---
+
+function wrap(open: string, close: string): (s: string) => string {
+  if (!isTTY) return (s) => s;
+  return (s) => `${open}${s}${close}`;
+}
+
+export const style = {
+  bold: wrap("\x1b[1m", "\x1b[22m"),
+  dim: wrap("\x1b[2m", "\x1b[22m"),
+  green: wrap("\x1b[32m", "\x1b[39m"),
+  red: wrap("\x1b[31m", "\x1b[39m"),
+  yellow: wrap("\x1b[33m", "\x1b[39m"),
+  cyan: wrap("\x1b[36m", "\x1b[39m"),
+};
+
+// --- Symbols ---
+
+const unicode = isTTY && process.platform !== "win32";
+
+export const sym = {
+  success: isTTY ? style.green(unicode ? "\u2714" : "\u221A") : "ok",
+  error: isTTY ? style.red(unicode ? "\u2716" : "\u00D7") : "error",
+  warning: isTTY ? style.yellow(unicode ? "\u26A0" : "!") : "!",
+  info: isTTY ? style.cyan(unicode ? "\u2139" : "i") : "i",
+  bullet: isTTY ? style.green("\u25CF") : "*",
+  bulletDim: isTTY ? style.dim("\u25CB") : "o",
+  pointer: isTTY ? style.cyan("\u203A") : ">",
+  line: "\u2500",
+  corner: "\u2514",
+  pipe: "\u2502",
+  tee: "\u251C",
+};
+
+// --- Helpers ---
+
+function padRight(s: string, len: number): string {
+  const vl = visibleLength(s);
+  return vl >= len ? s : s + " ".repeat(len - vl);
+}
+
+// --- Components ---
+
+export function heading(title: string): string {
+  const plain = stripAnsi(title);
+  return `  ${style.bold(title)}\n  ${sym.line.repeat(plain.length)}`;
+}
+
+export function keyValue(
+  entries: [string, string][],
+  opts?: { labelWidth?: number },
+): string {
+  const width = opts?.labelWidth ?? Math.max(...entries.map(([k]) => k.length)) + 2;
+  return entries
+    .map(([k, v]) => `  ${padRight(style.dim(k), width + (style.dim("").length))}${v}`)
+    .join("\n");
+}
+
+export function table(opts: {
+  headers: string[];
+  rows: string[][];
+  alignRight?: number[];
+}): string {
+  const { headers, rows, alignRight = [] } = opts;
+  const cols = headers.length;
+
+  // Compute column widths
+  const widths: number[] = headers.map((h) => visibleLength(h));
+  for (const row of rows) {
+    for (let i = 0; i < cols; i++) {
+      widths[i] = Math.max(widths[i], visibleLength(row[i] ?? ""));
+    }
+  }
+
+  const pad = (s: string, i: number): string => {
+    const diff = widths[i] - visibleLength(s);
+    if (diff <= 0) return s;
+    return alignRight.includes(i) ? " ".repeat(diff) + s : s + " ".repeat(diff);
+  };
+
+  const headerLine =
+    "  " + headers.map((h, i) => style.bold(pad(h, i))).join("  ");
+  const sepLine =
+    "  " + widths.map((w) => sym.line.repeat(w)).join("  ");
+  const dataLines = rows.map(
+    (row) => "  " + row.map((cell, i) => pad(cell ?? "", i)).join("  "),
+  );
+
+  return [headerLine, sepLine, ...dataLines].join("\n");
+}
+
+export function badge(
+  label: string,
+  variant: "success" | "error" | "warning" | "dim",
+): string {
+  switch (variant) {
+    case "success":
+      return `${style.green("\u25CF")} ${style.green(label)}`;
+    case "error":
+      return `${style.red("\u25CF")} ${style.red(label)}`;
+    case "warning":
+      return `${style.yellow("\u25CF")} ${style.yellow(label)}`;
+    case "dim":
+      return `${style.dim("\u25CB")} ${style.dim(label)}`;
+  }
+}
+
+export function tree(
+  items: Array<{ label: string; children?: string[] }>,
+): string {
+  const lines: string[] = [];
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    const isLast = i === items.length - 1;
+    const prefix = isLast ? sym.corner : sym.tee;
+    lines.push(`  ${prefix} ${item.label}`);
+    if (item.children) {
+      const indent = isLast ? "    " : `  ${sym.pipe} `;
+      for (let j = 0; j < item.children.length; j++) {
+        const childPrefix = j === item.children.length - 1 ? sym.corner : sym.tee;
+        lines.push(`  ${indent}${childPrefix} ${item.children[j]}`);
+      }
+    }
+  }
+  return lines.join("\n");
+}
+
+export function box(title: string, content: string): string {
+  const contentLines = content.split("\n");
+  const maxContent = Math.max(
+    ...contentLines.map((l) => visibleLength(l)),
+    visibleLength(title) + 2,
+  );
+  const innerWidth = maxContent + 4; // 2 padding each side
+
+  const topRule =
+    "\u256D\u2500 " +
+    style.bold(title) +
+    " " +
+    "\u2500".repeat(Math.max(0, innerWidth - visibleLength(title) - 3)) +
+    "\u256E";
+
+  const emptyLine = "\u2502" + " ".repeat(innerWidth) + "\u2502";
+
+  const bodyLines = contentLines.map((l) => {
+    const padding = innerWidth - visibleLength(l) - 2;
+    return "\u2502  " + l + " ".repeat(Math.max(0, padding)) + "\u2502";
+  });
+
+  const bottomRule = "\u2570" + "\u2500".repeat(innerWidth) + "\u256F";
+
+  return [topRule, emptyLine, ...bodyLines, emptyLine, bottomRule].join("\n");
+}
+
+// --- Spinner ---
+
+const SPINNER_FRAMES = ["\u280B", "\u2819", "\u2839", "\u2838", "\u283C", "\u2834", "\u2826", "\u2827", "\u2807", "\u280F"];
+
+export function spinner(message: string): {
+  update: (msg: string) => void;
+  succeed: (msg: string) => void;
+  fail: (msg: string) => void;
+  stop: () => void;
+} {
+  if (!isTTY) {
+    // Non-TTY: just print the message
+    process.stderr.write(`  ${message}\n`);
+    return {
+      update: (msg: string) => process.stderr.write(`  ${msg}\n`),
+      succeed: (msg: string) => process.stderr.write(`  ${msg}\n`),
+      fail: (msg: string) => process.stderr.write(`  ${msg}\n`),
+      stop: () => {},
+    };
+  }
+
+  let frame = 0;
+  let currentMsg = message;
+  let stopped = false;
+
+  const clear = () => {
+    process.stderr.write("\r\x1b[K");
+  };
+
+  const render = () => {
+    clear();
+    process.stderr.write(
+      `  ${style.cyan(SPINNER_FRAMES[frame % SPINNER_FRAMES.length])} ${currentMsg}`,
+    );
+  };
+
+  const interval = setInterval(() => {
+    if (stopped) return;
+    frame++;
+    render();
+  }, 80);
+
+  render();
+
+  return {
+    update(msg: string) {
+      currentMsg = msg;
+      render();
+    },
+    succeed(msg: string) {
+      stopped = true;
+      clearInterval(interval);
+      clear();
+      process.stderr.write(`  ${sym.success} ${msg}\n`);
+    },
+    fail(msg: string) {
+      stopped = true;
+      clearInterval(interval);
+      clear();
+      process.stderr.write(`  ${sym.error} ${msg}\n`);
+    },
+    stop() {
+      stopped = true;
+      clearInterval(interval);
+      clear();
+    },
+  };
+}
+
+// --- Interactive Select ---
+
+export function interactiveSelect<T>(opts: {
+  title: string;
+  items: T[];
+  render: (item: T, selected: boolean) => string;
+}): Promise<T | null> {
+  const { title, items, render: renderItem } = opts;
+
+  if (!isTTY || items.length === 0) {
+    // Non-TTY fallback: print list, return null
+    process.stderr.write(`  ${title}\n\n`);
+    for (let i = 0; i < items.length; i++) {
+      process.stderr.write(`  ${i + 1}) ${renderItem(items[i], false)}\n`);
+    }
+    return Promise.resolve(null);
+  }
+
+  return new Promise((resolve) => {
+    let selected = 0;
+    const totalLines = items.length + 2; // title + blank + items
+
+    const draw = (initial = false) => {
+      if (!initial) {
+        // Move cursor up and clear
+        process.stderr.write(`\x1b[${totalLines}A\x1b[J`);
+      }
+      process.stderr.write(`  ${title}\n\n`);
+      for (let i = 0; i < items.length; i++) {
+        const isSelected = i === selected;
+        const pointer = isSelected ? `${sym.pointer} ` : "  ";
+        process.stderr.write(`  ${pointer}${renderItem(items[i], isSelected)}\n`);
+      }
+    };
+
+    process.stdin.setRawMode(true);
+    process.stdin.resume();
+    process.stdin.setEncoding("utf-8");
+
+    draw(true);
+
+    const onData = (key: string) => {
+      if (key === "\x03") {
+        // Ctrl+C
+        cleanup();
+        resolve(null);
+        return;
+      }
+      if (key === "\r") {
+        // Enter
+        cleanup();
+        resolve(items[selected]);
+        return;
+      }
+      if (key === "\x1b[A") {
+        // Up
+        selected = Math.max(0, selected - 1);
+      } else if (key === "\x1b[B") {
+        // Down
+        selected = Math.min(items.length - 1, selected + 1);
+      }
+      draw();
+    };
+
+    const cleanup = () => {
+      process.stdin.setRawMode(false);
+      process.stdin.removeListener("data", onData);
+      process.stdin.pause();
+    };
+
+    process.stdin.on("data", onData);
+  });
+}


### PR DESCRIPTION
## Summary
- Add zero-dependency TUI module (`lib/tui.ts`) with styled output, tables, trees, boxes, spinners, and interactive select
- Add polished TTY formatters to `ask`, `search`, `scan`, `task list`, `setup status`, and `integrate` commands
- Clean up `ask`/`remember` responses to show answer-only (no session ID / entity reference noise)
- Differentiate `search` (fuzzy keyword CRM lookup) from `ask` (AI context graph query) in descriptions and slash commands
- Upgrade `choose()` prompt to arrow-key selection in TTY mode
- Respect `NO_COLOR`, `TERM=dumb`, and non-TTY pipes throughout

## Test plan
- [x] `npm run build` — compiles clean
- [x] `npm test` — all 65 tests pass
- [ ] `nex ask "who have I been in contact with"` — shows boxed answer, no raw JSON
- [ ] `nex search "test"` — shows table or meaningful error
- [ ] `nex integrate list` — interactive TUI with shared primitives
- [ ] `nex setup status` — tree-formatted status display
- [ ] `nex --help` — search/ask descriptions clearly differentiated
- [ ] `echo "test" | nex search "test"` — no ANSI codes in piped output
- [ ] `NO_COLOR=1 nex integrate list` — plain text, no colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)