### PR TITLE
feat: actionable integrate list, meeting bot labels, exit hints

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nex-ai/nex",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Nex CLI provides organizational context & memory to AI agents",
   "type": "module",
   "bin": {

--- a/cli/plugin-commands/integrate.md
+++ b/cli/plugin-commands/integrate.md
@@ -4,6 +4,10 @@ Help the user connect third-party integrations (Gmail, Google Calendar, Outlook,
 
 `gmail`, `google-calendar`, `outlook`, `outlook-calendar`, `slack`, `attio`, `hubspot`, `salesforce`
 
+### Calendar Integrations (Nex Meeting Bot)
+
+Google Calendar and Outlook Calendar integrations enable the **Nex Meeting Bot**. When connected, the Nex Meeting Bot automatically joins your scheduled calls across any platform (Google Meet, Zoom, Webex, Microsoft Teams, etc.), records transcripts, and feeds them into your context graph. This means your AI agent has access to call transcripts and meeting context without any manual effort.
+
 ## Steps
 
 1. First, list current integrations to see what's already connected:

--- a/cli/src/commands/integrate.ts
+++ b/cli/src/commands/integrate.ts
@@ -9,7 +9,7 @@ import { resolveApiKey, resolveFormat, resolveTimeout } from "../lib/config.js";
 import { AuthError } from "../lib/errors.js";
 import { printOutput, printError } from "../lib/output.js";
 import type { Format } from "../lib/output.js";
-import { style, sym, badge, isTTY } from "../lib/tui.js";
+import { style, sym, badge, isTTY, exitHint } from "../lib/tui.js";
 
 function getClient(): { client: NexClient; format: Format } {
   const opts = program.opts();
@@ -75,7 +75,7 @@ async function pollForConnection(
   existingIds: Set<number>,
   format: Format,
 ): Promise<void> {
-  process.stderr.write(`\n${sym.info} Waiting for OAuth completion...\n`);
+  process.stderr.write(`\n${sym.info} Waiting for OAuth completion...  ${exitHint}\n`);
   process.stderr.write(`  ${style.dim("Complete the OAuth flow in your browser, then return here.")}\n\n`);
 
   const maxWaitMs = 5 * 60 * 1000;
@@ -127,6 +127,16 @@ async function pollForConnection(
   process.exit(1);
 }
 
+/** Calendar integrations include the Nex Meeting Bot annotation. */
+const CALENDAR_TYPES = new Set(["calendar"]);
+
+function displayName(item: FullIntegrationEntry): string {
+  if (CALENDAR_TYPES.has(item.type)) {
+    return `${item.display_name} (Nex Meeting Bot)`;
+  }
+  return item.display_name;
+}
+
 const integrate = program
   .command("integrate")
   .description("Manage third-party integrations (Gmail, Slack, Salesforce, etc.)");
@@ -139,10 +149,29 @@ interface FullIntegrationEntry {
   connections: Array<{ id: number; status: string; identifier: string }>;
 }
 
-function renderList(items: FullIntegrationEntry[], selected: number, expanded: boolean): string {
+interface ActionItem {
+  label: string;
+  action: "connect" | "disconnect" | "reconnect";
+  connectionId?: number;
+}
+
+function getActions(item: FullIntegrationEntry): ActionItem[] {
+  const connected = item.connections.length > 0;
+  if (connected) {
+    const actions: ActionItem[] = [];
+    for (const conn of item.connections) {
+      actions.push({ label: `Disconnect ${conn.identifier}`, action: "disconnect", connectionId: conn.id });
+    }
+    actions.push({ label: "Reconnect (re-auth)", action: "reconnect" });
+    return actions;
+  }
+  return [{ label: "Connect", action: "connect" }];
+}
+
+function renderList(items: FullIntegrationEntry[], selected: number, expanded: boolean, actionIndex: number): string {
   const lines: string[] = [];
 
-  lines.push(`${style.bold("Integrations")}  ${style.dim("(arrow keys to navigate, enter to expand, q to quit)")}`);
+  lines.push(`${style.bold("Integrations")}  ${style.dim("(↑↓ navigate, enter expand, ←→ actions)")}  ${exitHint}`);
   lines.push("");
 
   for (let i = 0; i < items.length; i++) {
@@ -151,24 +180,29 @@ function renderList(items: FullIntegrationEntry[], selected: number, expanded: b
     const pointer = isSelected ? sym.pointer : " ";
     const connected = item.connections.length > 0;
     const status = connected ? badge("connected", "success") : badge("not connected", "dim");
-    const name = isSelected ? style.bold(item.display_name) : item.display_name;
+    const dname = displayName(item);
+    const name = isSelected ? style.bold(dname) : dname;
 
     lines.push(`  ${pointer} ${name}  ${status}`);
 
     if (isSelected && expanded) {
       lines.push(`    ${style.dim(item.description)}`);
+      if (CALENDAR_TYPES.has(item.type)) {
+        lines.push(`    ${style.dim("Joins calls on Google Meet, Zoom, Webex, Teams, etc. Transcripts are processed into your context graph.")}`);
+      }
       if (connected) {
         for (const conn of item.connections) {
           lines.push(`    ${style.green("\u2514")} ${conn.identifier}  ${style.dim(`(ID: ${conn.id}, status: ${conn.status})`)}`);
         }
-        lines.push(`    ${style.dim("Disconnect: nex integrate disconnect <id>")}`);
-      } else {
-        const shortcut = Object.entries(INTEGRATIONS).find(
-          ([, v]) => v.type === item.type && v.provider === item.provider
-        );
-        if (shortcut) {
-          lines.push(`    ${style.dim(`Connect: nex integrate connect ${shortcut[0]}`)}`);
-        }
+      }
+      // Render action items
+      const actions = getActions(item);
+      lines.push("");
+      for (let a = 0; a < actions.length; a++) {
+        const isActionSelected = a === actionIndex;
+        const actionPointer = isActionSelected ? style.cyan(sym.pointer) : " ";
+        const actionLabel = isActionSelected ? style.bold(actions[a].label) : style.dim(actions[a].label);
+        lines.push(`    ${actionPointer} ${actionLabel}`);
       }
     }
   }
@@ -177,23 +211,22 @@ function renderList(items: FullIntegrationEntry[], selected: number, expanded: b
   return lines.join("\n");
 }
 
-function interactiveList(items: FullIntegrationEntry[]): Promise<void> {
+function interactiveList(items: FullIntegrationEntry[], client: NexClient, format: Format): Promise<void> {
   return new Promise((resolve) => {
     let selected = 0;
     let expanded = false;
+    let actionIndex = 0;
 
     const draw = () => {
-      // Clear screen and move cursor to top
       process.stdout.write("\x1b[2J\x1b[H");
-      process.stdout.write(renderList(items, selected, expanded));
+      process.stdout.write(renderList(items, selected, expanded, actionIndex));
     };
 
     if (!process.stdin.isTTY) {
-      // Non-interactive: print simple list and exit
       for (const item of items) {
         const connected = item.connections.length > 0;
         const status = connected ? badge("connected", "success") : badge("not connected", "dim");
-        process.stdout.write(`${item.display_name}  ${status}\n`);
+        process.stdout.write(`${displayName(item)}  ${status}\n`);
         if (connected) {
           for (const conn of item.connections) {
             process.stdout.write(`  \u2514 ${conn.identifier} (ID: ${conn.id})\n`);
@@ -204,6 +237,63 @@ function interactiveList(items: FullIntegrationEntry[]): Promise<void> {
       return;
     }
 
+    const cleanup = () => {
+      process.stdin.setRawMode(false);
+      process.stdin.removeListener("data", onData);
+      process.stdin.pause();
+    };
+
+    const executeAction = async (item: FullIntegrationEntry, action: ActionItem) => {
+      cleanup();
+      process.stdout.write("\x1b[2J\x1b[H");
+
+      const shortcut = Object.entries(INTEGRATIONS).find(
+        ([, v]) => v.type === item.type && v.provider === item.provider
+      );
+
+      if (action.action === "connect" || action.action === "reconnect") {
+        if (!shortcut) {
+          printError(`No integration mapping for ${item.display_name}`);
+          resolve();
+          return;
+        }
+        const integration = INTEGRATIONS[shortcut[0]];
+
+        // Snapshot existing connections
+        let existingIds = new Set<number>();
+        try {
+          const integrations = await client.get<IntegrationEntry[]>("/v1/integrations/", 5_000);
+          if (Array.isArray(integrations)) {
+            existingIds = new Set(getConnections(integrations, integration.type, integration.provider).map((c) => c.id));
+          }
+        } catch { /* continue */ }
+
+        process.stderr.write(`${sym.info} Opening browser to connect ${item.display_name}...\n`);
+        const result = await client.post<{ auth_url: string; connect_id?: string }>(
+          `/v1/integrations/${encodeURIComponent(integration.type)}/${encodeURIComponent(integration.provider)}/connect`
+        );
+
+        if (!result.auth_url) {
+          printError("No auth URL returned from API");
+          resolve();
+          return;
+        }
+
+        openBrowser(result.auth_url);
+        await pollForConnection(client, integration.type, integration.provider, existingIds, format);
+        resolve();
+      } else if (action.action === "disconnect" && action.connectionId !== undefined) {
+        try {
+          await client.delete(`/v1/integrations/connections/${encodeURIComponent(action.connectionId)}`);
+          process.stderr.write(`${sym.success} Disconnected successfully.\n`);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          printError(`Failed to disconnect: ${msg}`);
+        }
+        resolve();
+      }
+    };
+
     process.stdin.setRawMode(true);
     process.stdin.resume();
     process.stdin.setEncoding("utf-8");
@@ -212,10 +302,7 @@ function interactiveList(items: FullIntegrationEntry[]): Promise<void> {
 
     const onData = (key: string) => {
       if (key === "q" || key === "\x03") {
-        // q or Ctrl+C
-        process.stdin.setRawMode(false);
-        process.stdin.removeListener("data", onData);
-        process.stdin.pause();
+        cleanup();
         process.stdout.write("\x1b[2J\x1b[H");
         resolve();
         return;
@@ -223,18 +310,40 @@ function interactiveList(items: FullIntegrationEntry[]): Promise<void> {
 
       if (key === "\x1b[A") {
         // Up arrow
-        selected = Math.max(0, selected - 1);
-        expanded = false;
+        if (expanded) {
+          actionIndex = Math.max(0, actionIndex - 1);
+        } else {
+          selected = Math.max(0, selected - 1);
+        }
       } else if (key === "\x1b[B") {
         // Down arrow
-        selected = Math.min(items.length - 1, selected + 1);
-        expanded = false;
-      } else if (key === "\r" || key === "\x1b[C") {
-        // Enter or Right arrow
-        expanded = !expanded;
-      } else if (key === "\x1b[D") {
-        // Left arrow
-        expanded = false;
+        if (expanded) {
+          const actions = getActions(items[selected]);
+          actionIndex = Math.min(actions.length - 1, actionIndex + 1);
+        } else {
+          selected = Math.min(items.length - 1, selected + 1);
+        }
+      } else if (key === "\r") {
+        // Enter
+        if (expanded) {
+          const actions = getActions(items[selected]);
+          if (actions[actionIndex]) {
+            executeAction(items[selected], actions[actionIndex]);
+            return; // Don't redraw — executeAction resolves the promise
+          }
+        } else {
+          expanded = true;
+          actionIndex = 0;
+        }
+      } else if (key === "\x1b[D" || key === "\x1b[C") {
+        // Left/Right arrow — toggle expand
+        if (expanded) {
+          expanded = false;
+          actionIndex = 0;
+        } else {
+          expanded = true;
+          actionIndex = 0;
+        }
       }
 
       draw();
@@ -261,7 +370,7 @@ integrate
       return;
     }
 
-    await interactiveList(result);
+    await interactiveList(result, client, format);
   });
 
 integrate

--- a/cli/src/commands/scan.ts
+++ b/cli/src/commands/scan.ts
@@ -8,7 +8,7 @@ import { NexClient } from "../lib/client.js";
 import { printOutput, printError } from "../lib/output.js";
 import { scanFiles, loadScanConfig, isScanEnabled } from "../lib/file-scanner.js";
 import type { Format } from "../lib/output.js";
-import { spinner as createSpinner, table, style, sym, isTTY } from "../lib/tui.js";
+import { spinner as createSpinner, table, style, sym, isTTY, exitHint } from "../lib/tui.js";
 
 interface ScanFileEntry {
   path?: string;
@@ -108,7 +108,7 @@ program
 
       // Show spinner for TTY text output
       const showSpinner = isTTY && format === "text" && !opts.dryRun;
-      const spin = showSpinner ? createSpinner("Scanning project files...") : null;
+      const spin = showSpinner ? createSpinner(`Scanning project files...  ${exitHint}`) : null;
 
       try {
         const result = await scanFiles(dir, scanOpts, async (content, context) => {

--- a/cli/src/lib/prompt.ts
+++ b/cli/src/lib/prompt.ts
@@ -3,7 +3,7 @@
  */
 
 import { createInterface } from "node:readline";
-import { isTTY, style, sym } from "./tui.js";
+import { isTTY, style, sym, exitHint } from "./tui.js";
 
 export async function confirm(message: string, defaultYes = true): Promise<boolean> {
   const suffix = defaultYes ? "[Y/n]" : "[y/N]";
@@ -55,7 +55,7 @@ export async function choose(message: string, options: string[]): Promise<number
       if (!initial) {
         process.stderr.write(`\x1b[${totalLines}A\x1b[J`);
       }
-      process.stderr.write(`  ${message}\n\n`);
+      process.stderr.write(`  ${message}  ${exitHint}\n\n`);
       for (let i = 0; i < options.length; i++) {
         const isSelected = i === selected;
         const pointer = isSelected ? sym.pointer : " ";

--- a/cli/src/lib/tui.ts
+++ b/cli/src/lib/tui.ts
@@ -56,6 +56,10 @@ export const sym = {
   tee: "\u251C",
 };
 
+// --- Exit hint ---
+
+export const exitHint: string = style.dim("(Ctrl+C to exit)");
+
 // --- Helpers ---
 
 function padRight(s: string, len: number): string {
@@ -272,7 +276,7 @@ export function interactiveSelect<T>(opts: {
         // Move cursor up and clear
         process.stderr.write(`\x1b[${totalLines}A\x1b[J`);
       }
-      process.stderr.write(`  ${title}\n\n`);
+      process.stderr.write(`  ${title}  ${exitHint}\n\n`);
       for (let i = 0; i < items.length; i++) {
         const isSelected = i === selected;
         const pointer = isSelected ? `${sym.pointer} ` : "  ";

--- a/mcp/src/tools/integrations.ts
+++ b/mcp/src/tools/integrations.ts
@@ -5,7 +5,7 @@ import { NexApiClient } from "../client.js";
 export function registerIntegrationTools(server: McpServer, client: NexApiClient) {
   server.tool(
     "list_integrations",
-    "List all available third-party integrations (Gmail, Slack, Salesforce, etc.) and their connection status. To connect a new integration, use the connect_integration tool. To disconnect, use disconnect_integration with the connection ID shown in the results.",
+    "List all available third-party integrations and their connection status. Calendar integrations (Google Calendar, Outlook Calendar) enable the Nex Meeting Bot which joins calls on any platform (Google Meet, Zoom, Webex, Teams, etc.) and feeds transcripts into the context graph. To connect, use connect_integration. To disconnect, use disconnect_integration.",
     {},
     { readOnlyHint: true },
     async () => {
@@ -16,7 +16,7 @@ export function registerIntegrationTools(server: McpServer, client: NexApiClient
 
   server.tool(
     "connect_integration",
-    "Start connecting a third-party integration via OAuth. Returns an auth_url to open in the browser and a connect_id to poll for status.",
+    "Start connecting a third-party integration via OAuth. Returns an auth_url to open in the browser and a connect_id to poll for status. Calendar integrations (type: 'calendar') enable the Nex Meeting Bot which auto-joins calls and processes transcripts.",
     {
       type: z.enum(["email", "calendar", "crm", "messaging"]).describe("Integration type"),
       provider: z.enum(["google", "microsoft", "attio", "slack", "salesforce", "hubspot"]).describe("Integration provider"),

--- a/openclaw-plugin/src/index.ts
+++ b/openclaw-plugin/src/index.ts
@@ -396,7 +396,7 @@ const plugin = {
     api.registerTool({
       name: "nex_list_integrations",
       label: "List Integrations",
-      description: "List available third-party integrations and their connection status. Use nex_connect_integration to connect new ones, or nex_disconnect_integration with a connection ID to remove.",
+      description: "List available third-party integrations and their connection status. Calendar integrations (Google Calendar, Outlook Calendar) enable the Nex Meeting Bot which joins calls on any platform (Google Meet, Zoom, Webex, Teams, etc.) and feeds transcripts into the context graph.",
       parameters: ListIntegrationsParams,
       async execute(_toolCallId, _params) {
         const result = await client.get("/v1/integrations/");
@@ -415,7 +415,7 @@ const plugin = {
     api.registerTool({
       name: "nex_connect_integration",
       label: "Connect Integration",
-      description: "Start connecting a third-party integration via OAuth. Returns an auth_url for the user to open in their browser. Types: email, calendar, crm, messaging. Providers: google, microsoft, attio, slack, salesforce, hubspot.",
+      description: "Start connecting a third-party integration via OAuth. Returns an auth_url for the user to open in their browser. Calendar integrations (type: 'calendar') enable the Nex Meeting Bot which auto-joins calls and processes transcripts. Types: email, calendar, crm, messaging. Providers: google, microsoft, attio, slack, salesforce, hubspot.",
       parameters: ConnectIntegrationParams,
       async execute(_toolCallId, params) {
         const { type, provider } = params as Static<typeof ConnectIntegrationParams>;


### PR DESCRIPTION
## Summary
- **Actionable integrate list**: Expanding an integration now shows selectable connect/disconnect/reconnect actions that execute inline (arrow keys to navigate, enter to execute)
- **Meeting bot labels**: Calendar integrations (Google Calendar, Outlook Calendar) now display "(Nex Meeting Bot)" with a description about auto-joining calls and transcript processing
- **Ctrl+C exit hints**: All interactive and long-running CLI operations now show a "(Ctrl+C to exit)" footer
- Updated descriptions across MCP tools, OpenClaw plugin, and CLI plugin-commands

## Test plan
- [ ] `nex integrate list` — expand an integration, verify action items appear
- [ ] Select "Connect" on a disconnected integration — verify browser opens and OAuth flow works
- [ ] Select "Disconnect" on a connected integration — verify disconnection
- [ ] Calendar integrations show "(Nex Meeting Bot)" label
- [ ] `nex setup` prompts show Ctrl+C hint
- [ ] `nex scan .` spinner shows Ctrl+C hint
- [ ] Non-TTY output still works without ANSI codes

🤖 Generated with [Claude Code](https://claude.com/claude-code)