### PR TITLE
feat: full-depth platform plugins for 12 platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,35 @@ One fact entered once. Available everywhere, instantly.
 | **Commands** | 50+ CLI commands | 50+ typed tools | 4 tools + 4 commands | 5 slash commands + MCP | bash scripts |
 | **Rate limiting** | File-based | File-based | Queue + file-based | File-based | N/A |
 | **Session tracking** | File-based | File-based | In-memory LRU | File-based | N/A |
-| **Setup** | `npx @nex-ai/cli` | `npm install` + config | Copy plugin | Build + hooks | Set `NEX_API_KEY` |
+| **Setup** | `nex setup` | `nex setup --with-mcp` | Copy plugin | `nex setup` | Set `NEX_API_KEY` |
 
-## Quick Start
+## Quick Start (Recommended)
+
+```bash
+# Install and run setup — handles everything in one step
+npm install -g @nex-ai/nex
+nex setup
+```
+
+`nex setup` registers your API key, auto-detects your AI platforms (Claude Code, Cursor, Windsurf, etc.), installs hooks, scans project files, and creates config. One command, fully configured.
+
+```bash
+# Now use it from any agent
+nex ask "who is Maria Rodriguez?"
+nex remember "Met with Maria, CTO of TechFlow. European expansion Q3, $2M budget."
+```
+
+See [`cli/README.md`](cli/README.md) for all 50+ commands.
+
+---
+
+<details>
+<summary>Manual setup per platform (if you prefer step-by-step)</summary>
 
 ### CLI (any terminal, any AI agent)
 
 ```bash
-npx @nex-ai/cli register --email you@company.com
+npx @nex-ai/nex register --email you@company.com
 ```
 
 That's it. Now use it:
@@ -66,9 +87,7 @@ nex recall "what do I know about TechFlow?"  # Returns <nex-context> XML block
 nex capture "Agent conversation text..."  # Rate-limited, filtered
 ```
 
-Install globally: `npm install -g @nex-ai/cli`
-
-See [`cli/README.md`](cli/README.md) for all 50+ commands.
+Install globally: `npm install -g @nex-ai/nex`
 
 ### MCP Server (Claude Desktop, Cursor, Windsurf)
 
@@ -182,6 +201,8 @@ bash scripts/nex-scan-files.sh --dir . --max-files 10
 ```
 
 See [`SKILL.md`](SKILL.md) for the full API reference.
+
+</details>
 
 ## Shared Config
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -12,7 +12,22 @@ npm install -g @nex-ai/nex
 npx @nex-ai/nex ask "who is Maria?"
 ```
 
-## Quick Start
+## Quick Start (Recommended)
+
+```bash
+# One command to get started — registers, detects platforms, installs hooks, scans files
+nex setup
+```
+
+`nex setup` handles everything: API key registration, platform detection, hook installation, file scanning, and config creation. Run it once and you're ready to go.
+
+```bash
+# Now query your knowledge
+nex ask "what's the latest on the Acme deal?"
+```
+
+<details>
+<summary>Manual setup (if you prefer step-by-step)</summary>
 
 ```bash
 # 1. Register for an API key
@@ -25,22 +40,26 @@ nex setup
 nex ask "what's the latest on the Acme deal?"
 ```
 
+</details>
+
 ## Supported Platforms
 
-`nex setup` auto-detects and configures these platforms:
+`nex setup` auto-detects and configures these platforms with full-depth integration:
 
-| Platform | Detection | Integration |
-|----------|-----------|-------------|
-| **Claude Code** | `~/.claude/` | Hooks (auto-recall, auto-capture, session start) + slash commands + MCP |
-| **Claude Desktop** | App config exists | MCP server |
-| **Cursor** | `~/.cursor/` | MCP server |
-| **VS Code (Copilot)** | `which code` or `.vscode/` | MCP server (workspace-level) |
-| **Windsurf** | `~/.codeium/windsurf/` | MCP server |
-| **Cline** | VS Code extension installed | MCP server (globalStorage config) |
-| **Continue.dev** | `.continue/` or `~/.continue/` | MCP server |
-| **Zed** | `~/.config/zed/` | MCP server (context_servers) |
-| **Kilo Code** | `.kilocode/` in project | MCP server |
-| **OpenCode** | `~/.config/opencode/` | MCP server |
+| Platform | Hooks | Plugins | Agents | Workflows | Rules | MCP |
+|----------|-------|---------|--------|-----------|-------|-----|
+| **Claude Code** | SessionStart, UserPromptSubmit, Stop | — | — | 26 slash commands | — | — |
+| **Cursor** | sessionStart, userPromptSubmit, stop | — | — | — | `.cursor/rules/nex.md` | `~/.cursor/mcp.json` |
+| **Windsurf** | pre_user_prompt, post_cascade_response | — | — | /nex-ask, /nex-remember, /nex-search | `.windsurf/rules/nex.md` | `mcp_config.json` |
+| **Cline** | UserPromptSubmit, TaskStart, TaskComplete | — | — | — | `.clinerules/nex.md` | `cline_mcp_settings.json` |
+| **OpenClaw** | auto-recall, auto-capture (plugin) | `openclaw plugins install` (49 tools) | — | — | — | — |
+| **OpenCode** | — | `.opencode/plugins/nex.ts` | — | — | `AGENTS.md` | `opencode.json` |
+| **VS Code** | — | — | `.github/agents/nex.agent.md` | — | `.github/instructions/` | `.vscode/mcp.json` |
+| **Kilo Code** | — | — | `.kilocodemodes` | — | `.kilocode/rules/nex.md` | `.kilocode/mcp.json` |
+| **Continue.dev** | — | — | — | — | `.continue/rules/nex.md` | `mcp.json` |
+| **Zed** | — | — | — | — | `.rules` | `settings.json` |
+| **Claude Desktop** | — | — | — | — | — | `claude_desktop_config.json` |
+| **Aider** | — | — | — | — | `CONVENTIONS.md` | — |
 
 All MCP-based platforms use the same server entry:
 
@@ -57,10 +76,11 @@ All MCP-based platforms use the same server entry:
 ## Setup Command
 
 ```bash
-nex setup                          # Auto-detect platforms, install plugin, scan files, create .nex.toml
-nex setup --with-mcp               # Also write MCP config to all detected platforms
+nex setup                          # Auto-detect platforms, install full stack, scan files, create .nex.toml
 nex setup --platform cursor        # Install for a specific platform only
