### PR TITLE
feat: interactive integration connection in nex setup

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -1,6 +1,11 @@
 # @nex-ai/nex
 
-Nex CLI provides organizational context & memory to AI agents across 10+ platforms.
+[![npm version](https://img.shields.io/npm/v/@nex-ai/nex)](https://www.npmjs.com/package/@nex-ai/nex)
+[![GitHub](https://img.shields.io/badge/github-nex--crm%2Fnex--as--a--skill-blue)](https://github.com/nex-crm/nex-as-a-skill)
+
+Nex CLI provides organizational context & memory to AI agents across 12 platforms.
+
+**GitHub**: [github.com/nex-crm/nex-as-a-skill](https://github.com/nex-crm/nex-as-a-skill)
 
 ## Install
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -28,6 +28,15 @@
     "tsx": "^4.19.0",
     "typescript": "^5.7.0"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nex-crm/nex-as-a-skill.git",
+    "directory": "cli"
+  },
+  "homepage": "https://github.com/nex-crm/nex-as-a-skill#readme",
+  "bugs": {
+    "url": "https://github.com/nex-crm/nex-as-a-skill/issues"
+  },
   "engines": {
     "node": ">=18"
   },

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nex-ai/nex",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "Nex CLI provides organizational context & memory to AI agents",
   "type": "module",
   "bin": {

--- a/cli/src/commands/integrate.ts
+++ b/cli/src/commands/integrate.ts
@@ -30,7 +30,7 @@ const INTEGRATIONS: Record<string, { type: string; provider: string }> = {
 
 const INTEGRATION_NAMES = Object.keys(INTEGRATIONS).join(", ");
 
-function openBrowser(url: string): void {
+export function openBrowser(url: string): void {
   try {
     let cmd: string;
     let args: string[];

--- a/cli/src/commands/setup.ts
+++ b/cli/src/commands/setup.ts
@@ -6,6 +6,7 @@
  * nex setup --no-hooks          Skip hook installation
  * nex setup --no-rules          Skip rules/instruction file installation
  * nex setup --no-plugin         Skip hooks/commands (alias for --no-hooks)
+ * nex setup --no-integrations    Skip integration connection step
  * nex setup --no-scan           Skip file scanning during setup
  * nex setup status              Show install status + integration connections
  */
@@ -16,9 +17,10 @@ import { program } from "../cli.js";
 import { resolveApiKey, resolveFormat, resolveTimeout, persistRegistration, loadConfig } from "../lib/config.js";
 import { NexClient } from "../lib/client.js";
 import { printOutput, printError } from "../lib/output.js";
-import { confirm, ask, choose } from "../lib/prompt.js";
+import { confirm, ask, choose, multiSelect } from "../lib/prompt.js";
 import type { Format } from "../lib/output.js";
-import { heading, keyValue, tree, badge, style, sym, spinner as createSpinner, exitHint } from "../lib/tui.js";
+import { heading, keyValue, tree, badge, style, sym, spinner as createSpinner, exitHint, isTTY } from "../lib/tui.js";
+import { openBrowser } from "./integrate.js";
 
 const INTEGRATIONS_MAP: Record<string, { type: string; provider: string }> = {
   gmail: { type: "email", provider: "google" },
@@ -243,6 +245,7 @@ async function runSetup(opts: {
   noPlugin: boolean;
   noHooks: boolean;
   noRules: boolean;
+  noIntegrations: boolean;
   noScan: boolean;
   format: Format;
 }): Promise<void> {
@@ -429,7 +432,12 @@ async function runSetup(opts: {
     }
   }
 
-  // 5. Create .nex.toml
+  // 5. Interactive integration connection
+  if (apiKey && isTTY && opts.format !== "json" && !opts.noIntegrations) {
+    await connectIntegrations(apiKey);
+  }
+
+  // 6. Create .nex.toml
   const created = writeDefaultProjectConfig();
   if (created) {
     results.push("Created .nex.toml with default settings");
@@ -437,7 +445,7 @@ async function runSetup(opts: {
     results.push(".nex.toml already exists");
   }
 
-  // 6. Scan and ingest project files (requires API key)
+  // 7. Scan and ingest project files (requires API key)
   if (!opts.noScan && apiKey && isScanEnabled()) {
     const showSpinner = opts.format !== "json";
     const spin = showSpinner ? createSpinner(`Scanning project files...  ${exitHint}`) : null;
@@ -466,7 +474,7 @@ async function runSetup(opts: {
     }
   }
 
-  // 7. Output results
+  // 8. Output results
   if (opts.format === "json") {
     printOutput({
       platforms: targetPlatforms.map((p) => ({
@@ -484,10 +492,133 @@ async function runSetup(opts: {
     process.stderr.write("\n");
   }
 
-  // 8. Show status (pass current apiKey — may differ from global opts after re-registration)
+  // 9. Show status (pass current apiKey — may differ from global opts after re-registration)
   if (opts.format !== "json") {
     await showStatus(opts.format, apiKey);
   }
+}
+
+// --- Integration connection step ---
+
+interface IntegrationEntry {
+  type: string;
+  provider: string;
+  display_name: string;
+  description: string;
+  connections: Array<{ id: string | number; status: string; identifier: string }>;
+}
+
+async function connectIntegrations(apiKey: string): Promise<void> {
+  const client = new NexClient(apiKey, 10_000);
+
+  let integrations: IntegrationEntry[];
+  try {
+    integrations = await client.get<IntegrationEntry[]>("/v1/integrations/", 10_000);
+    if (!Array.isArray(integrations) || integrations.length === 0) return;
+  } catch {
+    return; // Silently skip if API unavailable
+  }
+
+  // Build multi-select options
+  const options = integrations.map((item) => {
+    const connected = item.connections.length > 0;
+    const connInfo = connected
+      ? ` ${style.green("connected")} (${item.connections.map((c) => c.identifier).join(", ")})`
+      : "";
+    return {
+      label: `${item.display_name}${connInfo}`,
+      checked: false,
+      disabled: connected,
+    };
+  });
+
+  // Check if all are already connected
+  if (options.every((o) => o.disabled)) {
+    process.stderr.write(`\n  ${sym.success} All integrations already connected\n`);
+    return;
+  }
+
+  process.stderr.write("\n");
+  const selectedIndices = await multiSelect("Connect integrations:", options);
+
+  if (selectedIndices.length === 0) return;
+
+  // Connect each selected integration
+  for (const idx of selectedIndices) {
+    const item = integrations[idx];
+    const shortcut = Object.entries(INTEGRATIONS_MAP).find(
+      ([, v]) => v.type === item.type && v.provider === item.provider
+    );
+
+    if (!shortcut) continue;
+
+    const integration = INTEGRATIONS_MAP[shortcut[0]];
+    process.stderr.write(`  ${sym.info} Opening browser to connect ${item.display_name}...\n`);
+
+    try {
+      // Snapshot existing connection IDs
+      let existingIds = new Set<string | number>();
+      for (const conn of item.connections) {
+        existingIds.add(conn.id);
+      }
+
+      const result = await client.post<{ auth_url: string }>(
+        `/v1/integrations/${encodeURIComponent(integration.type)}/${encodeURIComponent(integration.provider)}/connect`
+      );
+
+      if (!result.auth_url) {
+        process.stderr.write(`  ${sym.error} No auth URL returned for ${item.display_name}\n`);
+        continue;
+      }
+
+      openBrowser(result.auth_url);
+
+      // Poll for connection
+      process.stderr.write(`  ${style.dim("Waiting for OAuth completion...")}  ${exitHint}\n`);
+      const connected = await pollForSetupConnection(client, integration.type, integration.provider, existingIds);
+      if (connected) {
+        process.stderr.write(`  ${sym.success} ${item.display_name} connected!\n\n`);
+      } else {
+        process.stderr.write(`  ${sym.warning} ${item.display_name} timed out — connect later with: nex integrate connect ${shortcut[0]}\n\n`);
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`  ${sym.error} Failed to connect ${item.display_name}: ${msg}\n`);
+    }
+  }
+}
+
+async function pollForSetupConnection(
+  client: NexClient,
+  type: string,
+  provider: string,
+  existingIds: Set<string | number>,
+): Promise<boolean> {
+  const maxWaitMs = 3 * 60 * 1000; // 3 minutes (shorter than integrate command)
+  const pollIntervalMs = 3000;
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < maxWaitMs) {
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+
+    try {
+      const integrations = await client.get<IntegrationEntry[]>("/v1/integrations/", 5_000);
+      if (!Array.isArray(integrations)) continue;
+
+      for (const entry of integrations) {
+        if (entry.type === type && entry.provider === provider && Array.isArray(entry.connections)) {
+          for (const conn of entry.connections) {
+            if (!existingIds.has(conn.id)) return true; // New connection found
+          }
+          // Reconnect scenario: same ID but refreshed
+          if (entry.connections.length > 0 && existingIds.size === 0) return true;
+        }
+      }
+    } catch {
+      // Continue polling
+    }
+  }
+  return false;
 }
 
 function maskKey(key: string): string {
@@ -509,6 +640,7 @@ const setup = program
   .option("--no-plugin", "Skip plugin (hooks/commands), only update config files")
   .option("--no-hooks", "Skip hook installation for all platforms")
   .option("--no-rules", "Skip rules/instruction file installation")
+  .option("--no-integrations", "Skip integration connection step")
   .option("--no-scan", "Skip file scanning during setup")
   .action(async (cmdOpts) => {
     const globalOpts = program.opts();
@@ -518,6 +650,7 @@ const setup = program
       noPlugin: cmdOpts.plugin === false,
       noHooks: cmdOpts.hooks === false,
       noRules: cmdOpts.rules === false,
+      noIntegrations: cmdOpts.integrations === false,
       noScan: cmdOpts.scan === false,
       format,
     });

--- a/cli/src/lib/prompt.ts
+++ b/cli/src/lib/prompt.ts
@@ -105,6 +105,112 @@ export async function choose(message: string, options: string[]): Promise<number
   });
 }
 
+/**
+ * Multi-select chooser with space to toggle, enter to confirm.
+ * Returns indices of selected items.
+ */
+export async function multiSelect(
+  message: string,
+  options: Array<{ label: string; checked?: boolean; disabled?: boolean }>,
+): Promise<number[]> {
+  const selected = options.map((o) => !!o.checked);
+
+  if (!isTTY) {
+    // Non-TTY fallback: return pre-checked items
+    return selected.reduce<number[]>((acc, v, i) => (v ? [...acc, i] : acc), []);
+  }
+
+  return new Promise((resolve) => {
+    let cursor = 0;
+    const totalLines = options.length + 3; // title + hint + blank + options
+
+    const draw = (initial = false) => {
+      if (!initial) {
+        process.stderr.write(`\x1b[${totalLines}A\x1b[J`);
+      }
+      process.stderr.write(`  ${message}  ${exitHint}\n`);
+      process.stderr.write(`  ${style.dim("(space to toggle, enter to confirm, s to skip all)")}\n\n`);
+      for (let i = 0; i < options.length; i++) {
+        const isCursor = i === cursor;
+        const pointer = isCursor ? sym.pointer : " ";
+        const isChecked = selected[i];
+        const isDisabled = options[i].disabled;
+        const checkbox = isDisabled
+          ? style.green("\u25A0")   // filled square for already connected
+          : isChecked
+            ? style.cyan("\u25A0") // filled square for selected
+            : "\u25A1";           // empty square
+        const label = isDisabled
+          ? style.dim(options[i].label)
+          : isCursor
+            ? style.bold(options[i].label)
+            : options[i].label;
+        process.stderr.write(`  ${pointer} ${checkbox} ${label}\n`);
+      }
+    };
+
+    process.stdin.setRawMode(true);
+    process.stdin.resume();
+    process.stdin.setEncoding("utf-8");
+
+    draw(true);
+
+    const onData = (key: string) => {
+      if (key === "\x03") {
+        cleanup();
+        process.stderr.write(`\x1b[${totalLines}A\x1b[J`);
+        process.stderr.write(`  ${message}\n`);
+        process.stderr.write(`  ${style.dim("Skipped")}\n\n`);
+        resolve([]);
+        return;
+      }
+      if (key === "s" || key === "S") {
+        cleanup();
+        process.stderr.write(`\x1b[${totalLines}A\x1b[J`);
+        process.stderr.write(`  ${message}\n`);
+        process.stderr.write(`  ${style.dim("Skipped")}\n\n`);
+        resolve([]);
+        return;
+      }
+      if (key === "\r") {
+        cleanup();
+        const result = selected.reduce<number[]>((acc, v, i) => {
+          if (v && !options[i].disabled) acc.push(i);
+          return acc;
+        }, []);
+        process.stderr.write(`\x1b[${totalLines}A\x1b[J`);
+        process.stderr.write(`  ${message}\n`);
+        if (result.length > 0) {
+          const names = result.map((i) => options[i].label).join(", ");
+          process.stderr.write(`  ${sym.success} ${names}\n\n`);
+        } else {
+          process.stderr.write(`  ${style.dim("None selected")}\n\n`);
+        }
+        resolve(result);
+        return;
+      }
+      if (key === " ") {
+        if (!options[cursor].disabled) {
+          selected[cursor] = !selected[cursor];
+        }
+      } else if (key === "\x1b[A") {
+        cursor = Math.max(0, cursor - 1);
+      } else if (key === "\x1b[B") {
+        cursor = Math.min(options.length - 1, cursor + 1);
+      }
+      draw();
+    };
+
+    const cleanup = () => {
+      process.stdin.setRawMode(false);
+      process.stdin.removeListener("data", onData);
+      process.stdin.pause();
+    };
+
+    process.stdin.on("data", onData);
+  });
+}
+
 export async function ask(message: string, required = false): Promise<string> {
   const rl = createInterface({ input: process.stdin, output: process.stderr });
 

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,95 +1,111 @@
 # Nex Plugins — Session Handoff
 
-> Last updated: 2026-03-09
+> Last updated: 2026-03-10
 
 ## First Steps
 
 1. Read this file fully
 2. Check CLI builds: `cd /Users/najmuzzaman/Documents/nex/nex-as-a-skill/cli && npm run build`
-3. Review uncommitted changes: `cd /Users/najmuzzaman/Documents/nex/nex-as-a-skill && git diff --stat`
+3. Run tests: `cd /Users/najmuzzaman/Documents/nex/nex-as-a-skill/cli && npm test`
 
-## What Was Done This Session
+## What Was Done Last Session (2026-03-10)
 
-### 1. Platform Rules/Instructions (P0 — COMPLETE)
+### 1. Full Platform Plugins — 6-Layer Setup Hierarchy (v0.1.20)
 
-Created 9 platform-specific rules/instruction template files in `cli/platform-rules/`:
-- `cursor-rules.md` → `.cursor/rules/nex.md`
-- `windsurf-rules.md` → `.windsurf/rules/nex.md`
-- `vscode-instructions.md` → `.github/instructions/nex.instructions.md` (has YAML frontmatter)
-- `cline-rules.md` → `.clinerules/nex.md`
-- `continue-rules.md` → `.continue/rules/nex.md`
-- `zed-rules.md` → `.rules` (append with markers)
-- `kilocode-rules.md` → `.kilocode/rules/nex.md`
-- `opencode-agents.md` → `AGENTS.md` (append with markers)
-- `aider-conventions.md` → `CONVENTIONS.md` (append with markers)
+Upgraded `nex setup` from 3-layer (plugins > rules > MCP) to 6-layer hierarchy per platform:
+**Hooks → Plugins → Agents → Workflows → Rules → MCP**
 
-Each file teaches the AI agent about Nex MCP tools (ask, remember, search, integrations).
+- Extracted shared hook logic into `cli/src/plugin/shared.ts` (doRecall, doCapture, doSessionStart)
+- Refactored 3 Claude Code hooks (auto-recall, auto-capture, auto-session-start) to use shared.ts
+- Created 8 adapter scripts in `cli/src/plugin/adapters/`:
+  - Cursor: session-start, recall, stop
+  - Windsurf: recall, capture
+  - Cline: recall, task-start, capture
+- Created `cli/platform-plugins/` with 7 template files:
+  - opencode-plugin.ts, vscode-agent.md, kilocode-modes.yaml, continue-provider.ts
+  - windsurf-workflows/: nex-ask.md, nex-remember.md, nex-search.md
+- Updated platform-detect.ts: 5 new capability fields, added OpenClaw + Aider (12 platforms total)
+- Updated installers.ts: 7 new installer functions
+- Updated setup.ts: 6-layer hierarchy, `--no-hooks` flag, fixed name prompt on key regen
+- PR #31 merged, published `@nex-ai/nex@0.1.20`
 
-### 2. Setup Hierarchy (plugins > rules > MCP)
+### 2. Core Backend Fixes
 
-Updated `nex setup` to use a clear hierarchy:
-- **Claude Code**: Plugin (hooks + slash commands) — no MCP needed
-- **Claude Desktop**: MCP only (no rules system)
-- **All others**: Rules (instruction files) + MCP (tools) — complementary
+- **PR #688 merged & deployed**: Artifact direction fix — `Artifact.__init__()` missing `direction` arg for TEXT-type artifacts in `core/py/context2/pipeline.py`
+- **PR #673 confirmed live**: Gmail reconnect (delete + recreate stale account)
+- **PR #681 confirmed live**: Historical email processing with engagement-based filtering
+- **Full historical email pipeline verified end-to-end** after Gmail reconnect with all 3 PRs deployed
 
-Files changed:
-- `cli/src/lib/platform-detect.ts` — Added `supportsRules`, `rulesPath` fields to Platform interface
-- `cli/src/lib/installers.ts` — Added `installRulesFile()` with standalone and append modes
-- `cli/src/commands/setup.ts` — Replaced install loop with hierarchy logic, `--no-mcp` → `--no-rules`
-- `cli/README.md` — Updated platforms table, setup flags, default behavior description
-- Root `README.md` — Quick Start restructured with `nex setup` as primary
+### 3. What Each Platform Gets Now
 
-### 3. P1 Integrations — Already Complete
+| Platform | Hooks | Plugins | Agents | Workflows | Rules | MCP |
+|----------|-------|---------|--------|-----------|-------|-----|
+| Claude Code | 3 hooks | — | — | 26 slash cmds | — | — |
+| OpenClaw | (plugin-internal) | 49 tools | — | — | — | — |
+| Cursor | 3 hooks | — | — | — | rules | MCP |
+| Windsurf | 2 hooks | — | — | 3 workflows | rules | MCP |
+| Cline | 3 hooks | — | — | — | rules | MCP |
+| OpenCode | — | plugin.ts | — | — | AGENTS.md | MCP |
+| VS Code | — | — | @nex agent | — | instructions | MCP |
+| Kilo Code | — | — | custom mode | — | rules | MCP |
+| Continue.dev | — | — | — | — | rules | MCP |
+| Zed | — | — | — | — | .rules | MCP |
+| Claude Desktop | — | — | — | — | — | MCP |
+| Aider | — | — | — | — | CONVENTIONS | — |
 
-Verified all surfaces already have integration tools:
-- MCP: `tools/integrations.ts` (4 tools)
-- OpenClaw: `nex_list/connect/disconnect_integration`
-- SKILL.md: Full API documentation
-- CLI slash commands: `/integrate`
+## Next Task: Interactive Integration Connection in `nex setup`
 
-### 4. Previous Session Work (still uncommitted)
+**Goal**: Make `nex setup` a complete one-command onboarding by adding an integration connection step.
 
-- `nex setup` is now the recommended onboarding path (README updates)
-- Core PRs: #681 merged (historical email), #687 created (deploy workflow fix)
+**Flow**:
+```
+nex setup
+  → Register (or reuse existing key)
+  → Install platform plugins (hooks, rules, MCP — already done)
+  → NEW: Show available integrations (Gmail, Slack, Google Calendar, Outlook, etc.)
+    → User selects which to connect (arrow-key TUI, can skip all)
+    → Already-connected integrations shown as ✓
+    → Opens OAuth URL in browser for each selected integration
+  → Done — full onboarding complete
+```
+
+**Key files to modify**:
+- `cli/src/commands/setup.ts` — Add integration step after platform install
+- `cli/src/lib/nex-api.ts` — Integration list/connect API calls (already exist)
+- `cli/src/lib/prompt.ts` — May need multi-select arrow-key chooser
+
+**Existing integration infrastructure** (already built):
+- `nex integrate list` — Lists available + connected integrations
+- `nex integrate connect <name>` — Opens OAuth URL in browser
+- API: `GET /api/sdk/integrations/available`, `POST /api/sdk/integrations/connect`
+- TUI: Interactive list with expand/collapse already in `cli/src/commands/integrate.ts`
 
 ## Build & Test
 
 ```bash
 cd /Users/najmuzzaman/Documents/nex/nex-as-a-skill
-cd cli && npm run build && npm test    # CLI: 65 tests pass
+cd cli && npm run build && npm test    # 65+ tests pass
 cd ../mcp && npm run build             # MCP server
 ```
-
-## NOT YET DONE
-
-### Commit & Publish
-- All changes are uncommitted in nex-as-a-skill repo
-- Version bump needed: 0.1.18 → 0.1.19
-- `npm publish --access public` after commit
-
-### Aider Support
-- Aider has NO MCP support — rules-only platform
-- `aider-conventions.md` template created but `nex setup` doesn't handle Aider yet
-- Need to add Aider to `platform-detect.ts` (detect via `which aider` or `.aider.conf.yml`)
-
-### TUI Polish (P2, plan exists)
-- Plan at `.claude/plans/wobbly-roaming-tulip.md`
-- Shared `lib/tui.ts` already partially built (used by setup status, integrate list)
-- Remaining: ask/search/scan/task formatters, arrow-key choose()
 
 ## Key Files
 
 | File | Purpose |
 |------|---------|
-| `cli/platform-rules/*.md` | Rules/instruction templates for each platform |
-| `cli/src/lib/platform-detect.ts` | Platform detection + capabilities |
-| `cli/src/lib/installers.ts` | MCP + plugin + rules installer functions |
-| `cli/src/commands/setup.ts` | Setup command — hierarchy-based install logic |
-| `cli/README.md` | npm README |
-| `README.md` | Repo README |
+| `cli/src/plugin/shared.ts` | Shared hook logic (doRecall, doCapture, doSessionStart) |
+| `cli/src/plugin/adapters/*.ts` | Platform-specific hook adapters |
+| `cli/platform-plugins/*` | Plugin/agent/workflow templates |
+| `cli/platform-rules/*.md` | Rules/instruction templates |
+| `cli/src/lib/platform-detect.ts` | Platform detection + 6 capability fields |
+| `cli/src/lib/installers.ts` | All installer functions (hooks, plugins, agents, workflows, rules, MCP) |
+| `cli/src/commands/setup.ts` | Setup command — 6-layer hierarchy |
+| `cli/src/commands/integrate.ts` | Integration list/connect/disconnect TUI |
+| `cli/package.json` | v0.1.20, files: dist, plugin-commands, platform-rules, platform-plugins |
 
 ## Core Repo Status
 
-- **PR #687**: Deploy workflow fix (`service=all` on `workflow_dispatch`) — open, needs merge
-- **PR #681**: Historical email processing — merged, deployed to staging, prod deploy triggered (run 22876044405)
-- **PR #673**: Gmail reconnect — awaiting Doug's re-review
+- **PR #688**: Artifact direction fix — merged & deployed to prod
+- **PR #681**: Historical email processing — merged & deployed to prod
+- **PR #673**: Gmail reconnect — merged & deployed to prod
+- **PR #680**: Semantic search date type fix — open
+- **PR #687**: Deploy workflow fix — open

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -2,6 +2,27 @@
 
 ## Completed
 
+### v0.1.20 — Full Platform Plugins + 6-Layer Setup Hierarchy (2026-03-10)
+- [x] Extracted shared hook logic into `cli/src/plugin/shared.ts` (doRecall, doCapture, doSessionStart)
+- [x] Refactored auto-recall.ts, auto-capture.ts, auto-session-start.ts to use shared.ts
+- [x] Created 8 platform adapter scripts in `cli/src/plugin/adapters/`:
+  - Cursor: session-start, recall, stop
+  - Windsurf: recall, capture
+  - Cline: recall, task-start, capture
+- [x] Created `cli/platform-plugins/` with 7 template files:
+  - opencode-plugin.ts, vscode-agent.md, kilocode-modes.yaml, continue-provider.ts
+  - windsurf-workflows: nex-ask.md, nex-remember.md, nex-search.md
+- [x] Updated platform-detect.ts: added supportsHooks, supportsCustomTools, supportsCustomAgents, supportsWorkflows, hookConfigPath; added OpenClaw + Aider platforms (12 total)
+- [x] Updated installers.ts: 7 new installer functions (hooks, plugins, agents, workflows per platform)
+- [x] Updated setup.ts: 6-layer hierarchy (Hooks → Plugins → Agents → Workflows → Rules → MCP)
+- [x] Added `--no-hooks` flag to setup
+- [x] Fixed name prompt bug: skip name prompt when regenerating API key for same email
+- [x] Added `platform-plugins` and `platform-rules` to package.json files array
+- [x] Updated CLI README with expanded 12-platform integration table
+- [x] Multi-agent team build: 4 parallel agents (cursor-hooks, windsurf-hooks, cline-hooks, platform-templates)
+- [x] Build passes, 65 tests pass, all adapter scripts exit 0
+- [x] PR #31 merged, published to npm as `@nex-ai/nex@0.1.20`
+
 ### v0.1.18 — TUI Polish + Integration Fixes (2026-03-09)
 - [x] Interactive integrate list with arrow-key selection, expand/collapse, inline actions
 - [x] Connection ID handling: `safenIds()` + `string | number` types
@@ -49,7 +70,7 @@
 - [x] File scanner with .nex.toml config
 - [x] Platform detection (10+ platforms)
 
-### v0.1.19 (unreleased) — Platform Rules + Setup Hierarchy (2026-03-09)
+### v0.1.19 — Platform Rules + Setup Hierarchy (2026-03-09, folded into v0.1.20)
 - [x] `nex setup` now installs rules + MCP for all detected platforms (hierarchy: plugins > rules > MCP)
 - [x] `--with-mcp` replaced with `--no-rules` (skip rules/instruction files)
 - [x] README restructured: `nex setup` is primary Quick Start, manual steps in collapsible sections
@@ -59,20 +80,29 @@
 - [x] Added `installRulesFile()` to `installers.ts` (standalone + append modes)
 - [x] Updated `setup.ts` install loop with hierarchy logic
 - [x] Updated README platforms table to show rules + MCP per platform
-- [ ] Not yet committed or published
+- [x] Published as part of v0.1.20
 
-## Core Backend Fixes (2026-03-09)
+## Core Backend Fixes (2026-03-09 — 2026-03-10)
 - [x] Search timeout: 300ms → 2000ms (PR #675, merged & deployed)
 - [x] Embedding dimension fix: 768 → 1024 (PR #679, merged & deployed)
 - [x] Semantic search date type fix (PR #680, open)
-- [x] Historical email processing (PR #681, merged & deployed to staging, prod deploy triggered)
+- [x] Historical email processing (PR #681, merged & deployed to prod)
 - [x] search_entities domain fallback (PR #676, merged & deployed)
-- [ ] Gmail reconnect sync fix (PR #673, awaiting Doug's re-review)
+- [x] Gmail reconnect sync fix (PR #673, merged & deployed to prod)
+- [x] Artifact direction fix: added `direction=None` to ArtifactModel for TEXT-type artifacts (PR #688, merged & deployed to prod)
 - [x] Deploy workflow fix: service=all on workflow_dispatch (PR #687, open)
+- [x] Full historical email pipeline verified end-to-end after Gmail reconnect (PRs #673 + #681 + #688)
 
 ## Pending / Next
 
-### P0: Platform Plugins/Rules — COMPLETE
+### P0: Interactive Integration Connection in `nex setup`
+- [ ] During `nex setup`, after platform install, show available integrations (Gmail, Slack, etc.)
+- [ ] Let user select which to connect (or skip all)
+- [ ] Integrations that are already connected show as such
+- [ ] Then proceed with normal setup flow
+- [ ] Goal: one-command onboarding — register + connect integrations + install platform plugins
+
+### P0 (DONE): Platform Plugins/Rules — COMPLETE
 - [x] Cursor: `.cursor/rules/nex.md` — rules + MCP
 - [x] Windsurf: `.windsurf/rules/nex.md` — rules + MCP
 - [x] VS Code / Copilot: `.github/instructions/nex.instructions.md` — instructions + MCP


### PR DESCRIPTION
## Summary
- `nex setup` now prompts users to connect integrations (Gmail, Slack, Google Calendar, etc.) after platform install
- Multi-select TUI with space to toggle, enter to confirm, s to skip — already-connected integrations shown as disabled
- Adds `--no-integrations` flag to skip the step
- Adds GitHub repo link to npm package (repository, homepage, bugs fields in package.json + README badges)
- Bumps to v0.1.21

## Test plan
- [ ] Run `nex setup` — verify integration multi-select appears after platform install
- [ ] Verify already-connected integrations show as disabled (green square)
- [ ] Select an integration, verify browser opens and OAuth polling works
- [ ] Press `s` to skip — verify setup continues normally
- [ ] Run `nex setup --no-integrations` — verify integration step is skipped
- [ ] Run `npm pack` — verify package includes repository metadata
- [ ] Build and tests pass: `npm run build && npm test` (65 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)