-nex setup --no-plugin              # Only create config files, skip hooks/commands
+nex setup --no-hooks               # Skip hook installation for all platforms
+nex setup --no-plugin              # Skip hooks/commands (alias for --no-hooks)
+nex setup --no-rules               # Skip rules/instruction file installation
 nex setup --no-scan                # Skip file scanning during setup
 nex setup status                   # Show all platforms, install status, and connections
 ```
@@ -68,15 +88,14 @@ nex setup status                   # Show all platforms, install status, and con
 **Default behavior** (no flags):
 - If no API key exists: prompts to register
 - If API key exists: offers to regenerate (picks up latest scopes) or change email
-- Claude Code: installs hooks + slash commands (no MCP — avoids filling context windows)
-- Other platforms: detected but MCP not written until `--with-mcp` is passed
+- Installs the full 6-layer hierarchy for each detected platform: hooks → plugins → agents → workflows → rules → MCP
 - Scans current directory and ingests new/changed files into Nex
 - Creates `.nex.toml` project config with commented defaults
 - Syncs API key to `~/.nex-mcp.json` (shared config)
 
-**Single install**: `npm install -g @nex-ai/nex` bundles everything — the Claude Code plugin hooks, slash commands, and MCP server are all included. No separate packages needed.
+**Single install**: `npm install -g @nex-ai/nex` bundles everything — hooks, adapters, platform plugins, slash commands, rules, and MCP server. No separate packages needed.
 
-> **Tip:** AI agents don't automatically know about Nex. Explicitly tell your agent to "use Nex for context and memory" in your prompts or CLAUDE.md instructions.
+**Integration hierarchy** (per platform): Hooks > Custom plugins > Custom agents/modes > Workflows > Rules > MCP. Each platform gets every layer it supports.
 
 ## Project Config: `.nex.toml`
 
@@ -110,7 +129,7 @@ Per-project settings file created by `nex setup`. All fields are optional.
 # depth = 2
 
 [mcp]
-# enabled = false             # Set to true by `nex setup --with-mcp`
+# enabled = false             # Set to true when `nex setup` installs MCP for this project/platform
 
 [output]
 # format = "text"             # "text" | "json"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nex-ai/nex",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Nex CLI provides organizational context & memory to AI agents",
   "type": "module",
   "bin": {
@@ -9,6 +9,8 @@
   "files": [
     "dist",
     "plugin-commands",
+    "platform-rules",
+    "platform-plugins",
     "README.md"
   ],
   "scripts": {

--- a/cli/platform-plugins/continue-provider.ts
+++ b/cli/platform-plugins/continue-provider.ts
@@ -1,0 +1,62 @@
+/**
+ * Nex context provider for Continue.dev
+ *
+ * Add this to your ~/.continue/config.ts to enable @nex context:
+ *
+ * import { nexProvider } from "./.plugins/nex-provider";
+ * export default { contextProviders: [nexProvider] };
+ *
+ * This file is copied to ~/.continue/.plugins/nex-provider.ts by `nex setup`.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+function loadApiKey(): string | null {
+  try {
+    const raw = readFileSync(join(homedir(), ".nex-mcp.json"), "utf-8");
+    return JSON.parse(raw).api_key ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export const nexProvider = {
+  title: "nex",
+  displayTitle: "Nex Context",
+  description: "Query organizational context, CRM, and memory from Nex",
+  type: "query" as const,
+
+  async getContextItems(query: string) {
+    const apiKey = loadApiKey();
+    if (!apiKey || !query.trim()) return [];
+
+    try {
+      const baseUrl = process.env.NEX_API_BASE_URL ?? "https://app.nex.ai";
+      const res = await fetch(`${baseUrl}/api/developers/v1/context/ask`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ query }),
+        signal: AbortSignal.timeout(10_000),
+      });
+
+      if (!res.ok) return [];
+      const data = (await res.json()) as { answer?: string };
+      if (!data.answer) return [];
+
+      return [
+        {
+          name: "Nex Context",
+          description: `Results for: ${query}`,
+          content: data.answer,
+        },
+      ];
+    } catch {
+      return [];
+    }
+  },
+};

--- a/cli/platform-plugins/kilocode-modes.yaml
+++ b/cli/platform-plugins/kilocode-modes.yaml
@@ -1,0 +1,17 @@
+customModes:
+  - slug: nex-crm
+    name: "Nex CRM"
+    roleDefinition: >
+      You are a CRM and organizational memory assistant powered by Nex.
+      You help users query their knowledge graph, CRM records, meetings,
+      communications, and organizational context. Use Nex MCP tools for
+      all queries about people, companies, deals, meetings, and emails.
+    customInstructions: >
+      Available Nex MCP tools: nex_ask (natural language query),
+      nex_remember (store information), nex_search (CRM lookup),
+      nex_list_integrations (check connections), nex_connect_integration (OAuth).
+      Always use nex_ask for knowledge queries. Use nex_search for name lookups.
+      Present results clearly with key entities highlighted.
+    groups:
+      - read
+      - mcp

--- a/cli/platform-plugins/opencode-plugin.ts
+++ b/cli/platform-plugins/opencode-plugin.ts
@@ -1,0 +1,103 @@
+/**
+ * Nex plugin for OpenCode — organizational context & memory.
+ *
+ * This file is copied to .opencode/plugins/nex.ts by `nex setup`.
+ * OpenCode's bun runtime resolves imports at load time.
+ *
+ * Provides:
+ * - Session lifecycle hooks (context loading on session create)
+ * - Context preservation during compaction
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+// Read API key from shared Nex config
+function loadApiKey(): string | null {
+  try {
+    const raw = readFileSync(join(homedir(), ".nex-mcp.json"), "utf-8");
+    const config = JSON.parse(raw);
+    return config.api_key ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function nexAsk(query: string, apiKey: string): Promise<string> {
+  const baseUrl = process.env.NEX_API_BASE_URL ?? "https://app.nex.ai";
+  const res = await fetch(`${baseUrl}/api/developers/v1/context/ask`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ query }),
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!res.ok) return "";
+  const data = await res.json() as { answer?: string };
+  return data.answer ?? "";
+}
+
+async function nexIngest(content: string, context: string, apiKey: string): Promise<void> {
+  const baseUrl = process.env.NEX_API_BASE_URL ?? "https://app.nex.ai";
+  await fetch(`${baseUrl}/api/developers/v1/context/text`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ content, context }),
+    signal: AbortSignal.timeout(5_000),
+  });
+}
+
+let cachedContext = "";
+
+export default {
+  name: "nex",
+
+  async "session.created"() {
+    const apiKey = loadApiKey();
+    if (!apiKey) return;
+
+    try {
+      const answer = await nexAsk(
+        "Summarize the key active context, recent interactions, and important updates for this user.",
+        apiKey,
+      );
+      if (answer) {
+        cachedContext = `<nex-context>\n${answer}\n</nex-context>`;
+      }
+    } catch {
+      // graceful degradation
+    }
+
+    return cachedContext ? { context: cachedContext } : undefined;
+  },
+
+  async "experimental.session.compacting"(_input: unknown, output: { context: string[] }) {
+    if (cachedContext) {
+      output.context.push(cachedContext);
+    }
+  },
+
+  async "session.completed"(_input: { messages?: Array<{ role: string; content: string }> }) {
+    const apiKey = loadApiKey();
+    if (!apiKey) return;
+
+    // Capture last assistant message
+    const messages = (_input as any)?.messages;
+    if (!Array.isArray(messages)) return;
+
+    const lastAssistant = [...messages].reverse().find((m) => m.role === "assistant");
+    if (!lastAssistant?.content || lastAssistant.content.length < 20) return;
+
+    try {
+      await nexIngest(lastAssistant.content.slice(0, 50_000), "opencode-conversation", apiKey);
+    } catch {
+      // graceful degradation
+    }
+  },
+};

--- a/cli/platform-plugins/vscode-agent.md
+++ b/cli/platform-plugins/vscode-agent.md
@@ -1,0 +1,34 @@
+---
+name: nex
+description: "Query organizational context, CRM, meetings, and memory via Nex"
+tools:
+  - nex
+---
+
+You are the Nex agent. You help users query their organizational knowledge, CRM records, meetings, and communications.
+
+## Available MCP Tools
+
+- **nex_ask** — Query the knowledge graph with natural language (people, companies, deals, meetings, emails)
+- **nex_remember** — Store information for future recall across all connected platforms
+- **nex_search** — Search CRM records by name (people, companies, deals)
+- **nex_list_integrations** — Check connected data sources (Gmail, Slack, Salesforce, etc.)
+- **nex_connect_integration** — Connect a new data source via OAuth
+
+## When to Use
+
+Use Nex tools when the user asks about:
+- People, companies, organizations, or contacts
+- Deals, opportunities, or sales pipeline
+- Meetings, calendar events, or scheduling
+- Emails, messages, or communications
+- Organizational context, history, or relationships
+- Storing notes or information for later
+
+## Guidelines
+
+- Always use `nex_ask` for natural language queries about organizational knowledge
+- Use `nex_search` when looking up specific CRM records by name
+- Use `nex_remember` to store meeting notes, decisions, or important context
+- Present results clearly with key entities highlighted
+- If no results are found, suggest the user connect relevant data sources

--- a/cli/platform-plugins/windsurf-workflows/nex-ask.md
+++ b/cli/platform-plugins/windsurf-workflows/nex-ask.md
@@ -1,0 +1,10 @@
+---
+name: nex-ask
+description: Ask Nex a question about organizational context, people, companies, deals, or meetings
+---
+
+Use the Nex MCP tool `nex_ask` to answer the user's question about organizational context.
+
+If the user provides a query, pass it directly. If not, ask what they'd like to know about their organizational context, CRM records, meetings, or communications.
+
+Always present the response clearly, highlighting key entities (people, companies, deals) and any relevant dates or action items.

--- a/cli/platform-plugins/windsurf-workflows/nex-remember.md
+++ b/cli/platform-plugins/windsurf-workflows/nex-remember.md
@@ -1,0 +1,10 @@
+---
+name: nex-remember
+description: Store information in Nex knowledge base for future recall
+---
+
+Use the Nex MCP tool `nex_remember` to store the provided information in the user's knowledge base.
+
+If the user provides content, ingest it directly. If not, ask what they'd like to remember.
+
+Confirm what was stored and mention that it will be available for future recall across all connected platforms.

--- a/cli/platform-plugins/windsurf-workflows/nex-search.md
+++ b/cli/platform-plugins/windsurf-workflows/nex-search.md
@@ -1,0 +1,10 @@
+---
+name: nex-search
+description: Search for CRM records (people, companies, deals) by name
+---
+
+Use the Nex MCP tool `nex_search` to search for CRM records matching the user's query.
+
+If the user provides a search term, use it directly. If not, ask what they're looking for.
+
+Present results in a structured format showing name, type, and key details for each match.

--- a/cli/platform-rules/aider-conventions.md
+++ b/cli/platform-rules/aider-conventions.md
@@ -1,0 +1,38 @@
+# --- Nex Context & Memory ---
+
+# Nex — Organizational Context & Memory
+
+Nex provides your AI agent with real-time organizational knowledge — contacts, deals, meetings, emails, notes, and more — via MCP tools.
+
+## MCP Tools Available
+
+### `nex_ask` — AI-powered context query (recommended)
+Use for natural language questions about organizational context.
+Examples: "what's the latest on the Acme deal?", "when did I last talk to Sarah?"
+
+### `nex_remember` — Store information
+Save notes, observations, meeting summaries, or any text to the knowledge base.
+Examples: "remember that John prefers email over Slack", store meeting notes
+
+### `nex_search` — Fuzzy record lookup
+Search CRM records (people, companies, deals) by name or keyword.
+Use when looking up a specific named entity rather than asking a question.
+
+### `nex_list_integrations` — Check connected data sources
+Shows which integrations (Gmail, Slack, Calendar, CRM) are connected and active.
+
+### `nex_connect_integration` — Connect a data source
+Initiate OAuth connection for Gmail, Google Calendar, Outlook, Slack, Salesforce, HubSpot, or Attio.
+
+## When to Use Nex
+
+When the user asks about:
+- **People or companies** — contacts, relationships, org charts
+- **Deals or opportunities** — status, history, next steps
+- **Meetings or calls** — past conversations, upcoming schedules
+- **Emails or messages** — communication history
+- **Organizational context** — company knowledge, team notes, decisions
+
+Always try `nex_ask` first for general queries. Use `nex_search` when you need to find a specific record by name.
+
+# --- End Nex ---

--- a/cli/platform-rules/cline-rules.md
+++ b/cli/platform-rules/cline-rules.md
@@ -1,0 +1,34 @@
+# Nex — Organizational Context & Memory
+
+Nex provides your AI agent with real-time organizational knowledge — contacts, deals, meetings, emails, notes, and more — via MCP tools.
+
+## MCP Tools Available
+
+### `nex_ask` — AI-powered context query (recommended)
+Use for natural language questions about organizational context.
+Examples: "what's the latest on the Acme deal?", "when did I last talk to Sarah?"
+
+### `nex_remember` — Store information
+Save notes, observations, meeting summaries, or any text to the knowledge base.
+Examples: "remember that John prefers email over Slack", store meeting notes
+
+### `nex_search` — Fuzzy record lookup
+Search CRM records (people, companies, deals) by name or keyword.
+Use when looking up a specific named entity rather than asking a question.
+
+### `nex_list_integrations` — Check connected data sources
+Shows which integrations (Gmail, Slack, Calendar, CRM) are connected and active.
+
+### `nex_connect_integration` — Connect a data source
+Initiate OAuth connection for Gmail, Google Calendar, Outlook, Slack, Salesforce, HubSpot, or Attio.
+
+## When to Use Nex
+
+When the user asks about:
+- **People or companies** — contacts, relationships, org charts
+- **Deals or opportunities** — status, history, next steps
+- **Meetings or calls** — past conversations, upcoming schedules
+- **Emails or messages** — communication history
+- **Organizational context** — company knowledge, team notes, decisions
+
+Always try `nex_ask` first for general queries. Use `nex_search` when you need to find a specific record by name.

--- a/cli/platform-rules/continue-rules.md
+++ b/cli/platform-rules/continue-rules.md
@@ -1,0 +1,34 @@
+# Nex — Organizational Context & Memory
+
+Nex provides your AI agent with real-time organizational knowledge — contacts, deals, meetings, emails, notes, and more — via MCP tools.
+
+## MCP Tools Available
+
+### `nex_ask` — AI-powered context query (recommended)
+Use for natural language questions about organizational context.
+Examples: "what's the latest on the Acme deal?", "when did I last talk to Sarah?"
+
+### `nex_remember` — Store information
+Save notes, observations, meeting summaries, or any text to the knowledge base.
+Examples: "remember that John prefers email over Slack", store meeting notes
+
+### `nex_search` — Fuzzy record lookup
+Search CRM records (people, companies, deals) by name or keyword.
+Use when looking up a specific named entity rather than asking a question.
+
+### `nex_list_integrations` — Check connected data sources
+Shows which integrations (Gmail, Slack, Calendar, CRM) are connected and active.
+
+### `nex_connect_integration` — Connect a data source
+Initiate OAuth connection for Gmail, Google Calendar, Outlook, Slack, Salesforce, HubSpot, or Attio.
+
+## When to Use Nex
+
+When the user asks about:
+- **People or companies** — contacts, relationships, org charts
+- **Deals or opportunities** — status, history, next steps
+- **Meetings or calls** — past conversations, upcoming schedules
+- **Emails or messages** — communication history
+- **Organizational context** — company knowledge, team notes, decisions
+
+Always try `nex_ask` first for general queries. Use `nex_search` when you need to find a specific record by name.

--- a/cli/platform-rules/cursor-rules.md
+++ b/cli/platform-rules/cursor-rules.md
@@ -1,0 +1,34 @@
+# Nex — Organizational Context & Memory
+
+Nex provides your AI agent with real-time organizational knowledge — contacts, deals, meetings, emails, notes, and more — via MCP tools.
+
+## MCP Tools Available
+
+### `nex_ask` — AI-powered context query (recommended)
+Use for natural language questions about organizational context.
+Examples: "what's the latest on the Acme deal?", "when did I last talk to Sarah?"
+
+### `nex_remember` — Store information
+Save notes, observations, meeting summaries, or any text to the knowledge base.
+Examples: "remember that John prefers email over Slack", store meeting notes
+
+### `nex_search` — Fuzzy record lookup
+Search CRM records (people, companies, deals) by name or keyword.
+Use when looking up a specific named entity rather than asking a question.
+
+### `nex_list_integrations` — Check connected data sources
+Shows which integrations (Gmail, Slack, Calendar, CRM) are connected and active.
+
+### `nex_connect_integration` — Connect a data source
+Initiate OAuth connection for Gmail, Google Calendar, Outlook, Slack, Salesforce, HubSpot, or Attio.
+
+## When to Use Nex
+
+When the user asks about:
+- **People or companies** — contacts, relationships, org charts
+- **Deals or opportunities** — status, history, next steps
+- **Meetings or calls** — past conversations, upcoming schedules
+- **Emails or messages** — communication history
+- **Organizational context** — company knowledge, team notes, decisions
+
+Always try `nex_ask` first for general queries. Use `nex_search` when you need to find a specific record by name.

--- a/cli/platform-rules/kilocode-rules.md
+++ b/cli/platform-rules/kilocode-rules.md
@@ -1,0 +1,34 @@
+# Nex — Organizational Context & Memory
+
+Nex provides your AI agent with real-time organizational knowledge — contacts, deals, meetings, emails, notes, and more — via MCP tools.
+
+## MCP Tools Available
+
+### `nex_ask` — AI-powered context query (recommended)
+Use for natural language questions about organizational context.
+Examples: "what's the latest on the Acme deal?", "when did I last talk to Sarah?"
+
+### `nex_remember` — Store information
+Save notes, observations, meeting summaries, or any text to the knowledge base.
+Examples: "remember that John prefers email over Slack", store meeting notes
+
+### `nex_search` — Fuzzy record lookup
+Search CRM records (people, companies, deals) by name or keyword.
+Use when looking up a specific named entity rather than asking a question.
+
+### `nex_list_integrations` — Check connected data sources
+Shows which integrations (Gmail, Slack, Calendar, CRM) are connected and active.
+
+### `nex_connect_integration` — Connect a data source
+Initiate OAuth connection for Gmail, Google Calendar, Outlook, Slack, Salesforce, HubSpot, or Attio.
+
+## When to Use Nex
+
+When the user asks about:
+- **People or companies** — contacts, relationships, org charts
+- **Deals or opportunities** — status, history, next steps
+- **Meetings or calls** — past conversations, upcoming schedules
+- **Emails or messages** — communication history
+- **Organizational context** — company knowledge, team notes, decisions
+
+Always try `nex_ask` first for general queries. Use `nex_search` when you need to find a specific record by name.

--- a/cli/platform-rules/opencode-agents.md
+++ b/cli/platform-rules/opencode-agents.md
@@ -1,0 +1,38 @@
+# --- Nex Context & Memory ---
+
+# Nex — Organizational Context & Memory
+
+Nex provides your AI agent with real-time organizational knowledge — contacts, deals, meetings, emails, notes, and more — via MCP tools.
+
+## MCP Tools Available
+
+### `nex_ask` — AI-powered context query (recommended)
+Use for natural language questions about organizational context.
+Examples: "what's the latest on the Acme deal?", "when did I last talk to Sarah?"
+
+### `nex_remember` — Store information
+Save notes, observations, meeting summaries, or any text to the knowledge base.
+Examples: "remember that John prefers email over Slack", store meeting notes
+
+### `nex_search` — Fuzzy record lookup
+Search CRM records (people, companies, deals) by name or keyword.
+Use when looking up a specific named entity rather than asking a question.
+
+### `nex_list_integrations` — Check connected data sources
+Shows which integrations (Gmail, Slack, Calendar, CRM) are connected and active.
+
+### `nex_connect_integration` — Connect a data source
+Initiate OAuth connection for Gmail, Google Calendar, Outlook, Slack, Salesforce, HubSpot, or Attio.
+
+## When to Use Nex
+
+When the user asks about:
+- **People or companies** — contacts, relationships, org charts
+- **Deals or opportunities** — status, history, next steps
+- **Meetings or calls** — past conversations, upcoming schedules
+- **Emails or messages** — communication history
+- **Organizational context** — company knowledge, team notes, decisions
+
+Always try `nex_ask` first for general queries. Use `nex_search` when you need to find a specific record by name.
+
+# --- End Nex ---

--- a/cli/platform-rules/vscode-instructions.md
+++ b/cli/platform-rules/vscode-instructions.md
@@ -1,0 +1,38 @@
+---
+applyTo: "**"
+---
+
+# Nex — Organizational Context & Memory
+
+Nex provides your AI agent with real-time organizational knowledge — contacts, deals, meetings, emails, notes, and more — via MCP tools.
+
+## MCP Tools Available
+
+### `nex_ask` — AI-powered context query (recommended)
+Use for natural language questions about organizational context.
+Examples: "what's the latest on the Acme deal?", "when did I last talk to Sarah?"
+
+### `nex_remember` — Store information
+Save notes, observations, meeting summaries, or any text to the knowledge base.
+Examples: "remember that John prefers email over Slack", store meeting notes
+
+### `nex_search` — Fuzzy record lookup
+Search CRM records (people, companies, deals) by name or keyword.
+Use when looking up a specific named entity rather than asking a question.
+
+### `nex_list_integrations` — Check connected data sources
+Shows which integrations (Gmail, Slack, Calendar, CRM) are connected and active.
+
+### `nex_connect_integration` — Connect a data source
+Initiate OAuth connection for Gmail, Google Calendar, Outlook, Slack, Salesforce, HubSpot, or Attio.
+
+## When to Use Nex
+
+When the user asks about:
+- **People or companies** — contacts, relationships, org charts
+- **Deals or opportunities** — status, history, next steps
+- **Meetings or calls** — past conversations, upcoming schedules
+- **Emails or messages** — communication history
+- **Organizational context** — company knowledge, team notes, decisions
+
+Always try `nex_ask` first for general queries. Use `nex_search` when you need to find a specific record by name.

--- a/cli/platform-rules/windsurf-rules.md
+++ b/cli/platform-rules/windsurf-rules.md
@@ -1,0 +1,34 @@
+# Nex — Organizational Context & Memory
+
+Nex provides your AI agent with real-time organizational knowledge — contacts, deals, meetings, emails, notes, and more — via MCP tools.
+
+## MCP Tools Available
+
+### `nex_ask` — AI-powered context query (recommended)
+Use for natural language questions about organizational context.
+Examples: "what's the latest on the Acme deal?", "when did I last talk to Sarah?"
+
+### `nex_remember` — Store information
+Save notes, observations, meeting summaries, or any text to the knowledge base.
+Examples: "remember that John prefers email over Slack", store meeting notes
+
+### `nex_search` — Fuzzy record lookup
+Search CRM records (people, companies, deals) by name or keyword.
+Use when looking up a specific named entity rather than asking a question.
+
+### `nex_list_integrations` — Check connected data sources
+Shows which integrations (Gmail, Slack, Calendar, CRM) are connected and active.
+
+### `nex_connect_integration` — Connect a data source
+Initiate OAuth connection for Gmail, Google Calendar, Outlook, Slack, Salesforce, HubSpot, or Attio.
+
+## When to Use Nex
+
+When the user asks about:
+- **People or companies** — contacts, relationships, org charts
+- **Deals or opportunities** — status, history, next steps
+- **Meetings or calls** — past conversations, upcoming schedules
+- **Emails or messages** — communication history
+- **Organizational context** — company knowledge, team notes, decisions
+
+Always try `nex_ask` first for general queries. Use `nex_search` when you need to find a specific record by name.

--- a/cli/platform-rules/zed-rules.md
+++ b/cli/platform-rules/zed-rules.md
@@ -1,0 +1,38 @@
+# --- Nex Context & Memory ---
+
+# Nex — Organizational Context & Memory
+
+Nex provides your AI agent with real-time organizational knowledge — contacts, deals, meetings, emails, notes, and more — via MCP tools.
+
+## MCP Tools Available
+
+### `nex_ask` — AI-powered context query (recommended)
+Use for natural language questions about organizational context.
+Examples: "what's the latest on the Acme deal?", "when did I last talk to Sarah?"
+
+### `nex_remember` — Store information
+Save notes, observations, meeting summaries, or any text to the knowledge base.
+Examples: "remember that John prefers email over Slack", store meeting notes
+
+### `nex_search` — Fuzzy record lookup
+Search CRM records (people, companies, deals) by name or keyword.
+Use when looking up a specific named entity rather than asking a question.
+
+### `nex_list_integrations` — Check connected data sources
+Shows which integrations (Gmail, Slack, Calendar, CRM) are connected and active.
+
+### `nex_connect_integration` — Connect a data source
+Initiate OAuth connection for Gmail, Google Calendar, Outlook, Slack, Salesforce, HubSpot, or Attio.
+
+## When to Use Nex
+
+When the user asks about:
+- **People or companies** — contacts, relationships, org charts
+- **Deals or opportunities** — status, history, next steps
+- **Meetings or calls** — past conversations, upcoming schedules
+- **Emails or messages** — communication history
+- **Organizational context** — company knowledge, team notes, decisions
+
+Always try `nex_ask` first for general queries. Use `nex_search` when you need to find a specific record by name.
+
+# --- End Nex ---

--- a/cli/src/commands/integrate.ts
+++ b/cli/src/commands/integrate.ts
@@ -285,7 +285,16 @@ function interactiveList(items: FullIntegrationEntry[], client: NexClient, forma
       } else if (action.action === "disconnect" && action.connectionId !== undefined) {
         try {
           await client.delete(`/v1/integrations/connections/${encodeURIComponent(action.connectionId)}`);
-          process.stderr.write(`${sym.success} Disconnected successfully.\n`);
+          // Optimistic local update — remove connection from in-memory list
+          // so the UI reflects the change immediately (avoids read-replica lag)
+          item.connections = item.connections.filter((c) => c.id !== action.connectionId);
+          process.stdin.setRawMode(true);
+          process.stdin.resume();
+          process.stdin.on("data", onData);
+          expanded = true;
+          actionIndex = 0;
+          draw();
+          return; // Stay in interactive list
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           printError(`Failed to disconnect: ${msg}`);

--- a/cli/src/commands/setup.ts
+++ b/cli/src/commands/setup.ts
@@ -221,7 +221,7 @@ async function showStatus(format: Format, overrideApiKey?: string): Promise<void
 
 async function registerAndPersist(globalOpts: { timeout?: string; apiKey?: string }, existingEmail?: string): Promise<string> {
   const email = existingEmail ?? await ask("Email (required):", true);
-  const name = await ask("Name (optional):");
+  const name = existingEmail ? undefined : await ask("Name (optional):");
 
   process.stderr.write("\nRegistering...\n");
   const client = new NexClient(undefined, resolveTimeout(globalOpts.timeout));

--- a/cli/src/commands/setup.ts
+++ b/cli/src/commands/setup.ts
@@ -1,15 +1,16 @@
 /**
- * `nex setup` command — detect platforms, install plugin/MCP, create .nex.toml.
+ * `nex setup` command — detect platforms, install hooks/plugins/MCP, create .nex.toml.
  *
- * nex setup                     Interactive: detect → install plugin + scan files + config
+ * nex setup                     Interactive: detect → install full stack + scan files + config
  * nex setup --platform <name>   Direct install for specific platform
- * nex setup --with-mcp          Also install MCP server
- * nex setup --no-plugin         Skip hooks/commands, only config files
+ * nex setup --no-hooks          Skip hook installation
+ * nex setup --no-rules          Skip rules/instruction file installation
+ * nex setup --no-plugin         Skip hooks/commands (alias for --no-hooks)
  * nex setup --no-scan           Skip file scanning during setup
  * nex setup status              Show install status + integration connections
  */
 
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { program } from "../cli.js";
 import { resolveApiKey, resolveFormat, resolveTimeout, persistRegistration, loadConfig } from "../lib/config.js";
@@ -31,7 +32,19 @@ const INTEGRATIONS_MAP: Record<string, { type: string; provider: string }> = {
 };
 import { detectPlatforms, getPlatformById, VALID_PLATFORM_IDS } from "../lib/platform-detect.js";
 import type { Platform } from "../lib/platform-detect.js";
-import { installMcpServer, installClaudeCodePlugin, syncApiKeyToMcpConfig } from "../lib/installers.js";
+import {
+  installMcpServer,
+  installClaudeCodePlugin,
+  installRulesFile,
+  syncApiKeyToMcpConfig,
+  installHooks,
+  installOpenCodePlugin,
+  installOpenClawPlugin,
+  installVSCodeAgent,
+  installKiloCodeMode,
+  installContinueProvider,
+  installWindsurfWorkflows,
+} from "../lib/installers.js";
 import { writeDefaultProjectConfig } from "../lib/project-config.js";
 import { scanFiles, loadScanConfig, isScanEnabled } from "../lib/file-scanner.js";
 
@@ -39,6 +52,18 @@ function getClient(): { client: NexClient; format: Format } {
   const opts = program.opts();
   const client = new NexClient(resolveApiKey(opts.apiKey), resolveTimeout(opts.timeout));
   return { client, format: resolveFormat(opts.format) as Format };
+}
+
+// --- Helpers ---
+
+function hasNexMcpInConfig(platform: Platform): boolean {
+  try {
+    const raw = readFileSync(platform.configPath, "utf-8");
+    const config = JSON.parse(raw);
+    return !!(config?.mcpServers?.nex || config?.context_servers?.nex);
+  } catch {
+    return false;
+  }
 }
 
 // --- Status subcommand ---
@@ -57,6 +82,10 @@ async function showStatus(format: Format, overrideApiKey?: string): Promise<void
         detected: p.detected,
         nex_installed: p.nexInstalled,
         plugin_support: p.pluginSupport,
+        hooks: p.supportsHooks,
+        custom_tools: p.supportsCustomTools,
+        custom_agents: p.supportsCustomAgents,
+        workflows: p.supportsWorkflows,
       })),
       project_config: projectConfigExists(),
     };
@@ -105,12 +134,44 @@ async function showStatus(format: Format, overrideApiKey?: string): Promise<void
       return { label: statusLabel };
     }
     const children: string[] = [];
-    if (p.pluginSupport) {
-      children.push(p.nexInstalled ? badge("hooks installed", "success") : badge("not installed", "dim"));
+
+    // Hooks status
+    if (p.supportsHooks || p.pluginSupport) {
+      children.push(p.nexInstalled ? badge("hooks installed", "success") : badge("hooks not installed", "dim"));
     }
-    if (p.id !== "claude-code") {
-      children.push(p.nexInstalled ? badge("MCP installed", "success") : badge("not installed", "dim"));
+
+    // Custom tools/plugins
+    if (p.supportsCustomTools) {
+      children.push(badge("plugin support", "dim"));
     }
+
+    // Custom agents
+    if (p.supportsCustomAgents) {
+      children.push(badge("agent support", "dim"));
+    }
+
+    // Workflows
+    if (p.supportsWorkflows && p.id !== "claude-code") {
+      children.push(badge("workflows", "dim"));
+    }
+
+    // Rules
+    if (p.supportsRules) {
+      const rulesInstalled = p.rulesPath ? existsSync(p.rulesPath) : false;
+      children.push(rulesInstalled ? badge("rules installed", "success") : badge("rules not installed", "dim"));
+    }
+
+    // MCP
+    if (p.id !== "claude-code" && p.id !== "openclaw" && p.id !== "aider" && p.configPath) {
+      const mcpInstalled = hasNexMcpInConfig(p);
+      children.push(mcpInstalled ? badge("MCP installed", "success") : badge("MCP not installed", "dim"));
+    }
+
+    // OpenClaw plugin
+    if (p.id === "openclaw") {
+      children.push(p.nexInstalled ? badge("plugin installed", "success") : badge("plugin not installed", "dim"));
+    }
+
     return { label: `${p.displayName}`, children };
   });
   lines.push(tree(platformItems));
@@ -179,13 +240,17 @@ async function registerAndPersist(globalOpts: { timeout?: string; apiKey?: strin
 
 async function runSetup(opts: {
   platform?: string;
-  withMcp: boolean;
   noPlugin: boolean;
+  noHooks: boolean;
+  noRules: boolean;
   noScan: boolean;
   format: Format;
 }): Promise<void> {
   const globalOpts = program.opts();
   let apiKey = resolveApiKey(globalOpts.apiKey);
+
+  // Combine --no-plugin and --no-hooks (both skip hooks)
+  const skipHooks = opts.noPlugin || opts.noHooks;
 
   // 1. Register or re-register
   if (!apiKey) {
@@ -203,7 +268,7 @@ async function runSetup(opts: {
       // Still install plugin hooks/commands (they'll gracefully degrade without a key)
       const platforms = detectPlatforms().filter((p) => p.detected);
       for (const platform of platforms) {
-        if (platform.id === "claude-code" && !opts.noPlugin) {
+        if (platform.id === "claude-code" && !skipHooks) {
           installClaudeCodePlugin();
         }
       }
@@ -235,13 +300,10 @@ async function runSetup(opts: {
     ]);
 
     if (choice === 0) {
-      // Regenerate with existing email (no prompt)
       apiKey = await registerAndPersist(globalOpts, existingEmail);
     } else if (choice === 1) {
-      // Change email — prompt for new one
       apiKey = await registerAndPersist(globalOpts);
     }
-    // choice === 2: keep current key, do nothing
   }
 
   // 2. Sync API key to shared config
@@ -271,41 +333,99 @@ async function runSetup(opts: {
 
   const results: string[] = [];
 
-  // 4. Install for each platform
+  // 4. Install for each platform — 6-layer hierarchy
   for (const platform of targetPlatforms) {
-    // Claude Code — install plugin (hooks + commands) unless --no-plugin
-    if (platform.id === "claude-code" && !opts.noPlugin) {
-      const result = installClaudeCodePlugin();
-      if (result.installed) {
-        if (result.hooksAdded.length > 0) {
-          results.push(`Claude Code: hooks installed (${result.hooksAdded.join(", ")})`);
+    const installed: string[] = [];
+
+    // ── Layer 1: Hooks (event-driven scripts) ──
+    if (!skipHooks) {
+      if (platform.id === "claude-code" && platform.pluginSupport) {
+        // Claude Code has its own installer (hooks + slash commands)
+        const result = installClaudeCodePlugin();
+        if (result.installed) {
+          if (result.hooksAdded.length > 0) {
+            installed.push(`hooks (${result.hooksAdded.join(", ")})`);
+          }
+          if (result.commandsCopied.length > 0) {
+            installed.push(`commands (${result.commandsCopied.length} slash commands)`);
+          }
         } else {
-          results.push("Claude Code: hooks already configured");
+          results.push(`${platform.displayName}: bundled plugin not found — reinstall @nex-ai/nex`);
+          continue;
         }
-        if (result.commandsCopied.length > 0) {
-          results.push(`Claude Code: commands installed (${result.commandsCopied.join(", ")})`);
+      } else if (platform.supportsHooks) {
+        const result = installHooks(platform);
+        if (result.installed && result.hooksAdded.length > 0) {
+          installed.push(`hooks (${result.hooksAdded.join(", ")})`);
         }
-      } else {
-        results.push("Claude Code: bundled plugin not found — reinstall @nex-ai/nex");
       }
     }
 
-    // MCP server — only with --with-mcp
-    if (opts.withMcp && platform.id !== "claude-code") {
-      const result = installMcpServer(platform, apiKey);
+    // ── Layer 2: Custom tools/plugins ──
+    if (platform.id === "opencode" && platform.supportsCustomTools) {
+      const result = installOpenCodePlugin();
       if (result.installed) {
-        results.push(`${platform.displayName}: MCP server configured at ${result.configPath}`);
+        installed.push(`plugin (${result.pluginPath.replace(process.cwd() + "/", "")})`);
       }
-    } else if (platform.id !== "claude-code" && !opts.withMcp) {
-      results.push(`${platform.displayName}: detected — use --with-mcp to install MCP server`);
     }
 
-    // Claude Code MCP — also with --with-mcp
-    if (opts.withMcp && platform.id === "claude-code") {
+    if (platform.id === "openclaw" && platform.pluginSupport) {
+      const result = installOpenClawPlugin(apiKey);
+      installed.push(result.message);
+      if (!result.installed) {
+        results.push(`${platform.displayName}: ${result.message}`);
+        continue;
+      }
+    }
+
+    // ── Layer 3: Custom agents/modes ──
+    if (platform.supportsCustomAgents) {
+      if (platform.id === "vscode") {
+        const result = installVSCodeAgent();
+        if (result.installed) {
+          installed.push(`agent (${result.agentPath.replace(process.cwd() + "/", "")})`);
+        }
+      }
+      if (platform.id === "kilocode") {
+        const result = installKiloCodeMode();
+        if (result.installed) {
+          installed.push(`mode (${result.modePath.replace(process.cwd() + "/", "")})`);
+        }
+      }
+    }
+
+    // ── Layer 4: Workflows/slash commands ──
+    if (platform.supportsWorkflows && platform.id !== "claude-code") {
+      if (platform.id === "windsurf") {
+        const result = installWindsurfWorkflows();
+        if (result.installed) {
+          installed.push(`workflows (${result.workflowCount})`);
+        }
+      }
+    }
+
+    // ── Layer 5: Rules/instructions file ──
+    if (platform.supportsRules && !opts.noRules) {
+      const result = installRulesFile(platform);
+      if (result.installed) {
+        const relPath = result.rulesPath.replace(process.cwd() + "/", "");
+        installed.push(`rules (${relPath})`);
+      }
+    }
+
+    // ── Layer 6: MCP server ──
+    // For all platforms except: Claude Code (hooks-only), OpenClaw (plugin-only), Aider (no MCP)
+    if (platform.id !== "claude-code" && platform.id !== "openclaw" && platform.id !== "aider" && platform.configPath) {
       const result = installMcpServer(platform, apiKey);
       if (result.installed) {
-        results.push(`Claude Code: MCP server configured`);
+        installed.push(`MCP (${result.configPath})`);
       }
+    }
+
+    if (installed.length > 0) {
+      results.push(`${platform.displayName}: ${installed.join(" + ")}`);
+    } else {
+      results.push(`${platform.displayName}: detected`);
     }
   }
 
@@ -370,8 +490,6 @@ async function runSetup(opts: {
   }
 }
 
-// --- Helpers ---
-
 function maskKey(key: string): string {
   if (key.length <= 8) return "****";
   return key.slice(0, 4) + "****" + key.slice(-4);
@@ -388,16 +506,18 @@ const setup = program
   .command("setup")
   .description("Set up Nex integration for your development environment")
   .option("--platform <name>", `Target platform: ${VALID_PLATFORM_IDS.join(", ")}`)
-  .option("--with-mcp", "Also install MCP server for detected platforms", false)
   .option("--no-plugin", "Skip plugin (hooks/commands), only update config files")
+  .option("--no-hooks", "Skip hook installation for all platforms")
+  .option("--no-rules", "Skip rules/instruction file installation")
   .option("--no-scan", "Skip file scanning during setup")
   .action(async (cmdOpts) => {
     const globalOpts = program.opts();
     const format = resolveFormat(globalOpts.format) as Format;
     await runSetup({
       platform: cmdOpts.platform,
-      withMcp: cmdOpts.withMcp,
       noPlugin: cmdOpts.plugin === false,
+      noHooks: cmdOpts.hooks === false,
+      noRules: cmdOpts.rules === false,
       noScan: cmdOpts.scan === false,
       format,
     });

--- a/cli/src/lib/installers.ts
+++ b/cli/src/lib/installers.ts
@@ -1,16 +1,20 @@
 /**
- * Platform-specific installers for Nex MCP server and Claude Code plugin.
+ * Platform-specific installers for Nex MCP server, hooks, plugins, agents, and workflows.
  *
- * - Generic MCP installer handles 9/12 platforms (same JSON mcpServers format)
- * - Claude Code installer handles hooks + slash commands
- * - Zed installer uses context_servers instead of mcpServers
- * - Continue.dev writes YAML config
+ * Installation hierarchy (per platform):
+ *   1. Hooks (event-driven scripts)
+ *   2. Custom tools/plugins (OpenCode plugin, OpenClaw plugin)
+ *   3. Custom agents/modes (VS Code agent, Kilo Code mode)
+ *   4. Workflows/slash commands (Windsurf workflows)
+ *   5. Rules (instruction files)
+ *   6. MCP (tool protocol)
  */
 
 import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync, unlinkSync, copyFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
+import { execFileSync } from "node:child_process";
 import type { Platform } from "./platform-detect.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -22,7 +26,7 @@ const MCP_SERVER_ENTRY = {
   env: {} as Record<string, string>,
 };
 
-// --- Generic MCP Installer ---
+// ── Shared helpers ──────────────────────────────────────────────────────
 
 function readJsonFile(path: string): Record<string, unknown> {
   try {
@@ -38,10 +42,41 @@ function writeJsonFile(path: string, data: Record<string, unknown>): void {
   writeFileSync(path, JSON.stringify(data, null, 2) + "\n", "utf-8");
 }
 
+/**
+ * Resolve bundled plugin paths.
+ * From dist/lib/installers.js:
+ *   __dirname = <pkg>/dist/lib/
+ *   dist/plugin/ = __dirname/../plugin/
+ *   plugin-commands/ = __dirname/../../plugin-commands/
+ *   platform-plugins/ = __dirname/../../platform-plugins/
+ *   platform-rules/ = __dirname/../../platform-rules/
+ */
+function getPluginDistDir(): string {
+  return join(__dirname, "..", "plugin");
+}
+
+function getPluginCommandsDir(): string {
+  return join(__dirname, "..", "..", "plugin-commands");
+}
+
+function getPluginRulesDir(): string {
+  return join(__dirname, "..", "..", "platform-rules");
+}
+
+function getPlatformPluginsDir(): string {
+  return join(__dirname, "..", "..", "platform-plugins");
+}
+
+// ── 1. Generic MCP Installer ───────────────────────────────────────────
+
 export function installMcpServer(
   platform: Platform,
   apiKey: string,
 ): { installed: boolean; configPath: string } {
+  if (!platform.configPath) {
+    return { installed: false, configPath: "" };
+  }
+
   const entry = {
     ...MCP_SERVER_ENTRY,
     env: { NEX_API_KEY: apiKey },
@@ -88,8 +123,6 @@ function installContinueMcp(
   configPath: string,
   apiKey: string,
 ): { installed: boolean; configPath: string } {
-  // Continue.dev can also accept JSON in a separate mcpServers config
-  // Write a simple JSON file alongside the YAML
   const mcpPath = configPath.replace("config.yaml", "mcp.json");
   const config = readJsonFile(mcpPath);
 
@@ -105,7 +138,7 @@ function installContinueMcp(
   return { installed: true, configPath: mcpPath };
 }
 
-// --- Claude Code Plugin Installer ---
+// ── 2. Claude Code Plugin Installer ────────────────────────────────────
 
 interface HookEntry {
   type: string;
@@ -123,24 +156,6 @@ interface HookGroup {
 interface SettingsJson {
   hooks?: Record<string, HookGroup[]>;
   [key: string]: unknown;
-}
-
-/**
- * Resolve bundled plugin paths.
- * Plugin source is compiled into dist/plugin/ alongside the CLI.
- * Slash commands are at plugin-commands/ in the package root.
- *
- * From dist/lib/installers.js:
- *   __dirname = <pkg>/dist/lib/
- *   dist/plugin/ = __dirname/../plugin/
- *   plugin-commands/ = __dirname/../../plugin-commands/
- */
-function getPluginDistDir(): string {
-  return join(__dirname, "..", "plugin");
-}
-
-function getPluginCommandsDir(): string {
-  return join(__dirname, "..", "..", "plugin-commands");
 }
 
 export function installClaudeCodePlugin(): {
@@ -246,29 +261,442 @@ export function installClaudeCodePlugin(): {
         const target = join(commandsDir, entry);
         const source = join(sourceCommandsDir, entry);
 
-        // Remove stale symlink or existing file, then copy fresh
-        try {
-          unlinkSync(target);
-        } catch {
-          // File didn't exist — fine
-        }
+        try { unlinkSync(target); } catch { /* File didn't exist */ }
 
         try {
           copyFileSync(source, target);
           commandsCopied.push(entry);
-        } catch {
-          // Copy failed — non-critical
-        }
+        } catch { /* Copy failed — non-critical */ }
       }
-    } catch {
-      // Commands dir read failed — non-critical
-    }
+    } catch { /* Commands dir read failed — non-critical */ }
   }
 
   return { installed: true, hooksAdded, commandsCopied };
 }
 
-// --- Sync API key to ~/.nex-mcp.json ---
+// ── 3. Hook Installers (Cursor, Windsurf, Cline) ──────────────────────
+
+/**
+ * Install hook scripts for platforms that support event-driven hooks.
+ * Each platform has its own adapter scripts in dist/plugin/adapters/.
+ */
+export function installHooks(
+  platform: Platform,
+): { installed: boolean; hooksAdded: string[] } {
+  // Claude Code handled separately via installClaudeCodePlugin
+  if (platform.id === "claude-code") {
+    return { installed: false, hooksAdded: [] };
+  }
+
+  const adapterDir = join(getPluginDistDir(), "adapters");
+  if (!existsSync(adapterDir)) {
+    return { installed: false, hooksAdded: [] };
+  }
+
+  if (platform.id === "cursor") return installCursorHooks(adapterDir, platform);
+  if (platform.id === "windsurf") return installWindsurfHooks(adapterDir, platform);
+  if (platform.id === "cline") return installClineHooks(adapterDir, platform);
+
+  return { installed: false, hooksAdded: [] };
+}
+
+function installCursorHooks(
+  adapterDir: string,
+  platform: Platform,
+): { installed: boolean; hooksAdded: string[] } {
+  const hookConfigPath = platform.hookConfigPath;
+  if (!hookConfigPath) return { installed: false, hooksAdded: [] };
+
+  const config = readJsonFile(hookConfigPath);
+  if (!config.hooks || typeof config.hooks !== "object") {
+    config.hooks = {};
+  }
+
+  const hooks = config.hooks as Record<string, unknown[]>;
+  const hooksAdded: string[] = [];
+
+  const cursorHookDefs = [
+    { event: "sessionStart", script: "cursor-session-start.js", timeout: 120000 },
+    { event: "userPromptSubmit", script: "cursor-recall.js", timeout: 10000 },
+    { event: "stop", script: "cursor-stop.js", timeout: 10000 },
+  ];
+
+  for (const def of cursorHookDefs) {
+    const scriptPath = join(adapterDir, def.script);
+    if (!existsSync(scriptPath)) continue;
+
+    if (!hooks[def.event]) hooks[def.event] = [];
+
+    // Remove existing nex hooks
+    hooks[def.event] = (hooks[def.event] as Array<Record<string, unknown>>).filter(
+      (h) => !String(h.command ?? "").includes("nex")
+    );
+
+    (hooks[def.event] as unknown[]).push({
+      type: "command",
+      command: `node ${scriptPath}`,
+      timeout: def.timeout,
+    });
+    hooksAdded.push(def.event);
+  }
+
+  writeJsonFile(hookConfigPath, config);
+  return { installed: true, hooksAdded };
+}
+
+function installWindsurfHooks(
+  adapterDir: string,
+  platform: Platform,
+): { installed: boolean; hooksAdded: string[] } {
+  const hookConfigPath = platform.hookConfigPath;
+  if (!hookConfigPath) return { installed: false, hooksAdded: [] };
+
+  const config = readJsonFile(hookConfigPath);
+  if (!config.hooks || typeof config.hooks !== "object") {
+    config.hooks = {};
+  }
+
+  const hooks = config.hooks as Record<string, unknown[]>;
+  const hooksAdded: string[] = [];
+
+  const windsurfHookDefs = [
+    { event: "pre_user_prompt", script: "windsurf-recall.js", timeout: 10000 },
+    { event: "post_cascade_response", script: "windsurf-capture.js", timeout: 10000 },
+  ];
+
+  for (const def of windsurfHookDefs) {
+    const scriptPath = join(adapterDir, def.script);
+    if (!existsSync(scriptPath)) continue;
+
+    if (!hooks[def.event]) hooks[def.event] = [];
+
+    hooks[def.event] = (hooks[def.event] as Array<Record<string, unknown>>).filter(
+      (h) => !String(h.command ?? "").includes("nex")
+    );
+
+    (hooks[def.event] as unknown[]).push({
+      type: "command",
+      command: `node ${scriptPath}`,
+      timeout: def.timeout,
+    });
+    hooksAdded.push(def.event);
+  }
+
+  writeJsonFile(hookConfigPath, config);
+  return { installed: true, hooksAdded };
+}
+
+function installClineHooks(
+  adapterDir: string,
+  platform: Platform,
+): { installed: boolean; hooksAdded: string[] } {
+  // Cline uses executable files in .clinerules/hooks/
+  const hookDir = platform.hookConfigPath;
+  if (!hookDir) return { installed: false, hooksAdded: [] };
+
+  mkdirSync(hookDir, { recursive: true });
+  const hooksAdded: string[] = [];
+
+  const clineHookDefs = [
+    { event: "UserPromptSubmit", script: "cline-recall.js" },
+    { event: "TaskStart", script: "cline-task-start.js" },
+    { event: "TaskComplete", script: "cline-capture.js" },
+  ];
+
+  for (const def of clineHookDefs) {
+    const scriptPath = join(adapterDir, def.script);
+    if (!existsSync(scriptPath)) continue;
+
+    // Write a shell wrapper that invokes node with the adapter script
+    const wrapperPath = join(hookDir, `nex-${def.event.toLowerCase()}`);
+    const wrapper = `#!/usr/bin/env sh\nexec node "${scriptPath}" "$@"\n`;
+    writeFileSync(wrapperPath, wrapper, { mode: 0o755 });
+    hooksAdded.push(def.event);
+  }
+
+  return { installed: true, hooksAdded };
+}
+
+// ── 4. Custom Tool/Plugin Installers ───────────────────────────────────
+
+/**
+ * Install OpenCode plugin template to .opencode/plugins/nex.ts.
+ */
+export function installOpenCodePlugin(): {
+  installed: boolean;
+  pluginPath: string;
+} {
+  const templatePath = join(getPlatformPluginsDir(), "opencode-plugin.ts");
+  if (!existsSync(templatePath)) {
+    return { installed: false, pluginPath: "" };
+  }
+
+  const targetDir = join(process.cwd(), ".opencode", "plugins");
+  const targetPath = join(targetDir, "nex.ts");
+
+  mkdirSync(targetDir, { recursive: true });
+  copyFileSync(templatePath, targetPath);
+
+  return { installed: true, pluginPath: targetPath };
+}
+
+/**
+ * Install OpenClaw plugin via CLI.
+ */
+export function installOpenClawPlugin(
+  apiKey: string,
+): { installed: boolean; message: string } {
+  // Check if openclaw CLI is available
+  let hasOpenClaw = false;
+  try {
+    execFileSync("which", ["openclaw"], { stdio: "ignore" });
+    hasOpenClaw = true;
+  } catch { /* not installed */ }
+
+  if (!hasOpenClaw) {
+    return {
+      installed: false,
+      message: "Install OpenClaw to enable: https://docs.openclaw.ai/install",
+    };
+  }
+
+  // Check if plugin already installed
+  const configPath = join(homedir(), ".openclaw", "openclaw.json");
+  const config = readJsonFile(configPath);
+  const plugins = (config.plugins ?? {}) as Record<string, unknown>;
+  const entries = (plugins.entries ?? {}) as Record<string, Record<string, unknown>>;
+
+  if (!entries.nex) {
+    // Install the plugin
+    try {
+      execFileSync("openclaw", ["plugins", "install", "@nex-ai/openclaw-plugin"], {
+        stdio: "ignore",
+        timeout: 30_000,
+      });
+    } catch {
+      return { installed: false, message: "Failed to install OpenClaw plugin" };
+    }
+  }
+
+  // Configure API key
+  const freshConfig = readJsonFile(configPath);
+  const freshPlugins = (freshConfig.plugins ?? {}) as Record<string, unknown>;
+  const freshEntries = (freshPlugins.entries ?? {}) as Record<string, Record<string, unknown>>;
+
+  if (!freshEntries.nex) freshEntries.nex = {};
+  if (!freshEntries.nex.config) freshEntries.nex.config = {};
+  (freshEntries.nex.config as Record<string, unknown>).apiKey = apiKey;
+  freshEntries.nex.enabled = true;
+
+  freshPlugins.entries = freshEntries;
+  freshConfig.plugins = freshPlugins;
+
+  writeJsonFile(configPath, freshConfig);
+  return { installed: true, message: "OpenClaw plugin installed and configured" };
+}
+
+// ── 5. Custom Agent/Mode Installers ────────────────────────────────────
+
+/**
+ * Install VS Code custom agent (.github/agents/nex.agent.md).
+ */
+export function installVSCodeAgent(): {
+  installed: boolean;
+  agentPath: string;
+} {
+  const templatePath = join(getPlatformPluginsDir(), "vscode-agent.md");
+  if (!existsSync(templatePath)) {
+    return { installed: false, agentPath: "" };
+  }
+
+  const targetDir = join(process.cwd(), ".github", "agents");
+  const targetPath = join(targetDir, "nex.agent.md");
+
+  mkdirSync(targetDir, { recursive: true });
+  copyFileSync(templatePath, targetPath);
+
+  return { installed: true, agentPath: targetPath };
+}
+
+/**
+ * Install Kilo Code custom mode (.kilocodemodes YAML).
+ */
+export function installKiloCodeMode(): {
+  installed: boolean;
+  modePath: string;
+} {
+  const templatePath = join(getPlatformPluginsDir(), "kilocode-modes.yaml");
+  if (!existsSync(templatePath)) {
+    return { installed: false, modePath: "" };
+  }
+
+  const targetPath = join(process.cwd(), ".kilocodemodes");
+
+  // Read existing modes file if present
+  let existing = "";
+  try {
+    existing = readFileSync(targetPath, "utf-8");
+  } catch { /* doesn't exist */ }
+
+  // If already has nex-crm mode, skip
+  if (existing.includes("nex-crm")) {
+    return { installed: true, modePath: targetPath };
+  }
+
+  const template = readFileSync(templatePath, "utf-8");
+
+  if (existing) {
+    // Append to existing customModes
+    // Remove the "customModes:" header from template since it already exists
+    const modesContent = template.replace(/^customModes:\s*\n/, "");
+    writeFileSync(targetPath, existing.trimEnd() + "\n" + modesContent, "utf-8");
+  } else {
+    writeFileSync(targetPath, template, "utf-8");
+  }
+
+  return { installed: true, modePath: targetPath };
+}
+
+/**
+ * Install Continue.dev context provider template.
+ */
+export function installContinueProvider(): {
+  installed: boolean;
+  providerPath: string;
+} {
+  const templatePath = join(getPlatformPluginsDir(), "continue-provider.ts");
+  if (!existsSync(templatePath)) {
+    return { installed: false, providerPath: "" };
+  }
+
+  const continueBase = existsSync(join(process.cwd(), ".continue"))
+    ? join(process.cwd(), ".continue")
+    : join(homedir(), ".continue");
+
+  const targetDir = join(continueBase, ".plugins");
+  const targetPath = join(targetDir, "nex-provider.ts");
+
+  mkdirSync(targetDir, { recursive: true });
+  copyFileSync(templatePath, targetPath);
+
+  return { installed: true, providerPath: targetPath };
+}
+
+// ── 6. Workflow Installers ─────────────────────────────────────────────
+
+/**
+ * Install Windsurf workflow files (slash commands).
+ */
+export function installWindsurfWorkflows(): {
+  installed: boolean;
+  workflowCount: number;
+} {
+  const sourceDir = join(getPlatformPluginsDir(), "windsurf-workflows");
+  if (!existsSync(sourceDir)) {
+    return { installed: false, workflowCount: 0 };
+  }
+
+  const targetDir = join(process.cwd(), ".windsurf", "workflows");
+  mkdirSync(targetDir, { recursive: true });
+
+  let count = 0;
+  try {
+    const entries = readdirSync(sourceDir);
+    for (const entry of entries) {
+      if (!entry.endsWith(".md")) continue;
+      copyFileSync(join(sourceDir, entry), join(targetDir, entry));
+      count++;
+    }
+  } catch { /* non-critical */ }
+
+  return { installed: count > 0, workflowCount: count };
+}
+
+// ── 7. Rules File Installer ────────────────────────────────────────────
+
+const NEX_RULES_MARKER_START = "# --- Nex Context & Memory ---";
+const NEX_RULES_MARKER_END = "# --- End Nex ---";
+
+/**
+ * Map platform ID to its rules template filename.
+ */
+const RULES_TEMPLATE_MAP: Record<string, string> = {
+  cursor: "cursor-rules.md",
+  vscode: "vscode-instructions.md",
+  windsurf: "windsurf-rules.md",
+  cline: "cline-rules.md",
+  continue: "continue-rules.md",
+  zed: "zed-rules.md",
+  kilocode: "kilocode-rules.md",
+  opencode: "opencode-agents.md",
+  aider: "aider-conventions.md",
+};
+
+/**
+ * Platforms where rules are APPENDED to an existing file (with markers)
+ * rather than written as a standalone file.
+ */
+const APPEND_PLATFORMS = new Set(["zed", "opencode", "aider"]);
+
+export function installRulesFile(
+  platform: Platform,
+): { installed: boolean; rulesPath: string } {
+  const rulesPath = platform.rulesPath;
+  if (!rulesPath) {
+    return { installed: false, rulesPath: "" };
+  }
+
+  const templateName = RULES_TEMPLATE_MAP[platform.id];
+  if (!templateName) {
+    return { installed: false, rulesPath: "" };
+  }
+
+  const templatePath = join(getPluginRulesDir(), templateName);
+  if (!existsSync(templatePath)) {
+    return { installed: false, rulesPath: "" };
+  }
+
+  const template = readFileSync(templatePath, "utf-8");
+
+  if (APPEND_PLATFORMS.has(platform.id)) {
+    // Append mode: add/replace section in existing file
+    let existing = "";
+    try {
+      existing = readFileSync(rulesPath, "utf-8");
+    } catch {
+      // File doesn't exist — will create
+    }
+
+    // Check if nex section already exists
+    const startIdx = existing.indexOf(NEX_RULES_MARKER_START);
+    const endIdx = existing.indexOf(NEX_RULES_MARKER_END);
+
+    if (startIdx !== -1 && endIdx !== -1) {
+      // Replace existing section
+      const before = existing.slice(0, startIdx);
+      const after = existing.slice(endIdx + NEX_RULES_MARKER_END.length);
+      const updated = before + template.trim() + after;
+      mkdirSync(dirname(rulesPath), { recursive: true });
+      writeFileSync(rulesPath, updated, "utf-8");
+    } else if (existing.includes("nex_ask") || existing.includes("Nex Context")) {
+      // Already has nex content without markers — skip to avoid duplicates
+      return { installed: true, rulesPath };
+    } else {
+      // Append to end
+      const separator = existing && !existing.endsWith("\n\n") ? "\n\n" : "";
+      mkdirSync(dirname(rulesPath), { recursive: true });
+      writeFileSync(rulesPath, existing + separator + template.trim() + "\n", "utf-8");
+    }
+  } else {
+    // Standalone mode: write the file directly
+    mkdirSync(dirname(rulesPath), { recursive: true });
+    writeFileSync(rulesPath, template, "utf-8");
+  }
+
+  return { installed: true, rulesPath };
+}
+
+// ── 8. Sync API key to ~/.nex-mcp.json ─────────────────────────────────
 
 export function syncApiKeyToMcpConfig(apiKey: string): void {
   const mcpConfigPath = join(homedir(), ".nex-mcp.json");

--- a/cli/src/lib/platform-detect.ts
+++ b/cli/src/lib/platform-detect.ts
@@ -13,6 +13,13 @@ export interface Platform {
   detected: boolean;
   nexInstalled: boolean;
   pluginSupport: boolean;
+  supportsRules: boolean;
+  supportsHooks: boolean;
+  supportsCustomTools: boolean;
+  supportsCustomAgents: boolean;
+  supportsWorkflows: boolean;
+  hookConfigPath: string | null;
+  rulesPath: string | null;
   configPath: string;
   configFormat: "standard" | "zed" | "continue";
 }
@@ -38,6 +45,16 @@ function hasNexMcpEntry(configPath: string, key = "nex"): boolean {
     const config = JSON.parse(raw);
     // Check mcpServers.nex or context_servers.nex
     return !!(config?.mcpServers?.[key] || config?.context_servers?.[key]);
+  } catch {
+    return false;
+  }
+}
+
+function hasNexRules(rulesPath: string | null): boolean {
+  if (!rulesPath) return false;
+  try {
+    const content = readFileSync(rulesPath, "utf-8");
+    return content.includes("Nex") && (content.includes("nex_ask") || content.includes("Nex Context"));
   } catch {
     return false;
   }
@@ -85,8 +102,38 @@ function clineConfigPath(): string {
   return join(home, ".config", "Code", "User", "globalStorage", "saoudrizwan.claude-dev", "settings", "cline_mcp_settings.json");
 }
 
+function openclawConfigPath(): string {
+  return join(home, ".openclaw", "openclaw.json");
+}
+
+function hasOpenClawNexPlugin(): boolean {
+  try {
+    const raw = readFileSync(openclawConfigPath(), "utf-8");
+    const config = JSON.parse(raw);
+    return !!(config?.plugins?.entries?.nex);
+  } catch {
+    return false;
+  }
+}
+
 export function detectPlatforms(): Platform[] {
   const cwd = process.cwd();
+
+  // Rules paths (project-local)
+  const cursorRulesPath = join(cwd, ".cursor", "rules", "nex.md");
+  const vscodeRulesPath = join(cwd, ".github", "instructions", "nex.instructions.md");
+  const windsurfRulesPath = join(cwd, ".windsurf", "rules", "nex.md");
+  const clineRulesPath = join(cwd, ".clinerules", "nex.md");
+  const continueBase = exists(join(cwd, ".continue")) ? join(cwd, ".continue") : join(home, ".continue");
+  const continueRulesPath = join(continueBase, "rules", "nex.md");
+  const zedRulesPath = join(cwd, ".rules");
+  const kilocodeRulesPath = join(cwd, ".kilocode", "rules", "nex.md");
+  const opencodeRulesPath = join(cwd, "AGENTS.md");
+
+  // Hook config paths
+  const cursorHookConfigPath = join(home, ".cursor", "hooks.json");
+  const windsurfHookConfigPath = join(cwd, ".windsurf", "hooks.json");
+  const clineHookDir = join(cwd, ".clinerules", "hooks");
 
   const platforms: Platform[] = [
     {
@@ -95,6 +142,13 @@ export function detectPlatforms(): Platform[] {
       detected: exists(join(home, ".claude")),
       nexInstalled: hasClaudeCodePlugin(),
       pluginSupport: true,
+      supportsRules: false,
+      supportsHooks: true,
+      supportsCustomTools: false,
+      supportsCustomAgents: false,
+      supportsWorkflows: true, // slash commands
+      hookConfigPath: join(home, ".claude", "settings.json"),
+      rulesPath: null,
       configPath: join(home, ".claude", "settings.json"),
       configFormat: "standard",
     },
@@ -104,6 +158,13 @@ export function detectPlatforms(): Platform[] {
       detected: exists(claudeDesktopConfigPath()),
       nexInstalled: hasNexMcpEntry(claudeDesktopConfigPath()),
       pluginSupport: false,
+      supportsRules: false,
+      supportsHooks: false,
+      supportsCustomTools: false,
+      supportsCustomAgents: false,
+      supportsWorkflows: false,
+      hookConfigPath: null,
+      rulesPath: null,
       configPath: claudeDesktopConfigPath(),
       configFormat: "standard",
     },
@@ -111,8 +172,15 @@ export function detectPlatforms(): Platform[] {
       id: "cursor",
       displayName: "Cursor",
       detected: exists(join(home, ".cursor")),
-      nexInstalled: hasNexMcpEntry(join(home, ".cursor", "mcp.json")),
+      nexInstalled: hasNexMcpEntry(join(home, ".cursor", "mcp.json")) || hasNexRules(cursorRulesPath),
       pluginSupport: false,
+      supportsRules: true,
+      supportsHooks: true,
+      supportsCustomTools: false,
+      supportsCustomAgents: false,
+      supportsWorkflows: false,
+      hookConfigPath: cursorHookConfigPath,
+      rulesPath: cursorRulesPath,
       configPath: join(home, ".cursor", "mcp.json"),
       configFormat: "standard",
     },
@@ -120,8 +188,15 @@ export function detectPlatforms(): Platform[] {
       id: "vscode",
       displayName: "VS Code",
       detected: whichExists("code") || exists(join(cwd, ".vscode")),
-      nexInstalled: hasNexMcpEntry(join(cwd, ".vscode", "mcp.json")),
+      nexInstalled: hasNexMcpEntry(join(cwd, ".vscode", "mcp.json")) || hasNexRules(vscodeRulesPath),
       pluginSupport: false,
+      supportsRules: true,
+      supportsHooks: false,
+      supportsCustomTools: false,
+      supportsCustomAgents: true,
+      supportsWorkflows: false,
+      hookConfigPath: null,
+      rulesPath: vscodeRulesPath,
       configPath: join(cwd, ".vscode", "mcp.json"),
       configFormat: "standard",
     },
@@ -129,8 +204,15 @@ export function detectPlatforms(): Platform[] {
       id: "windsurf",
       displayName: "Windsurf",
       detected: exists(join(home, ".codeium", "windsurf")),
-      nexInstalled: hasNexMcpEntry(join(home, ".codeium", "windsurf", "mcp_config.json")),
+      nexInstalled: hasNexMcpEntry(join(home, ".codeium", "windsurf", "mcp_config.json")) || hasNexRules(windsurfRulesPath),
       pluginSupport: false,
+      supportsRules: true,
+      supportsHooks: true,
+      supportsCustomTools: false,
+      supportsCustomAgents: false,
+      supportsWorkflows: true,
+      hookConfigPath: windsurfHookConfigPath,
+      rulesPath: windsurfRulesPath,
       configPath: join(home, ".codeium", "windsurf", "mcp_config.json"),
       configFormat: "standard",
     },
@@ -138,8 +220,15 @@ export function detectPlatforms(): Platform[] {
       id: "cline",
       displayName: "Cline",
       detected: hasClineExtension(),
-      nexInstalled: hasNexMcpEntry(clineConfigPath()),
+      nexInstalled: hasNexMcpEntry(clineConfigPath()) || hasNexRules(clineRulesPath),
       pluginSupport: false,
+      supportsRules: true,
+      supportsHooks: true,
+      supportsCustomTools: false,
+      supportsCustomAgents: false,
+      supportsWorkflows: false,
+      hookConfigPath: clineHookDir,
+      rulesPath: clineRulesPath,
       configPath: clineConfigPath(),
       configFormat: "standard",
     },
@@ -147,8 +236,15 @@ export function detectPlatforms(): Platform[] {
       id: "zed",
       displayName: "Zed",
       detected: exists(join(home, ".config", "zed")),
-      nexInstalled: hasNexMcpEntry(join(home, ".config", "zed", "settings.json"), "nex"),
+      nexInstalled: hasNexMcpEntry(join(home, ".config", "zed", "settings.json"), "nex") || hasNexRules(zedRulesPath),
       pluginSupport: false,
+      supportsRules: true,
+      supportsHooks: false,
+      supportsCustomTools: false,
+      supportsCustomAgents: false,
+      supportsWorkflows: false,
+      hookConfigPath: null,
+      rulesPath: zedRulesPath,
       configPath: join(home, ".config", "zed", "settings.json"),
       configFormat: "zed",
     },
@@ -156,8 +252,15 @@ export function detectPlatforms(): Platform[] {
       id: "continue",
       displayName: "Continue.dev",
       detected: exists(join(cwd, ".continue")) || exists(join(home, ".continue")),
-      nexInstalled: false, // YAML check would be complex — just report not installed
+      nexInstalled: hasNexRules(continueRulesPath),
       pluginSupport: false,
+      supportsRules: true,
+      supportsHooks: false,
+      supportsCustomTools: false,
+      supportsCustomAgents: false,
+      supportsWorkflows: false,
+      hookConfigPath: null,
+      rulesPath: continueRulesPath,
       configPath: exists(join(cwd, ".continue"))
         ? join(cwd, ".continue", "config.yaml")
         : join(home, ".continue", "config.yaml"),
@@ -167,8 +270,15 @@ export function detectPlatforms(): Platform[] {
       id: "kilocode",
       displayName: "Kilo Code",
       detected: exists(join(cwd, ".kilocode")),
-      nexInstalled: hasNexMcpEntry(join(cwd, ".kilocode", "mcp.json")),
+      nexInstalled: hasNexMcpEntry(join(cwd, ".kilocode", "mcp.json")) || hasNexRules(kilocodeRulesPath),
       pluginSupport: false,
+      supportsRules: true,
+      supportsHooks: false,
+      supportsCustomTools: false,
+      supportsCustomAgents: true,
+      supportsWorkflows: false,
+      hookConfigPath: null,
+      rulesPath: kilocodeRulesPath,
       configPath: join(cwd, ".kilocode", "mcp.json"),
       configFormat: "standard",
     },
@@ -176,9 +286,48 @@ export function detectPlatforms(): Platform[] {
       id: "opencode",
       displayName: "OpenCode",
       detected: exists(join(home, ".config", "opencode")),
-      nexInstalled: hasNexMcpEntry(join(home, ".config", "opencode", "opencode.json")),
+      nexInstalled: hasNexMcpEntry(join(home, ".config", "opencode", "opencode.json")) || hasNexRules(opencodeRulesPath),
       pluginSupport: false,
+      supportsRules: true,
+      supportsHooks: false,
+      supportsCustomTools: true,
+      supportsCustomAgents: false,
+      supportsWorkflows: false,
+      hookConfigPath: null,
+      rulesPath: opencodeRulesPath,
       configPath: join(home, ".config", "opencode", "opencode.json"),
+      configFormat: "standard",
+    },
+    {
+      id: "openclaw",
+      displayName: "OpenClaw",
+      detected: whichExists("openclaw") || exists(join(home, ".openclaw")),
+      nexInstalled: hasOpenClawNexPlugin(),
+      pluginSupport: true,
+      supportsRules: false,
+      supportsHooks: false, // Hooks handled by the plugin internally
+      supportsCustomTools: false,
+      supportsCustomAgents: false,
+      supportsWorkflows: false,
+      hookConfigPath: null,
+      rulesPath: null,
+      configPath: openclawConfigPath(),
+      configFormat: "standard",
+    },
+    {
+      id: "aider",
+      displayName: "Aider",
+      detected: whichExists("aider") || exists(join(cwd, "CONVENTIONS.md")),
+      nexInstalled: hasNexRules(join(cwd, "CONVENTIONS.md")),
+      pluginSupport: false,
+      supportsRules: true,
+      supportsHooks: false,
+      supportsCustomTools: false,
+      supportsCustomAgents: false,
+      supportsWorkflows: false,
+      hookConfigPath: null,
+      rulesPath: join(cwd, "CONVENTIONS.md"),
+      configPath: "", // Aider has no MCP support
       configFormat: "standard",
     },
   ];
@@ -205,4 +354,6 @@ export const VALID_PLATFORM_IDS = [
   "zed",
   "kilocode",
   "opencode",
+  "openclaw",
+  "aider",
 ];

--- a/cli/src/lib/project-config.ts
+++ b/cli/src/lib/project-config.ts
@@ -176,7 +176,7 @@ const DEFAULT_TOML = `# .nex.toml — Nex project configuration
 # depth = 2
 
 # [mcp]
-# enabled = false             # Set to true by \`nex setup --with-mcp\`
+# enabled = true              # MCP installed by default; use --no-mcp to skip
 
 # [output]
 # format = "text"             # "text" | "json"

--- a/cli/src/plugin/adapters/cline-capture.ts
+++ b/cli/src/plugin/adapters/cline-capture.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+/**
+ * Cline TaskComplete hook — auto-capture to Nex.
+ * Input: { taskComplete: { result: string } }
+ * Output: {}
+ */
+
+import { doCapture, readStdin } from "../shared.js";
+
+interface ClineInput {
+  taskComplete?: { result?: string };
+}
+
+async function main(): Promise<void> {
+  try {
+    const raw = await readStdin();
+    let input: ClineInput = {};
+    try { input = JSON.parse(raw); } catch { /* defaults */ }
+
+    await doCapture({ message: input.taskComplete?.result ?? "" });
+    process.stdout.write("{}");
+  } catch (err) {
+    process.stderr.write(`[nex-cline] Capture error: ${err instanceof Error ? err.message : String(err)}\n`);
+    process.stdout.write("{}");
+  }
+}
+
+main().then(() => process.exit(0)).catch(() => process.exit(0));

--- a/cli/src/plugin/adapters/cline-recall.ts
+++ b/cli/src/plugin/adapters/cline-recall.ts
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+/**
+ * Cline UserPromptSubmit hook — auto-recall from Nex.
+ * Input: { userPromptSubmit: { prompt: string } }
+ * Output: { contextModification: "..." } or {}
+ */
+
+import { doRecall, readStdin } from "../shared.js";
+
+interface ClineInput {
+  userPromptSubmit?: { prompt?: string };
+  session_id?: string;
+}
+
+async function main(): Promise<void> {
+  try {
+    const raw = await readStdin();
+    let input: ClineInput = {};
+    try { input = JSON.parse(raw); } catch { /* defaults */ }
+
+    const prompt = input.userPromptSubmit?.prompt ?? "";
+    const result = await doRecall(prompt, input.session_id);
+
+    if (!result) {
+      process.stdout.write("{}");
+      return;
+    }
+
+    process.stdout.write(JSON.stringify({ contextModification: result.context }));
+  } catch (err) {
+    process.stderr.write(`[nex-cline] Recall error: ${err instanceof Error ? err.message : String(err)}\n`);
+    process.stdout.write("{}");
+  }
+}
+
+main().then(() => process.exit(0)).catch(() => process.exit(0));

--- a/cli/src/plugin/adapters/cline-task-start.ts
+++ b/cli/src/plugin/adapters/cline-task-start.ts
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+/**
+ * Cline TaskStart hook — load baseline context from Nex.
+ * Input: { taskStart: { task: string } }
+ * Output: { contextModification: "..." } or {}
+ */
+
+import { doSessionStart, readStdin } from "../shared.js";
+
+interface ClineInput {
+  taskStart?: { task?: string };
+  session_id?: string;
+}
+
+async function main(): Promise<void> {
+  try {
+    const raw = await readStdin();
+    let input: ClineInput = {};
+    try { input = JSON.parse(raw); } catch { /* defaults */ }
+
+    const result = await doSessionStart("startup", input.session_id);
+    if (!result) {
+      process.stdout.write("{}");
+      return;
+    }
+
+    const context = result.registrationPrompt ?? result.context;
+    process.stdout.write(JSON.stringify({ contextModification: context }));
+  } catch (err) {
+    process.stderr.write(`[nex-cline] Task start error: ${err instanceof Error ? err.message : String(err)}\n`);
+    process.stdout.write("{}");
+  }
+}
+
+main().then(() => process.exit(0)).catch(() => process.exit(0));

--- a/cli/src/plugin/adapters/cursor-recall.ts
+++ b/cli/src/plugin/adapters/cursor-recall.ts
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+/**
+ * Cursor userPromptSubmit hook — auto-recall from Nex.
+ * Input: { prompt?: string, attachments?: unknown[], session_id?: string }
+ * Output: { continue: true, user_message: "<original + context>" } or {}
+ */
+
+import { doRecall, readStdin } from "../shared.js";
+
+interface CursorInput {
+  prompt?: string;
+  attachments?: unknown[];
+  session_id?: string;
+}
+
+async function main(): Promise<void> {
+  try {
+    const raw = await readStdin();
+    let input: CursorInput = {};
+    try { input = JSON.parse(raw); } catch { /* defaults */ }
+
+    const prompt = input.prompt ?? "";
+    const result = await doRecall(prompt, input.session_id);
+
+    if (!result) {
+      process.stdout.write("{}");
+      return;
+    }
+
+    // Inject context as additional_context (Cursor's context injection mechanism)
+    process.stdout.write(JSON.stringify({ additional_context: result.context }));
+  } catch (err) {
+    process.stderr.write(`[nex-cursor] Recall error: ${err instanceof Error ? err.message : String(err)}\n`);
+    process.stdout.write("{}");
+  }
+}
+
+main().then(() => process.exit(0)).catch(() => process.exit(0));

--- a/cli/src/plugin/adapters/cursor-session-start.ts
+++ b/cli/src/plugin/adapters/cursor-session-start.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * Cursor sessionStart hook — load baseline context from Nex.
+ * Input: { session_id?: string }
+ * Output: { additional_context: "..." } or {}
+ */
+
+import { doSessionStart, readStdin } from "../shared.js";
+
+async function main(): Promise<void> {
+  try {
+    const raw = await readStdin();
+    let input: { session_id?: string } = {};
+    try { input = JSON.parse(raw); } catch { /* defaults */ }
+
+    const result = await doSessionStart("startup", input.session_id);
+    if (!result) {
+      process.stdout.write("{}");
+      return;
+    }
+
+    const context = result.registrationPrompt ?? result.context;
+    process.stdout.write(JSON.stringify({ additional_context: context }));
+  } catch (err) {
+    process.stderr.write(`[nex-cursor] Session start error: ${err instanceof Error ? err.message : String(err)}\n`);
+    process.stdout.write("{}");
+  }
+}
+
+main().then(() => process.exit(0)).catch(() => process.exit(0));

--- a/cli/src/plugin/adapters/cursor-stop.ts
+++ b/cli/src/plugin/adapters/cursor-stop.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * Cursor stop hook — auto-capture conversation to Nex.
+ * Input: { last_message?: string, status?: string, session_id?: string }
+ * Output: {}
+ */
+
+import { doCapture, readStdin } from "../shared.js";
+
+interface CursorStopInput {
+  last_message?: string;
+  status?: string;
+  session_id?: string;
+}
+
+async function main(): Promise<void> {
+  try {
+    const raw = await readStdin();
+    let input: CursorStopInput = {};
+    try { input = JSON.parse(raw); } catch { /* defaults */ }
+
+    await doCapture({ message: input.last_message ?? "" });
+    process.stdout.write("{}");
+  } catch (err) {
+    process.stderr.write(`[nex-cursor] Capture error: ${err instanceof Error ? err.message : String(err)}\n`);
+    process.stdout.write("{}");
+  }
+}
+
+main().then(() => process.exit(0)).catch(() => process.exit(0));

--- a/cli/src/plugin/adapters/windsurf-capture.ts
+++ b/cli/src/plugin/adapters/windsurf-capture.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+/**
+ * Windsurf post_cascade_response hook — auto-capture to Nex.
+ * Input: { tool_info: { response: string } }
+ * Output: {}
+ */
+
+import { doCapture, readStdin } from "../shared.js";
+
+interface WindsurfInput {
+  tool_info?: { response?: string };
+}
+
+async function main(): Promise<void> {
+  try {
+    const raw = await readStdin();
+    let input: WindsurfInput = {};
+    try { input = JSON.parse(raw); } catch { /* defaults */ }
+
+    await doCapture({ message: input.tool_info?.response ?? "" });
+    process.stdout.write("{}");
+  } catch (err) {
+    process.stderr.write(`[nex-windsurf] Capture error: ${err instanceof Error ? err.message : String(err)}\n`);
+    process.stdout.write("{}");
+  }
+}
+
+main().then(() => process.exit(0)).catch(() => process.exit(0));

--- a/cli/src/plugin/adapters/windsurf-recall.ts
+++ b/cli/src/plugin/adapters/windsurf-recall.ts
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+/**
+ * Windsurf pre_user_prompt hook — auto-recall from Nex.
+ * Input: { tool_info: { user_prompt: string } }
+ * Output: context string on stdout (displayed via show_output) or {}
+ */
+
+import { doRecall, readStdin } from "../shared.js";
+
+interface WindsurfInput {
+  tool_info?: { user_prompt?: string };
+  session_id?: string;
+}
+
+async function main(): Promise<void> {
+  try {
+    const raw = await readStdin();
+    let input: WindsurfInput = {};
+    try { input = JSON.parse(raw); } catch { /* defaults */ }
+
+    const prompt = input.tool_info?.user_prompt ?? "";
+    const result = await doRecall(prompt, input.session_id);
+
+    if (!result) {
+      process.stdout.write("{}");
+      return;
+    }
+
+    // Windsurf displays stdout content via show_output
+    process.stdout.write(JSON.stringify({ additional_context: result.context }));
+  } catch (err) {
+    process.stderr.write(`[nex-windsurf] Recall error: ${err instanceof Error ? err.message : String(err)}\n`);
+    process.stdout.write("{}");
+  }
+}
+
+main().then(() => process.exit(0)).catch(() => process.exit(0));

--- a/cli/src/plugin/auto-capture.ts
+++ b/cli/src/plugin/auto-capture.ts
@@ -9,94 +9,16 @@
  * On ANY error: outputs {} and exits 0 (graceful degradation).
  */
 
-import { readdirSync, statSync, readFileSync } from "node:fs";
-import { join, extname } from "node:path";
-import { loadConfig, loadScanConfig, isHookEnabled } from "./config.js";
-import { NexClient } from "./nex-client.js";
-import { captureFilter } from "./capture-filter.js";
-import { RateLimiter } from "./rate-limiter.js";
-import { readManifest, writeManifest, isChanged, markIngested } from "./file-manifest.js";
-
-/** Ingest timeout — 3s leaves buffer within hook timeout */
-const INGEST_TIMEOUT_MS = 3_000;
-const MAX_PLAN_FILES = 2;
-
-const rateLimiter = new RateLimiter();
+import { doCapture, readStdin } from "./shared.js";
 
 interface HookInput {
   last_assistant_message?: string;
   session_id?: string;
 }
 
-/**
- * Scan .claude/plans/ for changed .md files and ingest up to MAX_PLAN_FILES.
- */
-async function ingestPlanFiles(client: NexClient): Promise<void> {
-  const scanConfig = loadScanConfig();
-  if (!scanConfig.enabled) return;
-
-  const plansDir = join(process.cwd(), ".claude", "plans");
-
-  let entries;
-  try {
-    entries = readdirSync(plansDir, { withFileTypes: true });
-  } catch {
-    return; // No .claude/plans/ dir — normal, skip silently
-  }
-
-  const manifest = readManifest();
-  let ingested = 0;
-
-  for (const entry of entries) {
-    if (ingested >= MAX_PLAN_FILES) break;
-    if (!entry.isFile()) continue;
-    if (extname(entry.name).toLowerCase() !== ".md") continue;
-
-    const fullPath = join(plansDir, entry.name);
-    try {
-      const stat = statSync(fullPath);
-      if (!isChanged(fullPath, stat, manifest)) continue;
-
-      if (!rateLimiter.canProceed()) {
-        process.stderr.write("[nex-capture] Rate limited — skipping plan file ingest\n");
-        break;
-      }
-
-      let content = readFileSync(fullPath, "utf-8");
-      if (content.length > 100_000) {
-        content = content.slice(0, 100_000) + "\n[...truncated]";
-      }
-
-      const context = `claude-code-plan:${entry.name}`;
-      await client.ingest(content, context, INGEST_TIMEOUT_MS);
-      markIngested(fullPath, stat, context, manifest);
-      ingested++;
-    } catch (err) {
-      process.stderr.write(
-        `[nex-capture] Plan file ingest failed (${entry.name}): ${err instanceof Error ? err.message : String(err)}\n`
-      );
-    }
-  }
-
-  if (ingested > 0) {
-    writeManifest(manifest);
-  }
-}
-
 async function main(): Promise<void> {
   try {
-    // Read stdin
-    const chunks: Buffer[] = [];
-    for await (const chunk of process.stdin) {
-      chunks.push(chunk as Buffer);
-    }
-    const raw = Buffer.concat(chunks).toString("utf-8");
-
-    // Check .nex.toml kill switch
-    if (!isHookEnabled("capture")) {
-      process.stdout.write("{}");
-      return;
-    }
+    const raw = await readStdin();
 
     let input: HookInput;
     try {
@@ -106,44 +28,9 @@ async function main(): Promise<void> {
       return;
     }
 
-    let cfg;
-    try {
-      cfg = loadConfig();
-    } catch {
-      process.stdout.write("{}");
-      return;
-    }
-
-    const client = new NexClient(cfg.apiKey, cfg.baseUrl);
-
-    // --- Conversation capture (existing behavior) ---
-    const message = input.last_assistant_message?.trim();
-    if (message) {
-      const filterResult = captureFilter(message);
-
-      if (!filterResult.skipped) {
-        if (rateLimiter.canProceed()) {
-          try {
-            await client.ingest(filterResult.text, "claude-code-conversation", INGEST_TIMEOUT_MS);
-          } catch (err) {
-            process.stderr.write(
-              `[nex-capture] Ingest failed: ${err instanceof Error ? err.message : String(err)}\n`
-            );
-          }
-        } else {
-          process.stderr.write("[nex-capture] Rate limited — skipping conversation ingest\n");
-        }
-      }
-    }
-
-    // --- Plan file ingestion ---
-    try {
-      await ingestPlanFiles(client);
-    } catch (err) {
-      process.stderr.write(
-        `[nex-capture] Plan file scan error: ${err instanceof Error ? err.message : String(err)}\n`
-      );
-    }
+    await doCapture({
+      message: input.last_assistant_message ?? "",
+    });
 
     process.stdout.write("{}");
   } catch (err) {

--- a/cli/src/plugin/auto-recall.ts
+++ b/cli/src/plugin/auto-recall.ts
@@ -9,38 +9,16 @@
  * On ANY error: outputs {} and exits 0 (graceful degradation).
  */
 
-import { loadConfig, isHookEnabled } from "./config.js";
-import { NexClient } from "./nex-client.js";
-import { formatNexContext } from "./context-format.js";
-import { SessionStore } from "./session-store.js";
-import { shouldRecall, recordRecall } from "./recall-filter.js";
-
-const sessions = new SessionStore();
+import { doRecall, readStdin, claudeCodeOutput } from "./shared.js";
 
 interface HookInput {
   prompt?: string;
   session_id?: string;
 }
 
-/**
- * Check if this is the first prompt for this session.
- * A session with no stored Nex session ID is considered "first prompt"
- * (SessionStart may have already set one, but that's fine — it means
- * baseline context was loaded, and first user prompt still gets recall).
- */
-function isFirstPrompt(sessionKey: string | undefined): boolean {
-  if (!sessionKey) return true;
-  return !sessions.get(sessionKey);
-}
-
 async function main(): Promise<void> {
   try {
-    // Read stdin
-    const chunks: Buffer[] = [];
-    for await (const chunk of process.stdin) {
-      chunks.push(chunk as Buffer);
-    }
-    const raw = Buffer.concat(chunks).toString("utf-8");
+    const raw = await readStdin();
 
     let input: HookInput;
     try {
@@ -51,78 +29,14 @@ async function main(): Promise<void> {
       return;
     }
 
-    // Check .nex.toml kill switch
-    if (!isHookEnabled("recall")) {
+    const result = await doRecall(input.prompt ?? "", input.session_id);
+
+    if (!result) {
       process.stdout.write("{}");
       return;
     }
 
-    const prompt = input.prompt?.trim();
-    if (!prompt || prompt.length < 5) {
-      process.stdout.write("{}");
-      return;
-    }
-
-    // Skip slash commands
-    if (prompt.startsWith("/")) {
-      process.stdout.write("{}");
-      return;
-    }
-
-    // --- Recall filter: decide if this prompt needs memory recall ---
-    const decision = shouldRecall(prompt, isFirstPrompt(input.session_id));
-    if (!decision.shouldRecall) {
-      process.stdout.write("{}");
-      return;
-    }
-
-    let cfg;
-    try {
-      cfg = loadConfig();
-    } catch (err) {
-      process.stderr.write(
-        `[nex-recall] Config error: ${err instanceof Error ? err.message : String(err)}\n`
-      );
-      process.stdout.write("{}");
-      return;
-    }
-
-    const client = new NexClient(cfg.apiKey, cfg.baseUrl);
-
-    // Resolve session ID for multi-turn continuity
-    const sessionKey = input.session_id;
-    const nexSessionId = sessionKey ? sessions.get(sessionKey) : undefined;
-
-    const result = await client.ask(prompt, nexSessionId, 10_000);
-
-    if (!result.answer) {
-      process.stdout.write("{}");
-      return;
-    }
-
-    // Store session ID for future turns
-    if (result.session_id && sessionKey) {
-      sessions.set(sessionKey, result.session_id);
-    }
-
-    // Record successful recall for debounce
-    recordRecall(result.session_id);
-
-    const entityCount = result.entity_references?.length ?? 0;
-    const context = formatNexContext({
-      answer: result.answer,
-      entityCount,
-      sessionId: result.session_id,
-    });
-
-    // Use hookSpecificOutput for discrete context injection (not shown in transcript)
-    const output = JSON.stringify({
-      hookSpecificOutput: {
-        hookEventName: "UserPromptSubmit",
-        additionalContext: context,
-      },
-    });
-    process.stdout.write(output);
+    process.stdout.write(claudeCodeOutput("UserPromptSubmit", result.context));
   } catch (err) {
     process.stderr.write(
       `[nex-recall] Unexpected error: ${err instanceof Error ? err.message : String(err)}\n`

--- a/cli/src/plugin/auto-session-start.ts
+++ b/cli/src/plugin/auto-session-start.ts
@@ -6,46 +6,19 @@
  * a baseline context summary and injects it so the agent "already knows"
  * relevant business context from the first message.
  *
- * On startup/clear: also scans project files and ingests changed ones.
- * On compact/resume: skips file scan (files already ingested, just re-query summary).
- *
  * On ANY error: outputs {} and exits 0 (graceful degradation).
  */
 
-import { loadConfig, loadScanConfig, ConfigError, isHookEnabled } from "./config.js";
-import { NexClient } from "./nex-client.js";
-import { RateLimiter } from "./rate-limiter.js";
-import { formatNexContext } from "./context-format.js";
-import { SessionStore } from "./session-store.js";
-import { recordRecall } from "./recall-filter.js";
-import { scanAndIngest } from "./file-scanner.js";
-import { ingestContextFiles } from "./context-files.js";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
-
-const sessions = new SessionStore();
+import { doSessionStart, readStdin, claudeCodeOutput } from "./shared.js";
 
 interface HookInput {
   session_id?: string;
   source?: string; // "startup" | "resume" | "clear" | "compact"
 }
 
-const SESSION_START_QUERY = "Summarize the key active context, recent interactions, and important updates for this user.";
-
 async function main(): Promise<void> {
   try {
-    // Read stdin
-    const chunks: Buffer[] = [];
-    for await (const chunk of process.stdin) {
-      chunks.push(chunk as Buffer);
-    }
-    const raw = Buffer.concat(chunks).toString("utf-8");
-
-    // Check .nex.toml kill switch
-    if (!isHookEnabled("session_start")) {
-      process.stdout.write("{}");
-      return;
-    }
+    const raw = await readStdin();
 
     let input: HookInput = {};
     try {
@@ -54,120 +27,20 @@ async function main(): Promise<void> {
       process.stderr.write("[nex-session-start] Failed to parse stdin JSON, continuing with defaults\n");
     }
 
-    let cfg;
-    try {
-      cfg = loadConfig();
-    } catch (err) {
-      if (err instanceof ConfigError) {
-        // No API key — inject registration prompt so Claude handles it
-        const pluginDir = dirname(fileURLToPath(import.meta.url));
-        const registerScript = join(pluginDir, "auto-register.js");
-        const registrationPrompt = [
-          "[Nex Memory Plugin] No API key configured. Registration is required to enable persistent memory.",
-          "",
-          "IMPORTANT: Before proceeding with the user's request, you must set up Nex memory:",
-          "1. Ask the user for their email address to register for a Nex account",
-          "2. Run the registration command: node " + registerScript + " <email> [name] [company]",
-          "3. Once registration succeeds, the API key is saved automatically — all memory features activate immediately",
-          "",
-          "Keep it brief — just ask for the email and register. No restart needed after registration.",
-        ].join("\n");
-
-        const output = JSON.stringify({
-          hookSpecificOutput: {
-            hookEventName: "SessionStart",
-            additionalContext: registrationPrompt,
-          },
-        });
-        process.stdout.write(output);
-        return;
-      }
-      process.stderr.write(
-        `[nex-session-start] Config error: ${err instanceof Error ? err.message : String(err)}\n`
-      );
-      process.stdout.write("{}");
-      return;
-    }
-
-    const client = new NexClient(cfg.apiKey, cfg.baseUrl);
-    const contextParts: string[] = [];
-
-    // --- File scan on startup or clear ---
     const source = input.source ?? "startup";
-    const shouldScan = source === "startup" || source === "clear";
+    const result = await doSessionStart(source, input.session_id);
 
-    if (shouldScan) {
-      const rateLimiter = new RateLimiter();
-      const cwd = process.cwd();
-
-      // --- Ingest CLAUDE.md + memory files (highest priority) ---
-      try {
-        const ctxResult = await ingestContextFiles(client, rateLimiter, cwd);
-        if (ctxResult.ingested > 0) {
-          contextParts.push(
-            `[Context files: ${ctxResult.ingested} ingested (${ctxResult.files.join(", ")})]`
-          );
-        }
-      } catch (err) {
-        process.stderr.write(
-          `[nex-session-start] Context files error: ${err instanceof Error ? err.message : String(err)}\n`
-        );
-      }
-
-      // --- Project file scan ---
-      try {
-        const scanConfig = loadScanConfig();
-        if (scanConfig.enabled) {
-          const scanResult = await scanAndIngest(client, rateLimiter, cwd, scanConfig);
-
-          if (scanResult.ingested > 0) {
-            contextParts.push(
-              `[File scan: ${scanResult.ingested} file${scanResult.ingested === 1 ? "" : "s"} ingested, ${scanResult.scanned} scanned]`
-            );
-          }
-        }
-      } catch (err) {
-        process.stderr.write(
-          `[nex-session-start] File scan error: ${err instanceof Error ? err.message : String(err)}\n`
-        );
-      }
-    }
-
-    // --- Nex context query ---
-    const result = await client.ask(SESSION_START_QUERY, undefined, 10_000);
-
-    if (!result.answer && contextParts.length === 0) {
+    if (!result) {
       process.stdout.write("{}");
       return;
     }
 
-    // Store session mapping
-    if (result.session_id && input.session_id) {
-      sessions.set(input.session_id, result.session_id);
+    if (result.registrationPrompt) {
+      process.stdout.write(claudeCodeOutput("SessionStart", result.registrationPrompt));
+      return;
     }
 
-    // Record this as a successful recall for debounce
-    recordRecall(result.session_id);
-
-    const entityCount = result.entity_references?.length ?? 0;
-    const context = formatNexContext({
-      answer: result.answer,
-      entityCount,
-      sessionId: result.session_id,
-    });
-
-    // Append scan summary if any
-    const fullContext = contextParts.length > 0
-      ? `${context}\n${contextParts.join("\n")}`
-      : context;
-
-    const output = JSON.stringify({
-      hookSpecificOutput: {
-        hookEventName: "SessionStart",
-        additionalContext: fullContext,
-      },
-    });
-    process.stdout.write(output);
+    process.stdout.write(claudeCodeOutput("SessionStart", result.context));
   } catch (err) {
     process.stderr.write(
       `[nex-session-start] Unexpected error: ${err instanceof Error ? err.message : String(err)}\n`

--- a/cli/src/plugin/shared.ts
+++ b/cli/src/plugin/shared.ts
@@ -1,0 +1,302 @@
+/**
+ * Shared hook logic — platform-agnostic recall, capture, and session-start.
+ *
+ * Extracted from auto-recall.ts, auto-capture.ts, auto-session-start.ts
+ * so adapters for Cursor, Windsurf, Cline, etc. can reuse the same logic
+ * without duplicating filter/client/format code.
+ */
+
+import { loadConfig, loadScanConfig, ConfigError, isHookEnabled } from "./config.js";
+import { NexClient } from "./nex-client.js";
+import { formatNexContext } from "./context-format.js";
+import { captureFilter } from "./capture-filter.js";
+import { SessionStore } from "./session-store.js";
+import { shouldRecall, recordRecall } from "./recall-filter.js";
+import { RateLimiter } from "./rate-limiter.js";
+import { scanAndIngest } from "./file-scanner.js";
+import { ingestContextFiles } from "./context-files.js";
+import { readManifest, writeManifest, isChanged, markIngested } from "./file-manifest.js";
+import { readdirSync, statSync, readFileSync } from "node:fs";
+import { join, extname } from "node:path";
+
+export interface RecallResult {
+  context: string;
+  nexSessionId?: string;
+}
+
+export interface CaptureInput {
+  message: string;
+  planDir?: string;
+}
+
+export interface SessionStartResult {
+  context: string;
+  nexSessionId?: string;
+  registrationPrompt?: string;
+}
+
+const sessions = new SessionStore();
+
+// ── Recall ──────────────────────────────────────────────────────────────
+
+/**
+ * Run recall logic: filter prompt → query Nex /ask → return formatted context.
+ * Returns null if recall is skipped or fails.
+ */
+export async function doRecall(
+  prompt: string,
+  sessionKey?: string,
+): Promise<RecallResult | null> {
+  if (!isHookEnabled("recall")) return null;
+
+  const trimmed = prompt?.trim();
+  if (!trimmed || trimmed.length < 5) return null;
+  if (trimmed.startsWith("/")) return null;
+
+  const isFirst = sessionKey ? !sessions.get(sessionKey) : true;
+  const decision = shouldRecall(trimmed, isFirst);
+  if (!decision.shouldRecall) return null;
+
+  const cfg = loadConfig();
+  const client = new NexClient(cfg.apiKey, cfg.baseUrl);
+
+  const nexSessionId = sessionKey ? sessions.get(sessionKey) : undefined;
+  const result = await client.ask(trimmed, nexSessionId, 10_000);
+
+  if (!result.answer) return null;
+
+  if (result.session_id && sessionKey) {
+    sessions.set(sessionKey, result.session_id);
+  }
+  recordRecall(result.session_id);
+
+  const entityCount = result.entity_references?.length ?? 0;
+  const context = formatNexContext({
+    answer: result.answer,
+    entityCount,
+    sessionId: result.session_id,
+  });
+
+  return { context, nexSessionId: result.session_id };
+}
+
+// ── Capture ─────────────────────────────────────────────────────────────
+
+const INGEST_TIMEOUT_MS = 3_000;
+const MAX_PLAN_FILES = 2;
+
+/**
+ * Run capture logic: filter message → ingest to Nex + scan plan files.
+ */
+export async function doCapture(input: CaptureInput): Promise<void> {
+  if (!isHookEnabled("capture")) return;
+
+  let cfg;
+  try {
+    cfg = loadConfig();
+  } catch {
+    return;
+  }
+
+  const client = new NexClient(cfg.apiKey, cfg.baseUrl);
+  const rateLimiter = new RateLimiter();
+
+  // Conversation capture
+  const message = input.message?.trim();
+  if (message) {
+    const filterResult = captureFilter(message);
+    if (!filterResult.skipped) {
+      if (rateLimiter.canProceed()) {
+        try {
+          await client.ingest(filterResult.text, "claude-code-conversation", INGEST_TIMEOUT_MS);
+        } catch (err) {
+          process.stderr.write(
+            `[nex-capture] Ingest failed: ${err instanceof Error ? err.message : String(err)}\n`
+          );
+        }
+      }
+    }
+  }
+
+  // Plan file ingestion
+  const plansDir = input.planDir ?? join(process.cwd(), ".claude", "plans");
+  try {
+    await ingestPlanFiles(client, rateLimiter, plansDir);
+  } catch (err) {
+    process.stderr.write(
+      `[nex-capture] Plan file scan error: ${err instanceof Error ? err.message : String(err)}\n`
+    );
+  }
+}
+
+async function ingestPlanFiles(
+  client: NexClient,
+  rateLimiter: RateLimiter,
+  plansDir: string,
+): Promise<void> {
+  const scanConfig = loadScanConfig();
+  if (!scanConfig.enabled) return;
+
+  let entries;
+  try {
+    entries = readdirSync(plansDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  const manifest = readManifest();
+  let ingested = 0;
+
+  for (const entry of entries) {
+    if (ingested >= MAX_PLAN_FILES) break;
+    if (!entry.isFile()) continue;
+    if (extname(entry.name).toLowerCase() !== ".md") continue;
+
+    const fullPath = join(plansDir, entry.name);
+    try {
+      const stat = statSync(fullPath);
+      if (!isChanged(fullPath, stat, manifest)) continue;
+
+      if (!rateLimiter.canProceed()) break;
+
+      let content = readFileSync(fullPath, "utf-8");
+      if (content.length > 100_000) {
+        content = content.slice(0, 100_000) + "\n[...truncated]";
+      }
+
+      const context = `claude-code-plan:${entry.name}`;
+      await client.ingest(content, context, INGEST_TIMEOUT_MS);
+      markIngested(fullPath, stat, context, manifest);
+      ingested++;
+    } catch {
+      // skip individual file errors
+    }
+  }
+
+  if (ingested > 0) writeManifest(manifest);
+}
+
+// ── Session Start ───────────────────────────────────────────────────────
+
+const SESSION_START_QUERY =
+  "Summarize the key active context, recent interactions, and important updates for this user.";
+
+/**
+ * Run session-start logic: scan files → query Nex baseline → return context.
+ * Returns null if disabled. Returns registrationPrompt if no API key.
+ */
+export async function doSessionStart(
+  source: string,
+  sessionKey?: string,
+): Promise<SessionStartResult | null> {
+  if (!isHookEnabled("session_start")) return null;
+
+  let cfg;
+  try {
+    cfg = loadConfig();
+  } catch (err) {
+    if (err instanceof ConfigError) {
+      // No API key — return registration instructions
+      return {
+        context: "",
+        registrationPrompt: buildRegistrationPrompt(),
+      };
+    }
+    return null;
+  }
+
+  const client = new NexClient(cfg.apiKey, cfg.baseUrl);
+  const contextParts: string[] = [];
+
+  // File scan on startup or clear
+  const shouldScan = source === "startup" || source === "clear";
+  if (shouldScan) {
+    const rateLimiter = new RateLimiter();
+    const cwd = process.cwd();
+
+    try {
+      const ctxResult = await ingestContextFiles(client, rateLimiter, cwd);
+      if (ctxResult.ingested > 0) {
+        contextParts.push(
+          `[Context files: ${ctxResult.ingested} ingested (${ctxResult.files.join(", ")})]`
+        );
+      }
+    } catch {
+      // non-fatal
+    }
+
+    try {
+      const scanConfig = loadScanConfig();
+      if (scanConfig.enabled) {
+        const scanResult = await scanAndIngest(client, rateLimiter, cwd, scanConfig);
+        if (scanResult.ingested > 0) {
+          contextParts.push(
+            `[File scan: ${scanResult.ingested} file${scanResult.ingested === 1 ? "" : "s"} ingested, ${scanResult.scanned} scanned]`
+          );
+        }
+      }
+    } catch {
+      // non-fatal
+    }
+  }
+
+  const result = await client.ask(SESSION_START_QUERY, undefined, 10_000);
+
+  if (!result.answer && contextParts.length === 0) return null;
+
+  if (result.session_id && sessionKey) {
+    sessions.set(sessionKey, result.session_id);
+  }
+  recordRecall(result.session_id);
+
+  const entityCount = result.entity_references?.length ?? 0;
+  const context = formatNexContext({
+    answer: result.answer,
+    entityCount,
+    sessionId: result.session_id,
+  });
+
+  const fullContext =
+    contextParts.length > 0
+      ? `${context}\n${contextParts.join("\n")}`
+      : context;
+
+  return { context: fullContext, nexSessionId: result.session_id };
+}
+
+function buildRegistrationPrompt(): string {
+  return [
+    "[Nex Memory Plugin] No API key configured. Registration is required to enable persistent memory.",
+    "",
+    "IMPORTANT: Before proceeding with the user's request, you must set up Nex memory:",
+    "1. Ask the user for their email address to register for a Nex account",
+    "2. Run: nex register --email <email>",
+    "3. Then run: nex setup",
+    "",
+    "Keep it brief — just ask for the email and register. No restart needed after registration.",
+  ].join("\n");
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+/** Read stdin as a string (shared across all hook scripts). */
+export async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks).toString("utf-8");
+}
+
+/** Wrap output in Claude Code hookSpecificOutput format. */
+export function claudeCodeOutput(
+  hookEventName: string,
+  additionalContext: string,
+): string {
+  return JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName,
+      additionalContext,
+    },
+  });
+}

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,80 +1,95 @@
-# Handoff: API Parity + CLI v0.1.11
+# Nex Plugins — Session Handoff
 
-## What Was Done (Session 2026-03-07)
+> Last updated: 2026-03-09
 
-### Full API Parity Across All Nex Surfaces
+## First Steps
 
-All Developer API operations are now available on every surface:
+1. Read this file fully
+2. Check CLI builds: `cd /Users/najmuzzaman/Documents/nex/nex-as-a-skill/cli && npm run build`
+3. Review uncommitted changes: `cd /Users/najmuzzaman/Documents/nex/nex-as-a-skill && git diff --stat`
 
-1. **OpenClaw Plugin** (`openclaw-plugin/src/index.ts`): 42 new tools added (49 total)
-   - Schema: list/get/create/update/delete objects + create/update/delete attributes
-   - Records: create/upsert/list/get/update/delete + timeline
-   - Search: search_records
-   - Relationships: list/create/delete defs + create/delete instances
-   - Lists: create/get/delete/list + add/upsert/list/update/remove members
-   - Tasks: create/list/get/update/delete
-   - Notes: create/list/get/update/delete
-   - Context: artifact_status, insights
-   - Added `patch()` and `put()` methods to NexClient
-   - Fixed `baseUrl` config resolution bug (was ignoring plugin config)
+## What Was Done This Session
 
-2. **Claude Code Plugin** (`cli/plugin-commands/`): 20 new slash commands (26 total)
-   - schema, create-object, add-field, update-field
-   - search, record, create-record, update-record, upsert-record, timeline
-   - tasks, create-task, notes, create-note
-   - relationships, link-records, lists, list-members
-   - insights, artifact
+### 1. Platform Rules/Instructions (P0 — COMPLETE)
 
-3. **SKILL.md**: Added Integrations section (Search already existed)
+Created 9 platform-specific rules/instruction template files in `cli/platform-rules/`:
+- `cursor-rules.md` → `.cursor/rules/nex.md`
+- `windsurf-rules.md` → `.windsurf/rules/nex.md`
+- `vscode-instructions.md` → `.github/instructions/nex.instructions.md` (has YAML frontmatter)
+- `cline-rules.md` → `.clinerules/nex.md`
+- `continue-rules.md` → `.continue/rules/nex.md`
+- `zed-rules.md` → `.rules` (append with markers)
+- `kilocode-rules.md` → `.kilocode/rules/nex.md`
+- `opencode-agents.md` → `AGENTS.md` (append with markers)
+- `aider-conventions.md` → `CONVENTIONS.md` (append with markers)
 
-### Setup Key Regeneration (v0.1.12)
+Each file teaches the AI agent about Nex MCP tools (ask, remember, search, integrations).
 
-`nex setup` now shows 3 options when a key exists:
-1. Generate new key for existing email (no re-prompt)
-2. Change email and generate new key
-3. Keep current key
+### 2. Setup Hierarchy (plugins > rules > MCP)
 
-Email is persisted in `~/.nex/config.json`. Status integrations fetch uses 5s timeout (was 120s).
+Updated `nex setup` to use a clear hierarchy:
+- **Claude Code**: Plugin (hooks + slash commands) — no MCP needed
+- **Claude Desktop**: MCP only (no rules system)
+- **All others**: Rules (instruction files) + MCP (tools) — complementary
 
-### Simplified `nex integrate connect` (v0.1.12)
+Files changed:
+- `cli/src/lib/platform-detect.ts` — Added `supportsRules`, `rulesPath` fields to Platform interface
+- `cli/src/lib/installers.ts` — Added `installRulesFile()` with standalone and append modes
+- `cli/src/commands/setup.ts` — Replaced install loop with hierarchy logic, `--no-mcp` → `--no-rules`
+- `cli/README.md` — Updated platforms table, setup flags, default behavior description
+- Root `README.md` — Quick Start restructured with `nex setup` as primary
 
-Removed `connect <type> <provider>` syntax. Now just:
-- `nex integrate connect gmail`
-- `nex integrate connect slack`
+### 3. P1 Integrations — Already Complete
 
-Available: `gmail`, `google-calendar`, `outlook`, `outlook-calendar`, `slack`, `salesforce`, `hubspot`, `attio`
+Verified all surfaces already have integration tools:
+- MCP: `tools/integrations.ts` (4 tools)
+- OpenClaw: `nex_list/connect/disconnect_integration`
+- SKILL.md: Full API documentation
+- CLI slash commands: `/integrate`
 
-### Published `@nex-ai/nex@0.1.12` to npm
+### 4. Previous Session Work (still uncommitted)
 
-## PRs (All Merged)
+- `nex setup` is now the recommended onboarding path (README updates)
+- Core PRs: #681 merged (historical email), #687 created (deploy workflow fix)
 
-| PR | Branch | Content |
-|----|--------|---------|
-| #25 | `feat/developer-api-oauth` | OAuth integration + OpenClaw tools + SKILL.md |
-| #26 | `feat/api-parity` | 20 Claude Code slash commands |
-| #27 | `fix/setup-key-regeneration` | Setup key regeneration fix |
+## Build & Test
 
-Core PR #669 (`nazz/feat/developer-api-oauth`) also merged - adds integration endpoints + scopes.
+```bash
+cd /Users/najmuzzaman/Documents/nex/nex-as-a-skill
+cd cli && npm run build && npm test    # CLI: 65 tests pass
+cd ../mcp && npm run build             # MCP server
+```
 
-## Current State
+## NOT YET DONE
 
-- **Branch**: `main` (up to date with all merged PRs)
-- **npm**: `@nex-ai/nex@0.1.12` is live
+### Commit & Publish
+- All changes are uncommitted in nex-as-a-skill repo
+- Version bump needed: 0.1.18 → 0.1.19
+- `npm publish --access public` after commit
 
-## Pending Manual Tests
+### Aider Support
+- Aider has NO MCP support — rules-only platform
+- `aider-conventions.md` template created but `nex setup` doesn't handle Aider yet
+- Need to add Aider to `platform-detect.ts` (detect via `which aider` or `.aider.conf.yml`)
 
-1. `nex setup` -> regenerate key -> `nex integrate list` works (no 403)
-2. Slash commands appear after `nex setup` in Claude Code
-3. All new OpenClaw tools work with a live API
+### TUI Polish (P2, plan exists)
+- Plan at `.claude/plans/wobbly-roaming-tulip.md`
+- Shared `lib/tui.ts` already partially built (used by setup status, integrate list)
+- Remaining: ask/search/scan/task formatters, arrow-key choose()
 
 ## Key Files
 
 | File | Purpose |
 |------|---------|
-| `openclaw-plugin/src/index.ts` | 49 tools (main plugin file) |
-| `openclaw-plugin/src/nex-client.ts` | HTTP client with get/post/patch/put/delete |
-| `openclaw-plugin/src/config.ts` | Config resolution (fixed baseUrl bug) |
-| `cli/src/commands/setup.ts` | Key regeneration logic |
-| `cli/plugin-commands/*.md` | 26 slash commands |
-| `SKILL.md` | Full API docs for OpenClaw surface |
-| `mcp/src/tools/*.ts` | 38+ MCP tools (reference, no changes) |
+| `cli/platform-rules/*.md` | Rules/instruction templates for each platform |
+| `cli/src/lib/platform-detect.ts` | Platform detection + capabilities |
+| `cli/src/lib/installers.ts` | MCP + plugin + rules installer functions |
+| `cli/src/commands/setup.ts` | Setup command — hierarchy-based install logic |
+| `cli/README.md` | npm README |
+| `README.md` | Repo README |
+
+## Core Repo Status
+
+- **PR #687**: Deploy workflow fix (`service=all` on `workflow_dispatch`) — open, needs merge
+- **PR #681**: Historical email processing — merged, deployed to staging, prod deploy triggered (run 22876044405)
+- **PR #673**: Gmail reconnect — awaiting Doug's re-review

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -2,6 +2,19 @@
 
 ## Completed
 
+### v0.1.18 — TUI Polish + Integration Fixes (2026-03-09)
+- [x] Interactive integrate list with arrow-key selection, expand/collapse, inline actions
+- [x] Connection ID handling: `safenIds()` + `string | number` types
+- [x] Optimistic disconnect: removes connection from in-memory list (avoids read-replica lag)
+- [x] Meeting bot support
+- [x] Cherry-picked all feature branch commits to main
+- [x] PR #30 merged, published to npm
+
+### v0.1.16-v0.1.17 — TTY + Actions (2026-03-08)
+- [x] TTY detection and formatting
+- [x] Integration actions (connect/disconnect/reconnect)
+- [x] Meeting bot integration type
+
 ### v0.1.12 — Setup UX + Integrate Simplification (2026-03-07)
 - [x] `nex setup`: 3-option key regeneration (reuse email / change email / keep)
 - [x] Email persisted in `~/.nex/config.json`
@@ -35,6 +48,54 @@
 - [x] SKILL.md: comprehensive API documentation
 - [x] File scanner with .nex.toml config
 - [x] Platform detection (10+ platforms)
+
+### v0.1.19 (unreleased) — Platform Rules + Setup Hierarchy (2026-03-09)
+- [x] `nex setup` now installs rules + MCP for all detected platforms (hierarchy: plugins > rules > MCP)
+- [x] `--with-mcp` replaced with `--no-rules` (skip rules/instruction files)
+- [x] README restructured: `nex setup` is primary Quick Start, manual steps in collapsible sections
+- [x] Root README updated: integration table shows `nex setup` instead of `npx @nex-ai/cli`
+- [x] Created 9 platform-specific rules/instruction templates in `cli/platform-rules/`
+- [x] Added `supportsRules` and `rulesPath` to Platform interface in `platform-detect.ts`
+- [x] Added `installRulesFile()` to `installers.ts` (standalone + append modes)
+- [x] Updated `setup.ts` install loop with hierarchy logic
+- [x] Updated README platforms table to show rules + MCP per platform
+- [ ] Not yet committed or published
+
+## Core Backend Fixes (2026-03-09)
+- [x] Search timeout: 300ms → 2000ms (PR #675, merged & deployed)
+- [x] Embedding dimension fix: 768 → 1024 (PR #679, merged & deployed)
+- [x] Semantic search date type fix (PR #680, open)
+- [x] Historical email processing (PR #681, merged & deployed to staging, prod deploy triggered)
+- [x] search_entities domain fallback (PR #676, merged & deployed)
+- [ ] Gmail reconnect sync fix (PR #673, awaiting Doug's re-review)
+- [x] Deploy workflow fix: service=all on workflow_dispatch (PR #687, open)
+
+## Pending / Next
+
+### P0: Platform Plugins/Rules — COMPLETE
+- [x] Cursor: `.cursor/rules/nex.md` — rules + MCP
+- [x] Windsurf: `.windsurf/rules/nex.md` — rules + MCP
+- [x] VS Code / Copilot: `.github/instructions/nex.instructions.md` — instructions + MCP
+- [x] Cline: `.clinerules/nex.md` — rules + MCP
+- [x] Continue.dev: `.continue/rules/nex.md` — rules + MCP
+- [x] Zed: `.rules` (append) — rules + MCP
+- [x] Kilo Code: `.kilocode/rules/nex.md` — rules + MCP
+- [x] OpenCode: `AGENTS.md` (append) — rules + MCP
+- [x] Aider: `CONVENTIONS.md` (append) — rules only (no MCP support)
+- [x] `nex setup` installs per-platform (hierarchy: plugins > rules > MCP)
+
+### P1: Integrations Feature Parity — ALREADY COMPLETE
+All surfaces already have integration tools:
+- [x] MCP server: 4 integration tools (`tools/integrations.ts`)
+- [x] OpenClaw plugin: 3 integration tools
+- [x] SKILL.md: integration bash scripts
+- [x] Claude Code slash commands: `/integrate`
+
+### P2: TUI Polish (plan exists)
+- [ ] Create shared `lib/tui.ts` module (spinner, table, box, tree, etc.)
+- [ ] Update search/ask command descriptions to differentiate
+- [ ] Add TTY formatters for ask, search, scan, setup status, task list
+- [ ] Upgrade `prompt.ts` to arrow-key selection
 
 ## API Coverage Matrix (Current)
 


### PR DESCRIPTION
## Summary

- **Shared hook core**: Extract `shared.ts` with `doRecall()`, `doCapture()`, `doSessionStart()` from Claude Code hooks — all adapters reuse this logic
- **Hook adapters**: Cursor (3 scripts), Windsurf (2 scripts), Cline (3 scripts) — event-driven hooks that call shared logic with platform-specific JSON formats
- **Platform plugins**: OpenCode plugin template (`.opencode/plugins/nex.ts`), VS Code custom agent (`.github/agents/nex.agent.md`), Kilo Code custom mode (`.kilocodemodes`), Continue.dev context provider, Windsurf workflows (3 slash commands)
- **OpenClaw auto-install**: Detects `openclaw` CLI, runs `plugins install`, configures API key
- **6-layer setup hierarchy**: Hooks → Plugins → Agents → Workflows → Rules → MCP — each platform gets every layer it supports
- **New platforms**: OpenClaw (Tier 0, full native plugin), Aider (Tier 4, CONVENTIONS.md rules only)
- **Bug fix**: `platform-rules/` was missing from `files` in package.json — now included alongside new `platform-plugins/`
- **Version bump**: 0.1.18 → 0.1.19

## What each platform gets

| Platform | Hooks | Plugins | Agents | Workflows | Rules | MCP |
|----------|-------|---------|--------|-----------|-------|-----|
| Claude Code | 3 hooks | — | — | 26 commands | — | — |
| Cursor | 3 hooks | — | — | — | ✓ | ✓ |
| Windsurf | 2 hooks | — | — | 3 workflows | ✓ | ✓ |
| Cline | 3 hooks | — | — | — | ✓ | ✓ |
| OpenClaw | plugin-internal | 49 tools | — | — | — | — |
| OpenCode | — | plugin | — | — | ✓ | ✓ |
| VS Code | — | — | @nex agent | — | ✓ | ✓ |
| Kilo Code | — | — | nex-crm mode | — | ✓ | ✓ |
| Continue.dev | — | — | — | — | ✓ | ✓ |
| Zed | — | — | — | — | ✓ | ✓ |
| Claude Desktop | — | — | — | — | — | ✓ |
| Aider | — | — | — | — | ✓ | — |

## Test plan

- [x] `npm run build` — compiles clean
- [x] `npm test` — all 65 tests pass
- [x] Adapter scripts exit 0 with valid JSON: `echo '{"prompt":"test"}' | node dist/plugin/adapters/cursor-recall.js`
- [x] `npm pack --dry-run` — all new directories included
- [ ] `nex setup --platform cursor` — verify hooks.json + rules + MCP installed
- [ ] `nex setup status` — shows all layers per platform

🤖 Generated with [Claude Code](https://claude.com/claude-code)