### PR TITLE
feat: nex graph — interactive context graph visualization

### DIFF
--- a/cli/scripts/gen-graph-db.ts
+++ b/cli/scripts/gen-graph-db.ts
@@ -1,0 +1,234 @@
+/**
+ * Generate graph HTML directly from the local Postgres database.
+ */
+import { execFileSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { spawn } from "node:child_process";
+import { generateGraphHtml } from "../src/lib/graph-html.js";
+import type { GraphData, ContextEdge, InsightNode, EntityInsightSummary } from "../src/lib/graph-html.js";
+
+const WORKSPACE_ID = process.argv[2] || "62190363569316105"; // nex-1 by default
+
+function pgQuery(sql: string): string {
+  return execFileSync("docker", [
+    "exec", "nex-postgres",
+    "psql", "-U", "postgres", "-d", "main", "-t", "-A", "-c", sql,
+  ], { encoding: "utf-8", timeout: 15_000 }).trim();
+}
+
+// Single query to get all graph data
+const raw = pgQuery(`
+SELECT json_build_object(
+  'nodes', (
+    SELECT COALESCE(json_agg(json_build_object(
+      'id', e.id::text,
+      'name', COALESCE(
+        (SELECT a.value->>'text' FROM attribute a WHERE a.entity_id = e.id AND a.slug = 'name' AND a.value->>'text' IS NOT NULL LIMIT 1),
+        (SELECT TRIM(COALESCE(a.value->'full_name'->>'first_name', '') || ' ' || COALESCE(a.value->'full_name'->>'last_name', '')) FROM attribute a WHERE a.entity_id = e.id AND a.slug = 'name' AND a.value->'full_name' IS NOT NULL LIMIT 1),
+        (SELECT a.value->>'first_name' FROM attribute a WHERE a.entity_id = e.id AND a.slug = 'name' AND a.value->>'first_name' IS NOT NULL LIMIT 1),
+        'Unknown'
+      ),
+      'type', e.definition_slug,
+      'definition_slug', e.definition_slug,
+      'primary_attribute', COALESCE(
+        (SELECT a.value->>'email' FROM attribute a WHERE a.entity_id = e.id AND a.slug = 'email_addresses' LIMIT 1),
+        (SELECT a.value->>'domain' FROM attribute a WHERE a.entity_id = e.id AND a.slug = 'domains' LIMIT 1),
+        ''
+      ),
+      'created_at', e.created_at
+    )), '[]'::json)
+    FROM entity e WHERE e.workspace_id = ${WORKSPACE_ID} AND e.archived_at IS NULL
+  ),
+  'edges', COALESCE((
+    SELECT json_agg(json_build_object(
+      'id', r.id::text,
+      'source', r.entity_1_id::text,
+      'target', r.entity_2_id::text,
+      'label', rd.entity_1_to_2_predicate,
+      'definition_id', r.definition_id::text
+    ))
+    FROM relationship r
+    JOIN relationship_definition rd ON r.definition_id = rd.id
+    WHERE r.workspace_id = ${WORKSPACE_ID}
+  ), '[]'::json),
+  'insights_raw', COALESCE((
+    SELECT json_agg(json_build_object(
+      'id', ei.id::text,
+      'content', ei.content,
+      'type', ei.type,
+      'confidence', ei.confidence,
+      'target_id', ei.target_id::text,
+      'hint', ec.hint,
+      'canonical_entity_id', ec.canonical_entity_id::text
+    ))
+    FROM entity_insight ei
+    LEFT JOIN entity_context2 ec ON ei.target_id = ec.id
+    WHERE ei.workspace_id = ${WORKSPACE_ID} AND ei.state = 'active'
+  ), '[]'::json),
+  'ghosts', COALESCE((
+    SELECT json_agg(json_build_object(
+      'id', 'ghost:' || ec.id::text,
+      'name', COALESCE(ec.hint, 'Unknown'),
+      'type', 'ghost',
+      'definition_slug', 'ghost',
+      'primary_attribute', '',
+      'created_at', ec.created_at
+    ))
+    FROM entity_context2 ec
+    WHERE ec.workspace_id = ${WORKSPACE_ID}
+    AND ec.canonical_entity_id IS NULL
+    AND ec.hint IS NOT NULL
+    AND ec.hint != ''
+  ), '[]'::json),
+  'relationship_definitions', COALESCE((
+    SELECT json_agg(json_build_object(
+      'id', rd.id::text,
+      'name', rd.entity_1_to_2_predicate || ' / ' || rd.entity_2_to_1_predicate,
+      'entity_1_to_2', rd.entity_1_to_2_predicate,
+      'entity_2_to_1', rd.entity_2_to_1_predicate
+    ))
+    FROM relationship_definition rd
+    WHERE rd.workspace_id = ${WORKSPACE_ID}
+  ), '[]'::json)
+);
+`);
+
+const dbData = JSON.parse(raw);
+
+// Merge ghost nodes into the node list
+const allNodes = [...dbData.nodes, ...(dbData.ghosts ?? [])];
+
+// Build entity ID set and name→id mapping for hint matching
+const entityIds = new Set(allNodes.map((n: any) => n.id));
+const nameToEntityId: Record<string, string> = {};
+for (const n of allNodes) {
+  nameToEntityId[n.name.toLowerCase()] = n.id;
+  if (n.primary_attribute) {
+    nameToEntityId[n.primary_attribute.toLowerCase()] = n.id;
+  }
+}
+
+// Also map context IDs to ghost IDs for insight targeting
+const contextIdToGhostId: Record<string, string> = {};
+for (const g of dbData.ghosts ?? []) {
+  // ghost id format: "ghost:contextId"
+  const contextId = g.id.replace("ghost:", "");
+  contextIdToGhostId[contextId] = g.id;
+}
+
+// Build insight nodes and context edges
+const insightNodes: InsightNode[] = [];
+const contextEdges: ContextEdge[] = [];
+const insightsByEntity: Record<string, EntityInsightSummary[]> = {};
+
+for (const ins of dbData.insights_raw ?? []) {
+  // Resolve target: canonical_entity_id → hint match → ghost context ID
+  let targetId = ins.canonical_entity_id ? String(ins.canonical_entity_id) : null;
+  if (!targetId || !entityIds.has(targetId)) {
+    const hint = (ins.hint ?? "").toLowerCase();
+    targetId = nameToEntityId[hint] ?? null;
+    // Partial match on hint
+    if (!targetId && hint) {
+      for (const [key, id] of Object.entries(nameToEntityId)) {
+        if (hint.includes(key) || key.includes(hint)) {
+          targetId = id;
+          break;
+        }
+      }
+    }
+  }
+  // Fallback: link to ghost entity via context ID
+  if (!targetId || !entityIds.has(targetId)) {
+    const ctxId = String(ins.target_id);
+    targetId = contextIdToGhostId[ctxId] ?? null;
+  }
+  if (!targetId || !entityIds.has(targetId)) continue;
+
+  // Panel insights
+  if (!insightsByEntity[targetId]) insightsByEntity[targetId] = [];
+  insightsByEntity[targetId].push({
+    content: ins.content,
+    confidence: ins.confidence,
+    type: ins.type,
+  });
+
+  // Graph insight nodes
+  const insightId = `ins:${ins.id}`;
+  insightNodes.push({
+    id: insightId,
+    content: ins.content,
+    type: ins.type,
+    confidence: ins.confidence,
+    source: "entity_insight",
+  });
+  contextEdges.push({
+    id: `ce:${ins.id}`,
+    source: insightId,
+    target: targetId,
+    label: ins.type,
+    edge_type: "insight",
+    confidence: ins.confidence,
+  });
+}
+
+// Build triplet context edges — resolve context IDs to entity IDs
+try {
+  const tripletRaw = pgQuery(`
+    SELECT COALESCE(json_agg(json_build_object(
+      'id', t.id::text,
+      'subject_entity', sc.canonical_entity_id::text,
+      'object_entity', oc.canonical_entity_id::text,
+      'predicate', t.predicate
+    )), '[]'::json)
+    FROM entity_insight_triplet t
+    JOIN entity_insight ei ON t.entity_insight_id = ei.id
+    LEFT JOIN entity_context2 sc ON t.subject_context_id = sc.id
+    LEFT JOIN entity_context2 oc ON t.object_context_id = oc.id
+    WHERE ei.workspace_id = ${WORKSPACE_ID} AND ei.state = 'active'
+    AND sc.canonical_entity_id IS NOT NULL AND oc.canonical_entity_id IS NOT NULL;
+  `);
+
+  const triplets = tripletRaw ? JSON.parse(tripletRaw) ?? [] : [];
+  const seenTrips = new Set<string>();
+  for (const t of triplets) {
+    const sid = String(t.subject_entity);
+    const oid = String(t.object_entity);
+    if (sid === oid) continue;
+    const key = `${sid}-${oid}-${t.predicate}`;
+    if (seenTrips.has(key)) continue;
+    seenTrips.add(key);
+    if (entityIds.has(sid) && entityIds.has(oid)) {
+      contextEdges.push({
+        id: `trip:${t.id}`,
+        source: sid,
+        target: oid,
+        label: t.predicate,
+        edge_type: "triplet",
+      });
+    }
+  }
+} catch { /* no triplets */ }
+
+const graphData: GraphData = {
+  nodes: allNodes,
+  edges: dbData.edges,
+  context_edges: contextEdges,
+  insight_nodes: insightNodes,
+  relationship_definitions: dbData.relationship_definitions,
+  insights: insightsByEntity,
+  total_nodes: allNodes.length,
+  total_edges: dbData.edges.length,
+  total_context_edges: contextEdges.length,
+};
+
+const html = generateGraphHtml(graphData);
+const outPath = join(tmpdir(), `nex-graph-${Date.now()}.html`);
+writeFileSync(outPath, html, "utf-8");
+
+const totalInsights = insightNodes.length;
+console.error(`Graph: ${graphData.total_nodes} entities, ${graphData.total_edges + contextEdges.length} connections, ${totalInsights} insights`);
+console.error(`Saved to: ${outPath}`);
+
+spawn("open", [`file://${outPath}`], { stdio: "ignore", detached: true }).unref();

--- a/cli/scripts/gen-graph.ts
+++ b/cli/scripts/gen-graph.ts
@@ -1,0 +1,227 @@
+/**
+ * Temporary script to generate graph HTML from workspace data via CLI commands.
+ * Used while /v1/graph endpoint is not deployed yet.
+ */
+import { execFileSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { spawn } from "node:child_process";
+import { generateGraphHtml } from "../src/lib/graph-html.js";
+import type { GraphData, GraphNode, GraphEdge, ContextEdge, InsightNode, EntityInsightSummary } from "../src/lib/graph-html.js";
+
+const cwd = join(import.meta.dirname, "..");
+
+function cli(args: string[]): string {
+  return execFileSync("npx", ["tsx", "src/index.ts", ...args, "--format", "json"], {
+    cwd,
+    encoding: "utf-8",
+    timeout: 30_000,
+  });
+}
+
+function getName(attrs: Record<string, any>): string {
+  const n = attrs?.name;
+  if (!n) return "Unknown";
+  if (n.type === "full_name") {
+    return [n.first_name, n.last_name].filter(Boolean).join(" ");
+  }
+  return n.text ?? "Unknown";
+}
+
+function getPrimary(attrs: Record<string, any>, type: string): string {
+  if (type === "person") {
+    return attrs?.email_addresses?.[0]?.email ?? attrs?.job_title?.text ?? "";
+  }
+  if (type === "company") {
+    return attrs?.domains?.[0]?.domain ?? "";
+  }
+  return "";
+}
+
+// 1. Fetch all object types
+const objectsRes = JSON.parse(cli(["object", "list"]));
+const objectDefs: Record<string, { id: string; slug: string; type: string }> = {};
+for (const obj of objectsRes.data) {
+  objectDefs[obj.id] = obj;
+}
+
+// 2. Fetch all records per object type
+const allNodes: GraphNode[] = [];
+const recordMap: Record<string, { type: string; name: string }> = {};
+
+for (const obj of objectsRes.data) {
+  const res = JSON.parse(cli(["record", "list", obj.slug, "--limit", "200", "--attributes", "all"]));
+  for (const rec of res.data) {
+    const name = getName(rec.attributes);
+    const primary = getPrimary(rec.attributes, obj.type);
+    allNodes.push({
+      id: rec.id,
+      name,
+      type: obj.type,
+      definition_slug: obj.slug,
+      primary_attribute: primary,
+      created_at: rec.created_at,
+    });
+    recordMap[rec.id] = { type: obj.type, name };
+  }
+}
+
+// 3. Fetch relationship definitions
+const relDefsRes = JSON.parse(cli(["rel", "list-defs"]));
+const relDefs = relDefsRes.data;
+
+// Build object ID → slug map
+const objIdToSlug: Record<string, string> = {};
+for (const obj of objectsRes.data) {
+  objIdToSlug[obj.id] = obj.slug;
+}
+
+// 4. Build edges — connect Najmuzzaman to Nex (known from data)
+const allEdges: GraphEdge[] = [];
+const seenEdges = new Set<string>();
+
+const knownRelationships = [
+  {
+    source: "62869717286693892", // Najmuzzaman
+    target: "62869717437688836", // Nex
+    label: "works at",
+    defId: relDefs.find((d: any) => d.entity_1_to_2_predicate === "employs")?.id ?? "",
+  },
+];
+
+for (const rel of knownRelationships) {
+  const key = `${rel.source}-${rel.target}`;
+  if (!seenEdges.has(key)) {
+    seenEdges.add(key);
+    allEdges.push({
+      id: `rel:${key}`,
+      source: rel.source,
+      target: rel.target,
+      label: rel.label,
+      definition_id: rel.defId,
+    });
+  }
+}
+
+// 5. Fetch insights
+const insightsRes = JSON.parse(cli(["insight", "list"]));
+const insightsByEntity: Record<string, EntityInsightSummary[]> = {};
+const contextEdges: ContextEdge[] = [];
+const insightNodes: InsightNode[] = [];
+
+// Map insight targets to record IDs using domain/name hints
+const hintToRecordId: Record<string, string> = {};
+for (const node of allNodes) {
+  const nameLower = node.name.toLowerCase();
+  hintToRecordId[nameLower] = node.id;
+  if (node.primary_attribute) {
+    hintToRecordId[node.primary_attribute.toLowerCase()] = node.id;
+  }
+}
+
+for (const insight of insightsRes.insights ?? []) {
+  const hint = (insight.target?.hint ?? "").toLowerCase();
+  let entityId = hintToRecordId[hint];
+
+  // Try matching by signal values
+  if (!entityId && insight.target?.signals) {
+    for (const sig of insight.target.signals) {
+      const val = (sig.value ?? "").toLowerCase();
+      if (hintToRecordId[val]) {
+        entityId = hintToRecordId[val];
+        break;
+      }
+    }
+  }
+
+  if (entityId) {
+    if (!insightsByEntity[entityId]) insightsByEntity[entityId] = [];
+    insightsByEntity[entityId].push({
+      content: insight.content,
+      confidence: insight.confidence,
+      type: insight.type,
+    });
+
+    // Create insight nodes + context edges
+    const insightId = `ins:${insightNodes.length}`;
+    insightNodes.push({
+      id: insightId,
+      content: insight.content,
+      type: insight.type,
+      confidence: insight.confidence,
+      source: "entity_insight",
+    });
+    contextEdges.push({
+      id: `ce:${contextEdges.length}`,
+      source: insightId,
+      target: entityId,
+      label: insight.type,
+      edge_type: "insight",
+      confidence: insight.confidence,
+    });
+  }
+}
+
+// 6. Create context edges between companies sharing "software" industry
+const companyIndustries: Record<string, string[]> = {};
+for (const node of allNodes) {
+  if (node.type === "company") {
+    try {
+      const recRes = JSON.parse(cli(["record", "get", node.id]));
+      const industries = recRes.attributes?.industries;
+      if (industries) {
+        companyIndustries[node.id] = industries.map((i: any) => i.option_id);
+      }
+    } catch { /* skip */ }
+  }
+}
+
+const softwareCompanies = Object.entries(companyIndustries)
+  .filter(([_, industries]) => industries.includes("software"))
+  .map(([id]) => id);
+
+for (let i = 0; i < softwareCompanies.length; i++) {
+  for (let j = i + 1; j < softwareCompanies.length; j++) {
+    const key = `${softwareCompanies[i]}-${softwareCompanies[j]}`;
+    if (!seenEdges.has(key)) {
+      seenEdges.add(key);
+      contextEdges.push({
+        id: `ctx:${key}`,
+        source: softwareCompanies[i],
+        target: softwareCompanies[j],
+        label: "same industry",
+        edge_type: "context",
+      });
+    }
+  }
+}
+
+// 7. Assemble graph data
+const graphData: GraphData = {
+  nodes: allNodes,
+  edges: allEdges,
+  context_edges: contextEdges,
+  insight_nodes: insightNodes,
+  relationship_definitions: relDefs.map((d: any) => ({
+    id: d.id,
+    name: `${objIdToSlug[d.entity_definition_1_id] ?? "?"} → ${objIdToSlug[d.entity_definition_2_id] ?? "?"}`,
+    entity_1_to_2: d.entity_1_to_2_predicate,
+    entity_2_to_1: d.entity_2_to_1_predicate,
+  })),
+  insights: insightsByEntity,
+  total_nodes: allNodes.length,
+  total_edges: allEdges.length,
+  total_context_edges: contextEdges.length,
+};
+
+// 8. Generate HTML and open
+const html = generateGraphHtml(graphData);
+const outPath = join(tmpdir(), `nex-graph-${Date.now()}.html`);
+writeFileSync(outPath, html, "utf-8");
+
+console.error(`Graph: ${allNodes.length} entities, ${allEdges.length + contextEdges.length} connections, ${insightNodes.length} insights`);
+console.error(`Saved to: ${outPath}`);
+
+// Open in browser
+spawn("open", [`file://${outPath}`], { stdio: "ignore", detached: true }).unref();

--- a/cli/src/commands/graph.ts
+++ b/cli/src/commands/graph.ts
@@ -1,0 +1,94 @@
+/**
+ * nex graph — Visualize the workspace entity graph in the browser.
+ */
+
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { spawn } from "node:child_process";
+import { program } from "../cli.js";
+import { NexClient } from "../lib/client.js";
+import { resolveApiKey, resolveFormat, resolveTimeout } from "../lib/config.js";
+import { printOutput, printError } from "../lib/output.js";
+import type { Format } from "../lib/output.js";
+import { generateGraphHtml } from "../lib/graph-html.js";
+import type { GraphData } from "../lib/graph-html.js";
+import { sym, style } from "../lib/tui.js";
+
+function getClient(): { client: NexClient; format: Format } {
+  const opts = program.opts();
+  const client = new NexClient(resolveApiKey(opts.apiKey), resolveTimeout(opts.timeout));
+  return { client, format: resolveFormat(opts.format) as Format };
+}
+
+function openBrowser(url: string): void {
+  try {
+    let cmd: string;
+    let args: string[];
+    if (process.platform === "darwin") {
+      cmd = "open";
+      args = [url];
+    } else if (process.platform === "linux") {
+      cmd = "xdg-open";
+      args = [url];
+    } else if (process.platform === "win32") {
+      cmd = "cmd";
+      args = ["/c", "start", "", url];
+    } else {
+      throw new Error("Unsupported platform");
+    }
+    spawn(cmd, args, { stdio: "ignore", detached: true }).unref();
+  } catch {
+    process.stderr.write(`Open this URL in your browser:\n${url}\n\n`);
+  }
+}
+
+program
+  .command("graph")
+  .description("Visualize the workspace entity graph in the browser")
+  .option("--out <file>", "Save HTML to a specific file path")
+  .option("--limit <n>", "Maximum number of entities to fetch (default: 1000)", "1000")
+  .option("--no-open", "Generate the file without opening the browser")
+  .action(async (opts: { out?: string; limit: string; open: boolean }) => {
+    const { client, format } = getClient();
+    const limit = parseInt(opts.limit, 10) || 1000;
+
+    process.stderr.write(`${sym.info} Fetching workspace graph...\n`);
+
+    let data: GraphData;
+    try {
+      data = await client.get<GraphData>(`/v1/graph?limit=${limit}`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      printError(`Failed to fetch graph: ${message}`);
+      process.exit(1);
+    }
+
+    const html = generateGraphHtml(data);
+    const outPath =
+      opts.out ?? join(tmpdir(), `nex-graph-${Date.now()}.html`);
+    writeFileSync(outPath, html, "utf-8");
+
+    if (format === "json") {
+      printOutput(
+        {
+          path: outPath,
+          total_nodes: data.total_nodes,
+          total_edges: data.total_edges,
+        },
+        "json",
+      );
+      return;
+    }
+
+    if (opts.open) {
+      openBrowser(`file://${outPath}`);
+      process.stderr.write(
+        `${sym.success} Graph opened ${style.dim("—")} ${data.total_nodes} entities, ${data.total_edges} relationships\n`,
+      );
+    } else {
+      process.stderr.write(
+        `${sym.success} Graph saved to ${outPath} ${style.dim("—")} ${data.total_nodes} entities, ${data.total_edges} relationships\n`,
+      );
+    }
+  });

--- a/cli/src/commands/setup.ts
+++ b/cli/src/commands/setup.ts
@@ -22,15 +22,15 @@ import type { Format } from "../lib/output.js";
 import { heading, keyValue, tree, badge, style, sym, spinner as createSpinner, exitHint, isTTY } from "../lib/tui.js";
 import { openBrowser } from "./integrate.js";
 
-const INTEGRATIONS_MAP: Record<string, { type: string; provider: string }> = {
-  gmail: { type: "email", provider: "google" },
-  "google-calendar": { type: "calendar", provider: "google" },
-  outlook: { type: "email", provider: "microsoft" },
-  "outlook-calendar": { type: "calendar", provider: "microsoft" },
-  slack: { type: "messaging", provider: "slack" },
-  salesforce: { type: "crm", provider: "salesforce" },
-  hubspot: { type: "crm", provider: "hubspot" },
-  attio: { type: "crm", provider: "attio" },
+const INTEGRATIONS_MAP: Record<string, { type: string; provider: string; displayName: string; description: string }> = {
+  gmail: { type: "email", provider: "google", displayName: "Gmail", description: "Connect your Gmail account to sync emails" },
+  "google-calendar": { type: "calendar", provider: "google", displayName: "Google Calendar (Nex Meeting Bot)", description: "Connect Google Calendar for meeting transcripts" },
+  outlook: { type: "email", provider: "microsoft", displayName: "Outlook", description: "Connect your Outlook account to sync emails" },
+  "outlook-calendar": { type: "calendar", provider: "microsoft", displayName: "Outlook Calendar (Nex Meeting Bot)", description: "Connect Outlook Calendar for meeting transcripts" },
+  slack: { type: "messaging", provider: "slack", displayName: "Slack", description: "Connect Slack to sync messages" },
+  salesforce: { type: "crm", provider: "salesforce", displayName: "Salesforce", description: "Connect Salesforce CRM" },
+  hubspot: { type: "crm", provider: "hubspot", displayName: "HubSpot", description: "Connect HubSpot CRM" },
+  attio: { type: "crm", provider: "attio", displayName: "Attio", description: "Connect Attio CRM" },
 };
 import { detectPlatforms, getPlatformById, VALID_PLATFORM_IDS } from "../lib/platform-detect.js";
 import type { Platform } from "../lib/platform-detect.js";
@@ -500,7 +500,7 @@ async function runSetup(opts: {
 
 // --- Integration connection step ---
 
-interface IntegrationEntry {
+export interface IntegrationEntry {
   type: string;
   provider: string;
   display_name: string;
@@ -508,15 +508,31 @@ interface IntegrationEntry {
   connections: Array<{ id: string | number; status: string; identifier: string }>;
 }
 
+/** Exported for testing. */
+export function fallbackIntegrations(): IntegrationEntry[] {
+  return Object.values(INTEGRATIONS_MAP).map((entry) => ({
+    type: entry.type,
+    provider: entry.provider,
+    display_name: entry.displayName,
+    description: entry.description,
+    connections: [],
+  }));
+}
+
 async function connectIntegrations(apiKey: string): Promise<void> {
   const client = new NexClient(apiKey, 10_000);
 
   let integrations: IntegrationEntry[];
   try {
-    integrations = await client.get<IntegrationEntry[]>("/v1/integrations/", 10_000);
-    if (!Array.isArray(integrations) || integrations.length === 0) return;
+    const fetched = await client.get<IntegrationEntry[]>("/v1/integrations/", 10_000);
+    if (!Array.isArray(fetched) || fetched.length === 0) {
+      process.stderr.write(`\n  ${style.dim("No integrations available yet.")} Run ${style.bold("nex integrate")} to connect integrations later.\n`);
+      return;
+    }
+    integrations = fetched;
   } catch {
-    return; // Silently skip if API unavailable
+    process.stderr.write(`\n  ${style.dim("Could not fetch integrations.")} Run ${style.bold("nex integrate")} to connect integrations later.\n`);
+    return;
   }
 
   // Build multi-select options

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -26,6 +26,7 @@ import "./commands/session.js";
 import "./commands/scan.js";
 import "./commands/integrate.js";
 import "./commands/setup.js";
+import "./commands/graph.js";
 
 /**
  * Read all data from stdin (non-TTY only).

--- a/cli/src/lib/graph-html.ts
+++ b/cli/src/lib/graph-html.ts
@@ -1,5 +1,5 @@
 /**
- * Self-contained HTML graph visualization using Cytoscape.js.
+ * Self-contained HTML graph visualization using force-graph (vasturiano).
  * Generates a single HTML string that can be opened in any browser.
  */
 
@@ -20,6 +20,21 @@ export interface GraphEdge {
   definition_id: string;
 }
 
+export interface ContextEdge {
+  id: string;
+  source: string;
+  target: string;
+  label: string;
+  edge_type: "context" | "triplet";
+  confidence?: number;
+}
+
+export interface EntityInsightSummary {
+  content: string;
+  confidence: number;
+  type: string;
+}
+
 export interface RelationshipDefinition {
   id: string;
   name: string;
@@ -30,9 +45,12 @@ export interface RelationshipDefinition {
 export interface GraphData {
   nodes: GraphNode[];
   edges: GraphEdge[];
+  context_edges: ContextEdge[];
   relationship_definitions: RelationshipDefinition[];
+  insights: Record<string, EntityInsightSummary[]>;
   total_nodes: number;
   total_edges: number;
+  total_context_edges: number;
 }
 
 const NODE_COLORS: Record<string, string> = {
@@ -63,44 +81,15 @@ export function generateGraphHtml(data: GraphData): string {
   const typeSet = new Set<string>();
   for (const n of data.nodes) typeSet.add(n.type);
 
-  // Build degree map for sizing
-  const degree: Record<string, number> = {};
-  for (const n of data.nodes) degree[n.id] = 0;
-  for (const e of data.edges) {
-    degree[e.source] = (degree[e.source] ?? 0) + 1;
-    degree[e.target] = (degree[e.target] ?? 0) + 1;
-  }
-  const maxDeg = Math.max(1, ...Object.values(degree));
-
-  // Node set for filtering dangling edges
-  const nodeIds = new Set(data.nodes.map((n) => n.id));
-
-  // Build Cytoscape elements
-  const elements = {
-    nodes: data.nodes.map((n) => ({
-      data: {
-        id: n.id,
-        label: n.name,
-        type: n.type,
-        primary_attribute: n.primary_attribute ?? "",
-        created_at: n.created_at ?? "",
-        color: nodeColors[n.type] ?? DEFAULT_COLOR,
-        size: 20 + ((degree[n.id] ?? 0) / maxDeg) * 40,
-      },
-    })),
-    edges: data.edges
-      .filter((e) => nodeIds.has(e.source) && nodeIds.has(e.target))
-      .map((e) => ({
-        data: {
-          id: "e" + e.id,
-          source: e.source,
-          target: e.target,
-          label: e.label,
-        },
-      })),
-  };
-
   const legendTypes = Array.from(typeSet).sort();
+
+  // Count total insights
+  let totalInsights = 0;
+  for (const key of Object.keys(data.insights ?? {})) {
+    totalInsights += (data.insights[key] ?? []).length;
+  }
+
+  const totalConnections = data.total_edges + data.total_context_edges;
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -111,7 +100,7 @@ export function generateGraphHtml(data: GraphData): string {
 <style>
 *{margin:0;padding:0;box-sizing:border-box}
 body{background:#1a1a2e;color:#e0e0e0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;overflow:hidden}
-#cy{width:100vw;height:100vh}
+#graph-container{width:100vw;height:100vh}
 #search-box{position:fixed;top:16px;left:16px;z-index:10;background:#25253e;border:1px solid #3a3a5c;border-radius:8px;padding:8px 12px;color:#e0e0e0;font-size:14px;width:240px;outline:none}
 #search-box::placeholder{color:#6a6a8a}
 #search-box:focus{border-color:#4F87E0}
@@ -119,19 +108,24 @@ body{background:#1a1a2e;color:#e0e0e0;font-family:-apple-system,BlinkMacSystemFo
 #legend{position:fixed;bottom:16px;left:16px;z-index:10;background:#25253e;border:1px solid #3a3a5c;border-radius:8px;padding:10px 14px;font-size:13px}
 .legend-item{display:flex;align-items:center;gap:8px;margin:4px 0}
 .legend-dot{width:10px;height:10px;border-radius:50%;flex-shrink:0}
+.legend-line{width:20px;height:2px;flex-shrink:0;border-radius:1px}
 #detail-panel{position:fixed;top:0;right:-320px;width:320px;height:100vh;background:#25253e;border-left:1px solid #3a3a5c;z-index:20;padding:20px;overflow-y:auto;transition:right .2s ease}
 #detail-panel.open{right:0}
 #detail-panel h3{margin-bottom:12px;font-size:16px;color:#fff}
 #detail-panel .field{margin-bottom:8px;font-size:13px}
 #detail-panel .field .label{color:#6a6a8a;font-size:11px;text-transform:uppercase;letter-spacing:.5px}
 #detail-panel .field .value{color:#e0e0e0;margin-top:2px}
+.insight-card{background:#2a2a45;border-radius:6px;padding:8px 10px;margin-top:6px}
+.insight-card .insight-type{display:inline-block;background:#3a3a5c;border-radius:3px;padding:1px 6px;font-size:10px;text-transform:uppercase;letter-spacing:.5px;color:#9a9ab0;margin-right:6px}
+.insight-card .insight-confidence{font-size:11px;color:#6a6a8a;float:right}
+.insight-card .insight-content{margin-top:4px;font-size:12px;color:#c0c0d0;line-height:1.4}
 #detail-close{position:absolute;top:12px;right:12px;background:none;border:none;color:#6a6a8a;cursor:pointer;font-size:18px}
 #detail-close:hover{color:#e0e0e0}
 </style>
 </head>
 <body>
 <input id="search-box" type="text" placeholder="Search entities..." autocomplete="off">
-<div id="stats">${escapeHtml(String(data.total_nodes))} entities &middot; ${escapeHtml(String(data.total_edges))} relationships</div>
+<div id="stats">${escapeHtml(String(data.total_nodes))} entities &middot; ${escapeHtml(String(totalConnections))} connections &middot; ${escapeHtml(String(totalInsights))} insights</div>
 <div id="legend">
 ${legendTypes
   .map(
@@ -139,136 +133,90 @@ ${legendTypes
       `<div class="legend-item"><span class="legend-dot" style="background:${escapeHtml(nodeColors[t] ?? DEFAULT_COLOR)}"></span>${escapeHtml(t)}</div>`
   )
   .join("\n")}
+<div class="legend-item"><span class="legend-line" style="background:#555"></span>Formal</div>
+<div class="legend-item"><span class="legend-line" style="background:#7c5cbf"></span>Context</div>
+<div class="legend-item"><span class="legend-line" style="background:#c4813a"></span>Triplet</div>
 </div>
 <div id="detail-panel">
 <button id="detail-close">&times;</button>
 <h3 id="detail-name"></h3>
 <div id="detail-body"></div>
 </div>
-<div id="cy"></div>
+<div id="graph-container"></div>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/cytoscape/3.30.4/cytoscape.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/force-graph"></script>
 
-<script id="graph-data" type="application/json">${escapeJsonForHtml(elements)}</script>
+<script id="graph-data" type="application/json">${escapeJsonForHtml(data)}</script>
 
 <script>
 (function(){
-  var elements = JSON.parse(document.getElementById("graph-data").textContent);
+  var data = JSON.parse(document.getElementById("graph-data").textContent);
 
-  var cy = cytoscape({
-    container: document.getElementById("cy"),
-    elements: elements,
-    style: [
-      {
-        selector: "node",
-        style: {
-          "background-color": "data(color)",
-          "label": "data(label)",
-          "width": "data(size)",
-          "height": "data(size)",
-          "color": "#c0c0d0",
-          "font-size": "11px",
-          "text-valign": "bottom",
-          "text-margin-y": "6px",
-          "text-outline-color": "#1a1a2e",
-          "text-outline-width": "2px",
-          "min-zoomed-font-size": 10
-        }
-      },
-      {
-        selector: "edge",
-        style: {
-          "width": 1.5,
-          "line-color": "#3a3a5c",
-          "target-arrow-color": "#3a3a5c",
-          "target-arrow-shape": "triangle",
-          "curve-style": "bezier",
-          "label": "data(label)",
-          "font-size": "9px",
-          "color": "#6a6a8a",
-          "text-rotation": "autorotate",
-          "text-outline-color": "#1a1a2e",
-          "text-outline-width": "1.5px",
-          "min-zoomed-font-size": 12
-        }
-      },
-      {
-        selector: "node.highlighted",
-        style: {
-          "border-width": "3px",
-          "border-color": "#fff"
-        }
-      },
-      {
-        selector: "node.faded",
-        style: {
-          "opacity": 0.15
-        }
-      },
-      {
-        selector: "edge.faded",
-        style: {
-          "opacity": 0.08
-        }
-      }
-    ],
-    layout: {
-      name: "cose",
-      animate: false,
-      nodeRepulsion: function(){ return 8000; },
-      idealEdgeLength: function(){ return 120; },
-      gravity: 0.3,
-      numIter: 300,
-      padding: 40
-    },
-    wheelSensitivity: 0.3
-  });
+  var nodeColors = {person:"#4F87E0",company:"#34A853",deal:"#F4A236"};
+  var defaultColor = "#9B59B6";
 
-  // Hover: highlight neighbors
-  cy.on("mouseover", "node", function(e){
-    var node = e.target;
-    var neighborhood = node.neighborhood().add(node);
-    cy.elements().addClass("faded");
-    neighborhood.removeClass("faded");
-    node.addClass("highlighted");
-  });
+  // Build node ID set for filtering dangling edges
+  var nodeIdSet = {};
+  data.nodes.forEach(function(n){ nodeIdSet[n.id] = true; });
 
-  cy.on("mouseout", "node", function(e){
-    cy.elements().removeClass("faded").removeClass("highlighted");
-  });
-
-  // Search
-  var searchBox = document.getElementById("search-box");
-  searchBox.addEventListener("input", function(){
-    var q = searchBox.value.trim().toLowerCase();
-    if (!q) {
-      cy.elements().removeClass("faded");
-      return;
-    }
-    cy.nodes().forEach(function(n){
-      var name = (n.data("label") || "").toLowerCase();
-      if (name.includes(q)) {
-        n.removeClass("faded");
-        n.neighborhood().add(n).removeClass("faded");
-      } else {
-        n.addClass("faded");
-      }
-    });
-    cy.edges().forEach(function(e){
-      if (e.source().hasClass("faded") && e.target().hasClass("faded")) {
-        e.addClass("faded");
-      } else {
-        e.removeClass("faded");
-      }
-    });
-    // Center on first match
-    var matches = cy.nodes().filter(function(n){
-      return (n.data("label") || "").toLowerCase().includes(q);
-    });
-    if (matches.length > 0) {
-      cy.animate({ center: { eles: matches.first() }, zoom: 1.5, duration: 300 });
+  // Merge edges + context_edges into links
+  var links = [];
+  (data.edges || []).forEach(function(e){
+    if (nodeIdSet[e.source] && nodeIdSet[e.target]) {
+      links.push({source:e.source, target:e.target, label:e.label, color:"#555", edgeType:"formal"});
     }
   });
+  (data.context_edges || []).forEach(function(e){
+    if (nodeIdSet[e.source] && nodeIdSet[e.target]) {
+      var c = e.edge_type === "triplet" ? "#c4813a" : "#7c5cbf";
+      links.push({source:e.source, target:e.target, label:e.label, color:c, edgeType:e.edge_type});
+    }
+  });
+
+  // Build degree map across all link types
+  var degree = {};
+  data.nodes.forEach(function(n){ degree[n.id] = 0; });
+  links.forEach(function(l){
+    degree[l.source] = (degree[l.source] || 0) + 1;
+    degree[l.target] = (degree[l.target] || 0) + 1;
+  });
+  var maxDeg = 1;
+  for (var k in degree) { if (degree[k] > maxDeg) maxDeg = degree[k]; }
+
+  // Build force-graph nodes
+  var fgNodes = data.nodes.map(function(n){
+    return {
+      id: n.id,
+      name: n.name,
+      type: n.type,
+      primary_attribute: n.primary_attribute || "",
+      created_at: n.created_at || "",
+      color: nodeColors[n.type] || defaultColor,
+      size: 2 + ((degree[n.id] || 0) / maxDeg) * 8
+    };
+  });
+
+  // Hover highlight state
+  var hoveredNode = null;
+  var connectedNodes = {};
+
+  function highlightNode(node) {
+    if (node) {
+      hoveredNode = node;
+      connectedNodes = {};
+      connectedNodes[node.id] = true;
+      links.forEach(function(l){
+        var sid = typeof l.source === "object" ? l.source.id : l.source;
+        var tid = typeof l.target === "object" ? l.target.id : l.target;
+        if (sid === node.id) connectedNodes[tid] = true;
+        if (tid === node.id) connectedNodes[sid] = true;
+      });
+    } else {
+      hoveredNode = null;
+      connectedNodes = {};
+    }
+    graph.nodeColor(graph.nodeColor());
+  }
 
   // Detail panel
   var panel = document.getElementById("detail-panel");
@@ -278,6 +226,10 @@ ${legendTypes
   document.getElementById("detail-close").addEventListener("click", function(){
     panel.classList.remove("open");
   });
+
+  function closeDetail() {
+    panel.classList.remove("open");
+  }
 
   function addField(parent, labelText, valueText) {
     var field = document.createElement("div");
@@ -293,17 +245,28 @@ ${legendTypes
     parent.appendChild(field);
   }
 
-  cy.on("tap", "node", function(e){
-    var node = e.target;
-    var d = node.data();
-    var neighbors = node.neighborhood("node");
-    detailName.textContent = d.label || d.id;
-    detailBody.textContent = "";
-    addField(detailBody, "Type", d.type || "");
-    if (d.primary_attribute) addField(detailBody, "Primary", d.primary_attribute);
-    if (d.created_at) addField(detailBody, "Created", d.created_at);
-    addField(detailBody, "Connections", String(neighbors.length));
-    if (neighbors.length > 0) {
+  function showDetail(node) {
+    detailName.textContent = node.name || node.id;
+    while (detailBody.firstChild) detailBody.removeChild(detailBody.firstChild);
+    addField(detailBody, "Type", node.type || "");
+    if (node.primary_attribute) addField(detailBody, "Primary", node.primary_attribute);
+    if (node.created_at) addField(detailBody, "Created", node.created_at);
+
+    // Count connections
+    var connCount = 0;
+    var connectedList = [];
+    var nodeMap = {};
+    fgNodes.forEach(function(n){ nodeMap[n.id] = n; });
+    links.forEach(function(l){
+      var sid = typeof l.source === "object" ? l.source.id : l.source;
+      var tid = typeof l.target === "object" ? l.target.id : l.target;
+      if (sid === node.id) { connCount++; connectedList.push(tid); }
+      if (tid === node.id) { connCount++; connectedList.push(sid); }
+    });
+    addField(detailBody, "Connections", String(connCount));
+
+    // Connected entities
+    if (connectedList.length > 0) {
       var field = document.createElement("div");
       field.className = "field";
       var lbl = document.createElement("div");
@@ -312,24 +275,106 @@ ${legendTypes
       field.appendChild(lbl);
       var val = document.createElement("div");
       val.className = "value";
-      neighbors.slice(0, 20).forEach(function(n){
+      var shown = connectedList.slice(0, 20);
+      shown.forEach(function(cid){
         var line = document.createElement("div");
-        line.textContent = n.data("label") || n.id();
+        var cn = nodeMap[cid];
+        line.textContent = cn ? cn.name : cid;
         val.appendChild(line);
       });
-      if (neighbors.length > 20) {
+      if (connectedList.length > 20) {
         var more = document.createElement("em");
-        more.textContent = "...and " + (neighbors.length - 20) + " more";
+        more.textContent = "...and " + (connectedList.length - 20) + " more";
         val.appendChild(more);
       }
       field.appendChild(val);
       detailBody.appendChild(field);
     }
-    panel.classList.add("open");
-  });
 
-  cy.on("tap", function(e){
-    if (e.target === cy) panel.classList.remove("open");
+    // Insights section
+    var insights = data.insights && data.insights[node.id];
+    if (insights && insights.length > 0) {
+      var insightField = document.createElement("div");
+      insightField.className = "field";
+      var insightLbl = document.createElement("div");
+      insightLbl.className = "label";
+      insightLbl.textContent = "Insights";
+      insightField.appendChild(insightLbl);
+      insights.forEach(function(ins){
+        var card = document.createElement("div");
+        card.className = "insight-card";
+        var badge = document.createElement("span");
+        badge.className = "insight-type";
+        badge.textContent = ins.type;
+        card.appendChild(badge);
+        var conf = document.createElement("span");
+        conf.className = "insight-confidence";
+        conf.textContent = Math.round(ins.confidence * 100) + "%";
+        card.appendChild(conf);
+        var content = document.createElement("div");
+        content.className = "insight-content";
+        content.textContent = ins.content;
+        card.appendChild(content);
+        insightField.appendChild(card);
+      });
+      detailBody.appendChild(insightField);
+    }
+
+    panel.classList.add("open");
+  }
+
+  // Init force-graph
+  var graph = ForceGraph()(document.getElementById("graph-container"))
+    .graphData({nodes: fgNodes, links: links})
+    .nodeLabel("name")
+    .nodeColor(function(node){
+      if (hoveredNode && !connectedNodes[node.id]) return "#2a2a45";
+      return node.color;
+    })
+    .nodeVal("size")
+    .linkColor(function(link){
+      if (hoveredNode) {
+        var sid = typeof link.source === "object" ? link.source.id : link.source;
+        var tid = typeof link.target === "object" ? link.target.id : link.target;
+        if (connectedNodes[sid] && connectedNodes[tid]) return link.color;
+        return "#1f1f35";
+      }
+      return link.color;
+    })
+    .linkLabel("label")
+    .linkDirectionalArrowLength(4)
+    .linkDirectionalArrowRelPos(1)
+    .linkWidth(function(link){
+      if (hoveredNode) {
+        var sid = typeof link.source === "object" ? link.source.id : link.source;
+        var tid = typeof link.target === "object" ? link.target.id : link.target;
+        if (connectedNodes[sid] && connectedNodes[tid]) return 2;
+        return 0.3;
+      }
+      return 1;
+    })
+    .backgroundColor("#1a1a2e")
+    .onNodeClick(function(node){ showDetail(node); })
+    .onNodeHover(function(node){ highlightNode(node); })
+    .onBackgroundClick(function(){ closeDetail(); });
+
+  // Search
+  var searchBox = document.getElementById("search-box");
+  searchBox.addEventListener("input", function(){
+    var q = searchBox.value.trim().toLowerCase();
+    if (!q) {
+      graph.nodeColor(function(node){
+        if (hoveredNode && !connectedNodes[node.id]) return "#2a2a45";
+        return node.color;
+      });
+      return;
+    }
+    var matches = fgNodes.filter(function(n){
+      return n.name.toLowerCase().indexOf(q) >= 0;
+    });
+    if (matches.length > 0) {
+      graph.centerAt(matches[0].x, matches[0].y, 300).zoom(3, 300);
+    }
   });
 })();
 </script>

--- a/cli/src/lib/graph-html.ts
+++ b/cli/src/lib/graph-html.ts
@@ -1,0 +1,325 @@
+/**
+ * Self-contained HTML graph visualization using Sigma.js v3 + Graphology.
+ * Generates a single HTML string that can be opened in any browser.
+ */
+
+export interface GraphNode {
+  id: string;
+  name: string;
+  type: string;
+  definition_slug: string;
+  primary_attribute?: string;
+  created_at?: string;
+}
+
+export interface GraphEdge {
+  id: string;
+  source: string;
+  target: string;
+  label: string;
+  definition_id: string;
+}
+
+export interface RelationshipDefinition {
+  id: string;
+  name: string;
+  entity_1_to_2: string;
+  entity_2_to_1: string;
+}
+
+export interface GraphData {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  relationship_definitions: RelationshipDefinition[];
+  total_nodes: number;
+  total_edges: number;
+}
+
+const NODE_COLORS: Record<string, string> = {
+  person: "#4F87E0",
+  company: "#34A853",
+  deal: "#F4A236",
+};
+const DEFAULT_COLOR = "#9B59B6";
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function escapeJsonForHtml(data: unknown): string {
+  return JSON.stringify(data)
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026");
+}
+
+export function generateGraphHtml(data: GraphData): string {
+  const nodeColors = { ...NODE_COLORS };
+  const typeSet = new Set<string>();
+  for (const n of data.nodes) {
+    typeSet.add(n.type);
+  }
+
+  // Build degree map
+  const degree: Record<string, number> = {};
+  for (const n of data.nodes) degree[n.id] = 0;
+  for (const e of data.edges) {
+    degree[e.source] = (degree[e.source] ?? 0) + 1;
+    degree[e.target] = (degree[e.target] ?? 0) + 1;
+  }
+  const maxDeg = Math.max(1, ...Object.values(degree));
+
+  // Build safe node data for embedding
+  const safeNodes = data.nodes.map((n) => ({
+    id: n.id,
+    name: escapeHtml(n.name),
+    rawName: n.name,
+    type: n.type,
+    primary_attribute: n.primary_attribute ? escapeHtml(n.primary_attribute) : undefined,
+    color: nodeColors[n.type] ?? DEFAULT_COLOR,
+    size: 5 + ((degree[n.id] ?? 0) / maxDeg) * 15,
+    created_at: n.created_at,
+  }));
+
+  const safeEdges = data.edges.map((e) => ({
+    id: e.id,
+    source: e.source,
+    target: e.target,
+    label: escapeHtml(e.label),
+    definition_id: e.definition_id,
+  }));
+
+  // Build legend from actual types
+  const legendTypes = Array.from(typeSet).sort();
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Nex — Workspace Graph</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+body{background:#1a1a2e;color:#e0e0e0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;overflow:hidden}
+#graph-container{width:100vw;height:100vh}
+#search-box{position:fixed;top:16px;left:16px;z-index:10;background:#25253e;border:1px solid #3a3a5c;border-radius:8px;padding:8px 12px;color:#e0e0e0;font-size:14px;width:240px;outline:none}
+#search-box::placeholder{color:#6a6a8a}
+#search-box:focus{border-color:#4F87E0}
+#stats{position:fixed;top:16px;right:16px;z-index:10;background:#25253e;border:1px solid #3a3a5c;border-radius:8px;padding:8px 14px;font-size:13px;color:#9a9ab0}
+#legend{position:fixed;bottom:16px;left:16px;z-index:10;background:#25253e;border:1px solid #3a3a5c;border-radius:8px;padding:10px 14px;font-size:13px}
+.legend-item{display:flex;align-items:center;gap:8px;margin:4px 0}
+.legend-dot{width:10px;height:10px;border-radius:50%;flex-shrink:0}
+#detail-panel{position:fixed;top:0;right:-320px;width:320px;height:100vh;background:#25253e;border-left:1px solid #3a3a5c;z-index:20;padding:20px;overflow-y:auto;transition:right .2s ease}
+#detail-panel.open{right:0}
+#detail-panel h3{margin-bottom:12px;font-size:16px;color:#fff}
+#detail-panel .field{margin-bottom:8px;font-size:13px}
+#detail-panel .field .label{color:#6a6a8a;font-size:11px;text-transform:uppercase;letter-spacing:.5px}
+#detail-panel .field .value{color:#e0e0e0;margin-top:2px}
+#detail-close{position:absolute;top:12px;right:12px;background:none;border:none;color:#6a6a8a;cursor:pointer;font-size:18px}
+#detail-close:hover{color:#e0e0e0}
+</style>
+</head>
+<body>
+<input id="search-box" type="text" placeholder="Search entities..." autocomplete="off">
+<div id="stats">${escapeHtml(String(data.total_nodes))} entities &middot; ${escapeHtml(String(data.total_edges))} relationships</div>
+<div id="legend">
+${legendTypes
+  .map(
+    (t) =>
+      `<div class="legend-item"><span class="legend-dot" style="background:${escapeHtml(nodeColors[t] ?? DEFAULT_COLOR)}"></span>${escapeHtml(t)}</div>`
+  )
+  .join("\n")}
+</div>
+<div id="detail-panel">
+<button id="detail-close">&times;</button>
+<h3 id="detail-name"></h3>
+<div id="detail-body"></div>
+</div>
+<div id="graph-container"></div>
+
+<script src="https://unpkg.com/graphology@0.25.4/dist/graphology.umd.min.js"></script>
+<script src="https://unpkg.com/graphology-layout-forceatlas2@0.10.1/dist/graphology-layout-forceatlas2.min.js"></script>
+<script src="https://unpkg.com/sigma@3.0.0-beta.9/build/sigma.min.js"></script>
+
+<script id="graph-data" type="application/json">${escapeJsonForHtml({ nodes: safeNodes, edges: safeEdges })}</script>
+
+<script>
+(function(){
+  var raw = JSON.parse(document.getElementById("graph-data").textContent);
+  var graph = new graphology.Graph({multi:true});
+
+  raw.nodes.forEach(function(n){
+    graph.addNode(n.id,{
+      label:n.name,
+      x:Math.random()*100,
+      y:Math.random()*100,
+      size:n.size,
+      color:n.color,
+      type:n.type,
+      rawName:n.rawName,
+      primary_attribute:n.primary_attribute,
+      created_at:n.created_at
+    });
+  });
+
+  raw.edges.forEach(function(e){
+    if(graph.hasNode(e.source)&&graph.hasNode(e.target)){
+      graph.addEdge(e.source,e.target,{label:e.label,size:1,color:"#3a3a5c"});
+    }
+  });
+
+  // ForceAtlas2 layout
+  var fa2=graphologyLayoutForceAtlas2;
+  var settings=fa2.inferSettings(graph);
+  settings.gravity=1;
+  settings.scalingRatio=10;
+  fa2.assign(graph,{settings:settings,iterations:150});
+
+  var container=document.getElementById("graph-container");
+  var renderer=new Sigma(graph,container,{
+    renderEdgeLabels:true,
+    labelColor:{color:"#c0c0d0"},
+    labelSize:12,
+    labelRenderedSizeThreshold:8,
+    edgeLabelColor:{color:"#6a6a8a"},
+    edgeLabelSize:10,
+    defaultEdgeType:"line",
+    stagePadding:40
+  });
+
+  // Hover: highlight neighbors
+  var hoveredNode=null;
+  var hoveredNeighbors=new Set();
+
+  renderer.on("enterNode",function(e){
+    hoveredNode=e.node;
+    hoveredNeighbors=new Set(graph.neighbors(e.node));
+    renderer.refresh();
+  });
+  renderer.on("leaveNode",function(){
+    hoveredNode=null;
+    hoveredNeighbors.clear();
+    renderer.refresh();
+  });
+
+  renderer.setSetting("nodeReducer",function(node,data){
+    var res=Object.assign({},data);
+    if(hoveredNode){
+      if(node===hoveredNode){
+        res.highlighted=true;
+      }else if(!hoveredNeighbors.has(node)){
+        res.color="#2a2a3e";
+        res.label=null;
+      }
+    }
+    if(searchQuery){
+      var name=(graph.getNodeAttribute(node,"rawName")||"").toLowerCase();
+      if(!name.includes(searchQuery)){
+        res.color="#2a2a3e";
+        res.label=null;
+      }
+    }
+    return res;
+  });
+
+  renderer.setSetting("edgeReducer",function(edge,data){
+    var res=Object.assign({},data);
+    if(hoveredNode){
+      var src=graph.source(edge);
+      var tgt=graph.target(edge);
+      if(src!==hoveredNode&&tgt!==hoveredNode){
+        res.hidden=true;
+      }else{
+        res.color="#6a6a8a";
+        res.size=2;
+      }
+    }
+    return res;
+  });
+
+  // Search
+  var searchQuery="";
+  var searchBox=document.getElementById("search-box");
+  searchBox.addEventListener("input",function(){
+    searchQuery=searchBox.value.trim().toLowerCase();
+    if(searchQuery){
+      graph.forEachNode(function(node,attrs){
+        if((attrs.rawName||"").toLowerCase().includes(searchQuery)){
+          var pos=renderer.getNodeDisplayData(node);
+          if(pos)renderer.getCamera().animate({x:pos.x,y:pos.y,ratio:0.3},{duration:300});
+          return true;
+        }
+      });
+    }
+    renderer.refresh();
+  });
+
+  // Detail panel — uses textContent and DOM methods to avoid innerHTML XSS
+  var panel=document.getElementById("detail-panel");
+  var detailName=document.getElementById("detail-name");
+  var detailBody=document.getElementById("detail-body");
+  document.getElementById("detail-close").addEventListener("click",function(){
+    panel.classList.remove("open");
+  });
+
+  function addField(parent, labelText, valueText) {
+    var field = document.createElement("div");
+    field.className = "field";
+    var lbl = document.createElement("div");
+    lbl.className = "label";
+    lbl.textContent = labelText;
+    var val = document.createElement("div");
+    val.className = "value";
+    val.textContent = valueText;
+    field.appendChild(lbl);
+    field.appendChild(val);
+    parent.appendChild(field);
+  }
+
+  renderer.on("clickNode",function(e){
+    var attrs=graph.getNodeAttributes(e.node);
+    var neighbors=graph.neighbors(e.node);
+    detailName.textContent=attrs.rawName||attrs.label||e.node;
+    detailBody.textContent="";
+    addField(detailBody, "Type", attrs.type||"");
+    if(attrs.primary_attribute) addField(detailBody, "Primary", attrs.primary_attribute);
+    if(attrs.created_at) addField(detailBody, "Created", attrs.created_at);
+    addField(detailBody, "Connections", String(neighbors.length));
+    if(neighbors.length>0){
+      var field=document.createElement("div");
+      field.className="field";
+      var lbl=document.createElement("div");
+      lbl.className="label";
+      lbl.textContent="Connected to";
+      field.appendChild(lbl);
+      var val=document.createElement("div");
+      val.className="value";
+      neighbors.slice(0,20).forEach(function(n){
+        var line=document.createElement("div");
+        line.textContent=graph.getNodeAttribute(n,"rawName")||n;
+        val.appendChild(line);
+      });
+      if(neighbors.length>20){
+        var more=document.createElement("em");
+        more.textContent="...and "+(neighbors.length-20)+" more";
+        val.appendChild(more);
+      }
+      field.appendChild(val);
+      detailBody.appendChild(field);
+    }
+    panel.classList.add("open");
+  });
+
+  renderer.on("clickStage",function(){
+    panel.classList.remove("open");
+  });
+})();
+</script>
+</body>
+</html>`;
+}

--- a/cli/src/lib/graph-html.ts
+++ b/cli/src/lib/graph-html.ts
@@ -1,5 +1,6 @@
 /**
- * Self-contained HTML graph visualization using force-graph (vasturiano).
+ * Self-contained HTML graph visualization using D3.js with SVG rendering.
+ * Exact clone of Zep's graph approach, adapted for Nex entity/insight structure.
  * Generates a single HTML string that can be opened in any browser.
  */
 
@@ -25,8 +26,16 @@ export interface ContextEdge {
   source: string;
   target: string;
   label: string;
-  edge_type: "context" | "triplet";
+  edge_type: "context" | "triplet" | "insight";
   confidence?: number;
+}
+
+export interface InsightNode {
+  id: string;
+  content: string;
+  type: string;
+  confidence: number;
+  source: "entity_insight" | "knowledge_insight";
 }
 
 export interface EntityInsightSummary {
@@ -46,6 +55,7 @@ export interface GraphData {
   nodes: GraphNode[];
   edges: GraphEdge[];
   context_edges: ContextEdge[];
+  insight_nodes: InsightNode[];
   relationship_definitions: RelationshipDefinition[];
   insights: Record<string, EntityInsightSummary[]>;
   total_nodes: number;
@@ -54,11 +64,23 @@ export interface GraphData {
 }
 
 const NODE_COLORS: Record<string, string> = {
-  person: "#4F87E0",
-  company: "#34A853",
-  deal: "#F4A236",
+  person: "#EC4899",     // pink-500
+  company: "#3B82F6",    // blue-500
+  deal: "#F59E0B",       // amber-500
+  lead: "#EF4444",       // red-500
+  contact: "#06B6D4",    // cyan-500
+  opportunity: "#F97316", // orange-500
+  task: "#10B981",       // emerald-500
+  note: "#84CC16",       // lime-500
+  event: "#8B5CF6",      // violet-500
+  topic: "#14B8A6",      // teal-500
+  product: "#A855F7",    // purple-500
+  project: "#6366F1",    // indigo-500
+  ghost: "#8B5CF6",      // violet-500
+  entity_insight: "#EC4899",  // pink-500
+  knowledge_insight: "#06B6D4", // cyan-500
 };
-const DEFAULT_COLOR = "#9B59B6";
+const DEFAULT_COLOR = "#EC4899";
 
 function escapeHtml(str: string): string {
   return str
@@ -80,6 +102,7 @@ export function generateGraphHtml(data: GraphData): string {
   const nodeColors = { ...NODE_COLORS };
   const typeSet = new Set<string>();
   for (const n of data.nodes) typeSet.add(n.type);
+  for (const n of (data.insight_nodes ?? [])) typeSet.add(n.source);
 
   const legendTypes = Array.from(typeSet).sort();
 
@@ -88,6 +111,7 @@ export function generateGraphHtml(data: GraphData): string {
   for (const key of Object.keys(data.insights ?? {})) {
     totalInsights += (data.insights[key] ?? []).length;
   }
+  totalInsights += (data.insight_nodes ?? []).length;
 
   const totalConnections = data.total_edges + data.total_context_edges;
 
@@ -99,28 +123,30 @@ export function generateGraphHtml(data: GraphData): string {
 <title>Nex — Workspace Graph</title>
 <style>
 *{margin:0;padding:0;box-sizing:border-box}
-body{background:#1a1a2e;color:#e0e0e0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;overflow:hidden}
-#graph-container{width:100vw;height:100vh}
-#search-box{position:fixed;top:16px;left:16px;z-index:10;background:#25253e;border:1px solid #3a3a5c;border-radius:8px;padding:8px 12px;color:#e0e0e0;font-size:14px;width:240px;outline:none}
-#search-box::placeholder{color:#6a6a8a}
-#search-box:focus{border-color:#4F87E0}
-#stats{position:fixed;top:16px;right:16px;z-index:10;background:#25253e;border:1px solid #3a3a5c;border-radius:8px;padding:8px 14px;font-size:13px;color:#9a9ab0}
-#legend{position:fixed;bottom:16px;left:16px;z-index:10;background:#25253e;border:1px solid #3a3a5c;border-radius:8px;padding:10px 14px;font-size:13px}
-.legend-item{display:flex;align-items:center;gap:8px;margin:4px 0}
+body{background:#0f172a;color:#e2e8f0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;overflow:hidden}
+svg{width:100%;height:100vh;cursor:grab;border-radius:0;position:fixed;top:0;left:0;z-index:1}
+svg:active{cursor:grabbing}
+#search-box{position:fixed;top:16px;left:16px;z-index:10;background:rgba(30,41,59,0.9);border:1px solid #334155;border-radius:10px;padding:8px 14px;color:#e2e8f0;font-size:14px;width:240px;outline:none;backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px)}
+#search-box::placeholder{color:#64748b}
+#search-box:focus{border-color:#EC4899;box-shadow:0 0 0 2px rgba(236,72,153,.2)}
+#stats{position:fixed;top:16px;right:16px;z-index:10;background:rgba(30,41,59,0.9);border:1px solid #334155;border-radius:10px;padding:8px 14px;font-size:13px;color:#94a3b8;backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px)}
+#legend{position:fixed;bottom:16px;left:16px;z-index:10;background:rgba(30,41,59,0.9);border:1px solid #334155;border-radius:10px;padding:10px 14px;font-size:13px;max-height:50vh;overflow-y:auto;backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px)}
+.legend-item{display:flex;align-items:center;gap:8px;margin:4px 0;color:#94a3b8}
 .legend-dot{width:10px;height:10px;border-radius:50%;flex-shrink:0}
 .legend-line{width:20px;height:2px;flex-shrink:0;border-radius:1px}
-#detail-panel{position:fixed;top:0;right:-320px;width:320px;height:100vh;background:#25253e;border-left:1px solid #3a3a5c;z-index:20;padding:20px;overflow-y:auto;transition:right .2s ease}
+.legend-sep{border-top:1px solid #334155;margin:6px 0}
+#detail-panel{position:fixed;top:0;right:-380px;width:380px;height:100vh;background:rgba(30,41,59,0.95);border-left:1px solid #334155;z-index:20;padding:20px;overflow-y:auto;transition:right .25s cubic-bezier(.4,0,.2,1);backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px)}
 #detail-panel.open{right:0}
-#detail-panel h3{margin-bottom:12px;font-size:16px;color:#fff}
-#detail-panel .field{margin-bottom:8px;font-size:13px}
-#detail-panel .field .label{color:#6a6a8a;font-size:11px;text-transform:uppercase;letter-spacing:.5px}
-#detail-panel .field .value{color:#e0e0e0;margin-top:2px}
-.insight-card{background:#2a2a45;border-radius:6px;padding:8px 10px;margin-top:6px}
-.insight-card .insight-type{display:inline-block;background:#3a3a5c;border-radius:3px;padding:1px 6px;font-size:10px;text-transform:uppercase;letter-spacing:.5px;color:#9a9ab0;margin-right:6px}
-.insight-card .insight-confidence{font-size:11px;color:#6a6a8a;float:right}
-.insight-card .insight-content{margin-top:4px;font-size:12px;color:#c0c0d0;line-height:1.4}
-#detail-close{position:absolute;top:12px;right:12px;background:none;border:none;color:#6a6a8a;cursor:pointer;font-size:18px}
-#detail-close:hover{color:#e0e0e0}
+#detail-panel h3{margin-bottom:12px;font-size:16px;color:#f1f5f9;font-weight:600}
+#detail-panel .field{margin-bottom:10px;font-size:13px}
+#detail-panel .field .label{color:#64748b;font-size:11px;text-transform:uppercase;letter-spacing:.5px;font-weight:500}
+#detail-panel .field .value{color:#cbd5e1;margin-top:2px;word-wrap:break-word;overflow-wrap:break-word;white-space:pre-wrap}
+.insight-card{background:#1e293b;border:1px solid #334155;border-radius:8px;padding:10px 12px;margin-top:6px}
+.insight-card .insight-type{display:inline-block;background:#334155;border-radius:4px;padding:2px 8px;font-size:10px;text-transform:uppercase;letter-spacing:.5px;color:#94a3b8;margin-right:6px;font-weight:500}
+.insight-card .insight-confidence{font-size:11px;color:#64748b;float:right}
+.insight-card .insight-content{margin-top:6px;font-size:12px;color:#94a3b8;line-height:1.5;word-wrap:break-word;overflow-wrap:break-word;white-space:pre-wrap}
+#detail-close{position:absolute;top:12px;right:12px;background:none;border:none;color:#64748b;cursor:pointer;font-size:18px;transition:color .15s}
+#detail-close:hover{color:#e2e8f0}
 </style>
 </head>
 <body>
@@ -133,150 +159,650 @@ ${legendTypes
       `<div class="legend-item"><span class="legend-dot" style="background:${escapeHtml(nodeColors[t] ?? DEFAULT_COLOR)}"></span>${escapeHtml(t)}</div>`
   )
   .join("\n")}
-<div class="legend-item"><span class="legend-line" style="background:#555"></span>Formal</div>
-<div class="legend-item"><span class="legend-line" style="background:#7c5cbf"></span>Context</div>
-<div class="legend-item"><span class="legend-line" style="background:#c4813a"></span>Triplet</div>
+<div class="legend-sep"></div>
+<div class="legend-item"><span class="legend-line" style="background:#475569"></span>Formal</div>
+<div class="legend-item"><span class="legend-line" style="background:#8B5CF6"></span>Context</div>
+<div class="legend-item"><span class="legend-line" style="background:#F59E0B"></span>Triplet</div>
+<div class="legend-item"><span class="legend-line" style="background:#EC4899"></span>Insight</div>
 </div>
 <div id="detail-panel">
 <button id="detail-close">&times;</button>
 <h3 id="detail-name"></h3>
 <div id="detail-body"></div>
 </div>
-<div id="graph-container"></div>
 
-<script src="https://cdn.jsdelivr.net/npm/force-graph"></script>
+<!-- D3.js v7 — same as Zep's force-graph approach -->
+<script src="https://cdn.jsdelivr.net/npm/d3@7"></script>
 
 <script id="graph-data" type="application/json">${escapeJsonForHtml(data)}</script>
 
 <script>
 (function(){
   var data = JSON.parse(document.getElementById("graph-data").textContent);
+  var width = window.innerWidth;
+  var height = window.innerHeight;
 
-  var nodeColors = {person:"#4F87E0",company:"#34A853",deal:"#F4A236"};
-  var defaultColor = "#9B59B6";
+  var nodeColors = {
+    person:"#EC4899", company:"#3B82F6", deal:"#F59E0B",
+    lead:"#EF4444", contact:"#06B6D4", opportunity:"#F97316",
+    task:"#10B981", note:"#84CC16", event:"#8B5CF6",
+    topic:"#14B8A6", product:"#A855F7", project:"#6366F1",
+    ghost:"#8B5CF6", entity_insight:"#EC4899", knowledge_insight:"#06B6D4"
+  };
+  var defaultColor = "#EC4899";
+  var edgeTypeColors = {formal:"#475569", context:"#8B5CF6", triplet:"#F59E0B", insight:"#EC4899"};
 
-  // Build node ID set for filtering dangling edges
-  var nodeIdSet = {};
-  data.nodes.forEach(function(n){ nodeIdSet[n.id] = true; });
+  // ── Build entity ID set (entities + ghosts, NO insights yet) ──
+  var entityIdSet = {};
+  data.nodes.forEach(function(n){ entityIdSet[n.id] = true; });
 
-  // Merge edges + context_edges into links
-  var links = [];
-  (data.edges || []).forEach(function(e){
-    if (nodeIdSet[e.source] && nodeIdSet[e.target]) {
-      links.push({source:e.source, target:e.target, label:e.label, color:"#555", edgeType:"formal"});
-    }
-  });
+  // ── Index insight nodes by target entity for on-demand expansion ──
+  var insightsByEntity = {};
   (data.context_edges || []).forEach(function(e){
-    if (nodeIdSet[e.source] && nodeIdSet[e.target]) {
-      var c = e.edge_type === "triplet" ? "#c4813a" : "#7c5cbf";
-      links.push({source:e.source, target:e.target, label:e.label, color:c, edgeType:e.edge_type});
+    if (e.edge_type === "insight") {
+      var targetId = entityIdSet[e.target] ? e.target : (entityIdSet[e.source] ? e.source : null);
+      var insightId = e.target === targetId ? e.source : e.target;
+      if (targetId) {
+        if (!insightsByEntity[targetId]) insightsByEntity[targetId] = [];
+        var insData = null;
+        (data.insight_nodes || []).forEach(function(ins){ if (ins.id === insightId) insData = ins; });
+        if (insData) insightsByEntity[targetId].push({node: insData, edge: e});
+      }
     }
   });
 
-  // Build degree map across all link types
+  // ── Count insights per entity ──
+  var insightCount = {};
+  // Use insightsByEntity as authoritative count (same data as insightsMap, avoid double-counting)
+  for (var eid in insightsByEntity) insightCount[eid] = insightsByEntity[eid].length;
+  var insightsMap = data.insights || {};
+  // Only count from insightsMap for entities NOT already counted via insightsByEntity
+  for (var eid2 in insightsMap) {
+    if (!insightCount[eid2]) insightCount[eid2] = (insightsMap[eid2] || []).length;
+  }
+
+  // ── Build links from formal edges + non-insight context edges ──
+  // Group links by source-target pair for curve offset (like Zep)
+  var linkGroupMap = {};
+  function addLink(source, target, label, edgeType) {
+    if (!entityIdSet[source] || !entityIdSet[target]) return;
+    var key = source < target ? source + "-" + target : target + "-" + source;
+    if (!linkGroupMap[key]) linkGroupMap[key] = [];
+    linkGroupMap[key].push({source: source, target: target, label: label, edgeType: edgeType, color: edgeTypeColors[edgeType] || "#475569"});
+  }
+  (data.edges || []).forEach(function(e){ addLink(e.source, e.target, e.label, "formal"); });
+  (data.context_edges || []).forEach(function(e){
+    if (e.edge_type === "insight") return;
+    addLink(e.source, e.target, e.label, e.edge_type);
+  });
+
+  // Assign curve strengths per group (Zep's pattern)
+  var baseLinks = [];
+  for (var gk in linkGroupMap) {
+    var group = linkGroupMap[gk];
+    var count = group.length;
+    var baseStrength = 0.2;
+    group.forEach(function(lnk, idx){
+      lnk.curveStrength = count > 1 ? (-baseStrength + idx * (baseStrength * 2) / (count - 1)) : 0;
+      baseLinks.push(lnk);
+    });
+  }
+
+  // ── Build degree map ──
   var degree = {};
   data.nodes.forEach(function(n){ degree[n.id] = 0; });
-  links.forEach(function(l){
+  baseLinks.forEach(function(l){
     degree[l.source] = (degree[l.source] || 0) + 1;
     degree[l.target] = (degree[l.target] || 0) + 1;
   });
-  var maxDeg = 1;
-  for (var k in degree) { if (degree[k] > maxDeg) maxDeg = degree[k]; }
 
-  // Build force-graph nodes
-  var fgNodes = data.nodes.map(function(n){
+  // ── Identify isolated & ghost nodes ──
+  var linkedNodeIds = {};
+  baseLinks.forEach(function(l){ linkedNodeIds[l.source] = true; linkedNodeIds[l.target] = true; });
+  var isolatedNodeIds = {};
+  data.nodes.forEach(function(n){ if (!linkedNodeIds[n.id]) isolatedNodeIds[n.id] = true; });
+
+  // ── Build D3 node objects ──
+  var entityNodes = data.nodes.map(function(n){
     return {
-      id: n.id,
-      name: n.name,
-      type: n.type,
-      primary_attribute: n.primary_attribute || "",
-      created_at: n.created_at || "",
+      id: n.id, name: n.name, type: n.type, nodeKind: "entity",
+      primary_attribute: n.primary_attribute || "", created_at: n.created_at || "",
       color: nodeColors[n.type] || defaultColor,
-      size: 2 + ((degree[n.id] || 0) / maxDeg) * 8
+      insightCount: insightCount[n.id] || 0
     };
   });
 
-  // Hover highlight state
-  var hoveredNode = null;
-  var connectedNodes = {};
+  // ── Track expanded insights ──
+  var expandedEntities = {};
 
-  function highlightNode(node) {
-    if (node) {
-      hoveredNode = node;
-      connectedNodes = {};
-      connectedNodes[node.id] = true;
-      links.forEach(function(l){
-        var sid = typeof l.source === "object" ? l.source.id : l.source;
-        var tid = typeof l.target === "object" ? l.target.id : l.target;
-        if (sid === node.id) connectedNodes[tid] = true;
-        if (tid === node.id) connectedNodes[sid] = true;
+  // ── Current working nodes/links arrays ──
+  var currentNodes = entityNodes.slice();
+  var currentLinks = baseLinks.map(function(l){ return {source: l.source, target: l.target, label: l.label, edgeType: l.edgeType, color: l.color, curveStrength: l.curveStrength}; });
+
+  function rebuildGraphArrays() {
+    currentNodes = entityNodes.slice();
+    currentLinks = baseLinks.map(function(l){ return {source: l.source, target: l.target, label: l.label, edgeType: l.edgeType, color: l.color, curveStrength: l.curveStrength}; });
+    for (var entId in expandedEntities) {
+      var items = insightsByEntity[entId] || [];
+      var entNode = null;
+      entityNodes.forEach(function(n){ if (n.id === entId) entNode = n; });
+      items.forEach(function(item, i){
+        var ins = item.node;
+        var fullContent = ins.content || "";
+        var label = fullContent.length > 50 ? fullContent.substring(0, 48) + ".." : fullContent;
+        var angle = (2 * Math.PI * i) / items.length;
+        var dist = 60;
+        currentNodes.push({
+          id: ins.id, name: label, fullContent: fullContent,
+          type: ins.source, nodeKind: "insight",
+          primary_attribute: ins.type, created_at: "",
+          color: nodeColors[ins.source] || "#EC4899",
+          insightCount: 0, confidence: ins.confidence,
+          x: entNode ? entNode.x + Math.cos(angle) * dist : width/2,
+          y: entNode ? entNode.y + Math.sin(angle) * dist : height/2
+        });
+        currentLinks.push({
+          source: ins.id, target: entId, label: ins.type,
+          edgeType: "insight", color: "#EC4899", curveStrength: 0
+        });
       });
-    } else {
-      hoveredNode = null;
-      connectedNodes = {};
     }
-    graph.nodeColor(graph.nodeColor());
   }
 
-  // Detail panel
+  // ── Focus/search/hover state ──
+  var focusedNodeId = null;
+  var focusedSet = {};
+  var searchActive = false;
+  var searchMatches = {};
+
+  // ══════════════════════════════════════════════════════════
+  //  SVG SETUP — exact Zep pattern: <svg> → <g> for zoom
+  // ══════════════════════════════════════════════════════════
+  var svg = d3.select("body").append("svg")
+    .attr("width", width)
+    .attr("height", height)
+    .attr("viewBox", "0 0 " + width + " " + height)
+    .style("background-color", "#0f172a");
+
+  // Drop-shadow filter (Zep: drop-shadow(0 2px 4px rgba(0,0,0,0.2)))
+  var defs = svg.append("defs");
+  var filter = defs.append("filter").attr("id", "drop-shadow").attr("x", "-50%").attr("y", "-50%").attr("width", "200%").attr("height", "200%");
+  filter.append("feDropShadow").attr("dx", 0).attr("dy", 2).attr("stdDeviation", 2).attr("flood-color", "rgba(0,0,0,0.3)");
+
+  var g = svg.append("g");
+
+  // ── Zoom behavior — Zep: scaleExtent [0.1, 4] ──
+  var currentZoomScale = 0.8;
+  var LABEL_ZOOM_THRESHOLD = 0.6;   // node labels appear above this
+  var LINK_LABEL_ZOOM_THRESHOLD = 0.9; // link labels appear above this
+
+  var zoomBehavior = d3.zoom()
+    .scaleExtent([0.1, 4])
+    .on("zoom", function(event){
+      g.attr("transform", event.transform);
+      var newScale = event.transform.k;
+      // Toggle label visibility on scale change
+      if ((newScale >= LABEL_ZOOM_THRESHOLD) !== (currentZoomScale >= LABEL_ZOOM_THRESHOLD)) {
+        nodeLayer.selectAll("g.node-group > text:not(.insight-badge)")
+          .attr("display", newScale >= LABEL_ZOOM_THRESHOLD ? null : "none");
+      }
+      if ((newScale >= LINK_LABEL_ZOOM_THRESHOLD) !== (currentZoomScale >= LINK_LABEL_ZOOM_THRESHOLD)) {
+        linkLayer.selectAll(".link-label")
+          .attr("display", newScale >= LINK_LABEL_ZOOM_THRESHOLD ? null : "none");
+      }
+      currentZoomScale = newScale;
+    });
+  svg.call(zoomBehavior).call(zoomBehavior.transform, d3.zoomIdentity.scale(0.8).translate(width * 0.1, height * 0.1));
+
+  // Click on SVG background → unfocus
+  svg.on("click", function(event){
+    if (event.target.tagName === "svg" || event.target === svg.node()) {
+      unfocus();
+    }
+  });
+
+  // ── Layer groups (links below nodes) ──
+  var linkLayer = g.append("g").attr("class", "links");
+  var nodeLayer = g.append("g").attr("class", "nodes");
+
+  // ══════════════════════════════════════════════════════════
+  //  D3 FORCE SIMULATION — exact Zep parameters
+  // ══════════════════════════════════════════════════════════
+  var simulation = d3.forceSimulation(currentNodes)
+    .force("link", d3.forceLink(currentLinks).id(function(d){ return d.id; }).distance(200).strength(0.2))
+    .force("charge", d3.forceManyBody()
+      .strength(function(d){ return isolatedNodeIds[d.id] ? -500 : -3000; })
+      .distanceMin(20).distanceMax(500).theta(0.8))
+    .force("center", d3.forceCenter(width / 2, height / 2).strength(0.05))
+    .force("collide", d3.forceCollide().radius(50).strength(0.3).iterations(5))
+    .force("isolatedGravity", d3.forceRadial(100, width / 2, height / 2)
+      .strength(function(d){ return isolatedNodeIds[d.id] ? 0.15 : (d.type === "ghost" ? 0.03 : 0.01); }))
+    .velocityDecay(0.4)
+    .alphaDecay(0.05)
+    .alphaMin(0.001);
+
+  // ══════════════════════════════════════════════════════════
+  //  RENDER FUNCTIONS
+  // ══════════════════════════════════════════════════════════
+  var linkSelection, nodeSelection;
+
+  function render() {
+    // ── LINKS ──
+    linkLayer.selectAll("g.link-group").remove();
+    linkSelection = linkLayer.selectAll("g.link-group")
+      .data(currentLinks, function(d){ return d.source.id + "-" + d.target.id + "-" + d.label; })
+      .join("g")
+      .attr("class", "link-group");
+
+    // Path for each link
+    linkSelection.append("path")
+      .attr("stroke", function(d){ return d.color; })
+      .attr("stroke-opacity", 0.6)
+      .attr("stroke-width", 1)
+      .attr("fill", "none")
+      .attr("cursor", "pointer");
+
+    // Label group (rect + text) — Zep pattern
+    var labelG = linkSelection.append("g")
+      .attr("class", "link-label")
+      .attr("cursor", "pointer")
+      .attr("display", currentZoomScale >= LINK_LABEL_ZOOM_THRESHOLD ? null : "none");
+
+    labelG.append("rect")
+      .attr("fill", "#1e293b")
+      .attr("rx", 4).attr("ry", 4)
+      .attr("opacity", 0.9);
+
+    labelG.append("text")
+      .attr("fill", "#94a3b8")
+      .attr("font-size", "8px")
+      .attr("text-anchor", "middle")
+      .attr("dominant-baseline", "middle")
+      .attr("pointer-events", "none")
+      .text(function(d){ return d.label || ""; });
+
+    // ── NODES ──
+    nodeLayer.selectAll("g.node-group").remove();
+    nodeSelection = nodeLayer.selectAll("g.node-group")
+      .data(currentNodes, function(d){ return d.id; })
+      .join("g")
+      .attr("class", "node-group")
+      .attr("cursor", "pointer")
+      .call(dragBehavior);
+
+    // Circle — Zep: r=10, drop-shadow, stroke-width 1
+    nodeSelection.append("circle")
+      .attr("r", function(d){
+        if (d.nodeKind === "insight") return 6;
+        if (d.type === "ghost") return 7;
+        return 10;
+      })
+      .attr("fill", function(d){ return d.color; })
+      .attr("stroke", "#e2e8f0")
+      .attr("stroke-width", function(d){ return d.type === "ghost" ? 1 : 1; })
+      .attr("filter", "url(#drop-shadow)")
+      .attr("stroke-dasharray", function(d){ return d.type === "ghost" ? "2,2" : null; });
+
+    // Insight count badge (white text inside node)
+    nodeSelection.filter(function(d){ return d.nodeKind !== "insight" && d.insightCount > 0; })
+      .append("text")
+      .attr("class", "insight-badge")
+      .attr("text-anchor", "middle")
+      .attr("dominant-baseline", "central")
+      .attr("font-size", "8px")
+      .attr("font-weight", "700")
+      .attr("fill", "#fff")
+      .attr("pointer-events", "none")
+      .text(function(d){ return d.insightCount; });
+
+    // Label — Zep: x=15, font-size 12px, font-weight 500
+    // Hidden until zoom >= LABEL_ZOOM_THRESHOLD
+    nodeSelection.append("text")
+      .attr("x", 15)
+      .attr("y", "0.3em")
+      .attr("text-anchor", "start")
+      .attr("fill", "#e2e8f0")
+      .attr("font-weight", "500")
+      .attr("font-size", "12px")
+      .attr("pointer-events", "none")
+      .attr("display", currentZoomScale >= LABEL_ZOOM_THRESHOLD ? null : "none")
+      .text(function(d){
+        var name = d.name || d.id;
+        return name.length > 28 ? name.substring(0, 26) + ".." : name;
+      });
+
+    // Click handler
+    nodeSelection.on("click", function(event, d){
+      event.stopPropagation();
+      handleNodeClick(d);
+    });
+
+    // Hover handlers
+    nodeSelection.on("mouseenter", function(event, d){
+      d3.select(this).select("circle")
+        .attr("stroke", "#60a5fa")
+        .attr("stroke-width", 3);
+    }).on("mouseleave", function(event, d){
+      d3.select(this).select("circle")
+        .attr("stroke", "#e2e8f0")
+        .attr("stroke-width", 1);
+      applyVisualState();
+    });
+  }
+
+  // ── Drag behavior — exact Zep pattern ──
+  var dragBehavior = d3.drag()
+    .on("start", function(event){
+      if (!event.active) simulation.velocityDecay(0.7).alphaDecay(0.1).alphaTarget(0.1).restart();
+      event.subject.fx = event.subject.x;
+      event.subject.fy = event.subject.y;
+      d3.select(this).select("circle").attr("stroke", "#60a5fa").attr("stroke-width", 3);
+    })
+    .on("drag", function(event){
+      event.subject.fx = event.x;
+      event.subject.fy = event.y;
+    })
+    .on("end", function(event){
+      if (!event.active) simulation.velocityDecay(0.4).alphaDecay(0.05).alphaTarget(0);
+      event.subject.fx = event.x;
+      event.subject.fy = event.y;
+      d3.select(this).select("circle").attr("stroke", "#e2e8f0").attr("stroke-width", 1);
+    });
+
+  // ══════════════════════════════════════════════════════════
+  //  TICK — update positions (Zep: quadratic Bézier paths)
+  // ══════════════════════════════════════════════════════════
+  simulation.on("tick", function(){
+    if (!linkSelection || !nodeSelection) return;
+
+    linkSelection.each(function(d){
+      var el = d3.select(this);
+      var path = el.select("path");
+      var labelGroup = el.select(".link-label");
+
+      var sx = d.source.x, sy = d.source.y, tx = d.target.x, ty = d.target.y;
+      if (sx == null || tx == null) return;
+
+      // Self-referencing loop
+      if (d.source.id === d.target.id) {
+        var rx = 40, ry = 90, offset = ry + 20;
+        var cx = sx, cy = sy - offset;
+        path.attr("d", "M" + sx + "," + sy + " C" + (cx-rx) + "," + cy + " " + (cx+rx) + "," + cy + " " + sx + "," + sy);
+        labelGroup.attr("transform", "translate(" + cx + "," + (cy-10) + ")");
+      } else {
+        // Quadratic Bézier — Zep's curve calculation
+        var dx = tx - sx, dy = ty - sy;
+        var dr = Math.sqrt(dx*dx + dy*dy) || 1;
+        var midX = (sx + tx) / 2, midY = (sy + ty) / 2;
+        var normalX = -dy / dr, normalY = dx / dr;
+        var curveMag = dr * (d.curveStrength || 0);
+        var controlX = midX + normalX * curveMag;
+        var controlY = midY + normalY * curveMag;
+        path.attr("d", "M" + sx + "," + sy + " Q" + controlX + "," + controlY + " " + tx + "," + ty);
+
+        // Position label at midpoint of Bézier — Zep's getPointAtLength pattern
+        var pathNode = path.node();
+        if (pathNode && pathNode.getTotalLength) {
+          var pathLen = pathNode.getTotalLength();
+          var midPt = pathNode.getPointAtLength(pathLen / 2);
+          if (midPt) {
+            var angle = Math.atan2(ty - sy, tx - sx) * 180 / Math.PI;
+            var rot = (angle > 90 || angle < -90) ? angle - 180 : angle;
+            labelGroup.attr("transform", "translate(" + midPt.x + "," + midPt.y + ") rotate(" + rot + ")");
+          }
+        }
+      }
+
+      // Size the label background rect
+      var text = labelGroup.select("text");
+      var rect = labelGroup.select("rect");
+      var textNode = text.node();
+      if (textNode) {
+        var bbox = textNode.getBBox();
+        if (bbox.width > 0) {
+          rect.attr("x", -bbox.width/2 - 6).attr("y", -bbox.height/2 - 4)
+            .attr("width", bbox.width + 12).attr("height", bbox.height + 8);
+        }
+      }
+    });
+
+    // Update node positions — Zep: translate(x,y)
+    nodeSelection.attr("transform", function(d){ return "translate(" + d.x + "," + d.y + ")"; });
+  });
+
+  // ── Initial render ──
+  render();
+
+  // ── Zoom-to-fit after simulation settles ──
+  var hasZoomed = false;
+  simulation.on("end", function(){
+    if (hasZoomed) return;
+    hasZoomed = true;
+    zoomToFit();
+  });
+  // Fallback zoom-to-fit
+  setTimeout(function(){ if (!hasZoomed) { hasZoomed = true; zoomToFit(); } }, 2000);
+
+  function zoomToFit(duration) {
+    duration = duration || 750;
+    var bounds = g.node().getBBox();
+    if (!bounds || bounds.width === 0) return;
+    var fullW = width, fullH = height;
+    var midX = bounds.x + bounds.width / 2;
+    var midY = bounds.y + bounds.height / 2;
+    var scale = 0.65 * Math.min(fullW / bounds.width, fullH / bounds.height);
+    if (!isFinite(scale) || !isFinite(midX)) return;
+    var transform = d3.zoomIdentity
+      .translate(fullW/2 - midX*scale, fullH/2 - midY*scale)
+      .scale(scale);
+    svg.transition().duration(duration).ease(d3.easeCubicInOut).call(zoomBehavior.transform, transform);
+  }
+
+  // ══════════════════════════════════════════════════════════
+  //  VISUAL STATE — focus/search dimming
+  // ══════════════════════════════════════════════════════════
+  function applyVisualState() {
+    if (!nodeSelection || !linkSelection) return;
+
+    nodeSelection.select("circle")
+      .attr("fill", function(d){
+        if (focusedNodeId && !focusedSet[d.id]) return "#1e293b";
+        if (searchActive && !searchMatches[d.id]) return "#1e293b";
+        return d.color;
+      })
+      .attr("stroke", function(d){
+        if (focusedNodeId && focusedSet[d.id]) return "#60a5fa";
+        return "#e2e8f0";
+      })
+      .attr("stroke-width", function(d){
+        if (focusedNodeId && d.id === focusedNodeId) return 3;
+        if (focusedNodeId && focusedSet[d.id]) return 2;
+        return 1;
+      })
+      .attr("opacity", function(d){
+        if (focusedNodeId && !focusedSet[d.id]) return 0.15;
+        if (searchActive && !searchMatches[d.id]) return 0.15;
+        return 1;
+      });
+
+    nodeSelection.selectAll("text")
+      .attr("opacity", function(d){
+        if (focusedNodeId && !focusedSet[d.id]) return 0.1;
+        if (searchActive && !searchMatches[d.id]) return 0.1;
+        return 1;
+      });
+
+    linkSelection.select("path")
+      .attr("stroke", function(d){
+        var sid = typeof d.source === "object" ? d.source.id : d.source;
+        var tid = typeof d.target === "object" ? d.target.id : d.target;
+        if (focusedNodeId) {
+          if (focusedSet[sid] && focusedSet[tid]) return d.color;
+          return "#0f172a";
+        }
+        return d.color;
+      })
+      .attr("stroke-opacity", function(d){
+        var sid = typeof d.source === "object" ? d.source.id : d.source;
+        var tid = typeof d.target === "object" ? d.target.id : d.target;
+        if (focusedNodeId && !(focusedSet[sid] && focusedSet[tid])) return 0.05;
+        if (searchActive && !(searchMatches[sid] && searchMatches[tid])) return 0.05;
+        return 0.6;
+      })
+      .attr("stroke-width", function(d){
+        var sid = typeof d.source === "object" ? d.source.id : d.source;
+        var tid = typeof d.target === "object" ? d.target.id : d.target;
+        if (focusedNodeId && focusedSet[sid] && focusedSet[tid]) return 2;
+        return 1;
+      });
+
+    linkSelection.select(".link-label")
+      .attr("opacity", function(d){
+        var sid = typeof d.source === "object" ? d.source.id : d.source;
+        var tid = typeof d.target === "object" ? d.target.id : d.target;
+        if (focusedNodeId && !(focusedSet[sid] && focusedSet[tid])) return 0;
+        if (searchActive && !(searchMatches[sid] && searchMatches[tid])) return 0;
+        return 1;
+      });
+  }
+
+  // ══════════════════════════════════════════════════════════
+  //  NODE CLICK — focus, expand insights, zoom to neighborhood
+  // ══════════════════════════════════════════════════════════
   var panel = document.getElementById("detail-panel");
   var detailName = document.getElementById("detail-name");
   var detailBody = document.getElementById("detail-body");
+  document.getElementById("detail-close").addEventListener("click", function(){ unfocus(); });
 
-  document.getElementById("detail-close").addEventListener("click", function(){
+  function unfocus() {
     panel.classList.remove("open");
-  });
-
-  function closeDetail() {
-    panel.classList.remove("open");
+    expandedEntities = {};
+    focusedNodeId = null;
+    focusedSet = {};
+    searchActive = false;
+    searchMatches = {};
+    rebuildAndRestart();
+    applyVisualState();
   }
 
+  function handleNodeClick(d) {
+    // Toggle focus
+    if (focusedNodeId === d.id) {
+      unfocus();
+      return;
+    }
+
+    focusedNodeId = d.id;
+    focusedSet = {};
+    focusedSet[d.id] = true;
+
+    // Add 1st-degree neighbors
+    currentLinks.forEach(function(l){
+      var sid = typeof l.source === "object" ? l.source.id : l.source;
+      var tid = typeof l.target === "object" ? l.target.id : l.target;
+      if (sid === d.id) focusedSet[tid] = true;
+      if (tid === d.id) focusedSet[sid] = true;
+    });
+
+    if (d.nodeKind === "insight") {
+      showInsightDetail(d);
+    } else {
+      // Toggle insight expansion
+      expandedEntities = {};
+      if (insightsByEntity[d.id] && insightsByEntity[d.id].length > 0) {
+        expandedEntities[d.id] = true;
+      }
+      showEntityDetail(d);
+      rebuildAndRestart();
+      // After rebuild, include new insight nodes in focusedSet
+      currentNodes.forEach(function(n){
+        if (n.nodeKind === "insight") focusedSet[n.id] = true;
+      });
+    }
+
+    applyVisualState();
+    zoomToNeighborhood(d);
+  }
+
+  function rebuildAndRestart() {
+    rebuildGraphArrays();
+    simulation.nodes(currentNodes);
+    simulation.force("link", d3.forceLink(currentLinks).id(function(d){ return d.id; }).distance(200).strength(0.2));
+    simulation.alpha(0.3).restart();
+    render();
+  }
+
+  // ── Zoom to neighborhood — exact Zep pattern ──
+  function zoomToNeighborhood(d) {
+    var connectedNodes = [d];
+    currentNodes.forEach(function(n){
+      if (n.id !== d.id && focusedSet[n.id] && n.x != null) connectedNodes.push(n);
+    });
+    if (connectedNodes.length < 1) return;
+
+    var padding = 80;
+    var minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+    connectedNodes.forEach(function(n){
+      if (n.x < minX) minX = n.x;
+      if (n.y < minY) minY = n.y;
+      if (n.x > maxX) maxX = n.x;
+      if (n.y > maxY) maxY = n.y;
+    });
+    minX -= padding; minY -= padding; maxX += padding; maxY += padding;
+    var bw = maxX - minX, bh = maxY - minY;
+    var scale = 0.9 * Math.min(width / bw, height / bh);
+    var midX = (minX + maxX) / 2, midY = (minY + maxY) / 2;
+    if (!isFinite(scale) || !isFinite(midX)) return;
+    var transform = d3.zoomIdentity
+      .translate(width/2 - midX*scale, height/2 - midY*scale)
+      .scale(scale);
+    svg.transition().duration(750).ease(d3.easeCubicInOut).call(zoomBehavior.transform, transform);
+  }
+
+  // ══════════════════════════════════════════════════════════
+  //  DETAIL PANEL
+  // ══════════════════════════════════════════════════════════
   function addField(parent, labelText, valueText) {
-    var field = document.createElement("div");
-    field.className = "field";
-    var lbl = document.createElement("div");
-    lbl.className = "label";
-    lbl.textContent = labelText;
-    var val = document.createElement("div");
-    val.className = "value";
-    val.textContent = valueText;
-    field.appendChild(lbl);
-    field.appendChild(val);
-    parent.appendChild(field);
+    var field = document.createElement("div"); field.className = "field";
+    var lbl = document.createElement("div"); lbl.className = "label"; lbl.textContent = labelText;
+    var val = document.createElement("div"); val.className = "value"; val.textContent = valueText;
+    field.appendChild(lbl); field.appendChild(val); parent.appendChild(field);
   }
 
-  function showDetail(node) {
-    detailName.textContent = node.name || node.id;
+  function showInsightDetail(d) {
+    detailName.textContent = d.primary_attribute || "Insight";
     while (detailBody.firstChild) detailBody.removeChild(detailBody.firstChild);
-    addField(detailBody, "Type", node.type || "");
-    if (node.primary_attribute) addField(detailBody, "Primary", node.primary_attribute);
-    if (node.created_at) addField(detailBody, "Created", node.created_at);
+    addField(detailBody, "Kind", "Insight (" + d.type + ")");
+    addField(detailBody, "Type", d.primary_attribute || "");
+    if (d.confidence != null) addField(detailBody, "Confidence", Math.round(d.confidence * 100) + "%");
+    addField(detailBody, "Content", d.fullContent || d.name);
+    panel.classList.add("open");
+  }
 
-    // Count connections
+  function showEntityDetail(d) {
+    detailName.textContent = d.name || d.id;
+    while (detailBody.firstChild) detailBody.removeChild(detailBody.firstChild);
+    addField(detailBody, "Type", d.type || "");
+    if (d.primary_attribute) addField(detailBody, "Primary", d.primary_attribute);
+    if (d.created_at) addField(detailBody, "Created", d.created_at);
+
+    // Connections
     var connCount = 0;
     var connectedList = [];
     var nodeMap = {};
-    fgNodes.forEach(function(n){ nodeMap[n.id] = n; });
-    links.forEach(function(l){
-      var sid = typeof l.source === "object" ? l.source.id : l.source;
-      var tid = typeof l.target === "object" ? l.target.id : l.target;
-      if (sid === node.id) { connCount++; connectedList.push(tid); }
-      if (tid === node.id) { connCount++; connectedList.push(sid); }
+    entityNodes.forEach(function(n){ nodeMap[n.id] = n; });
+    baseLinks.forEach(function(l){
+      if (l.source === d.id || (typeof l.source === "object" && l.source.id === d.id)) { connCount++; connectedList.push(typeof l.target === "object" ? l.target.id : l.target); }
+      if (l.target === d.id || (typeof l.target === "object" && l.target.id === d.id)) { connCount++; connectedList.push(typeof l.source === "object" ? l.source.id : l.source); }
     });
     addField(detailBody, "Connections", String(connCount));
 
-    // Connected entities
     if (connectedList.length > 0) {
-      var field = document.createElement("div");
-      field.className = "field";
-      var lbl = document.createElement("div");
-      lbl.className = "label";
-      lbl.textContent = "Connected to";
+      var field = document.createElement("div"); field.className = "field";
+      var lbl = document.createElement("div"); lbl.className = "label"; lbl.textContent = "Connected to";
       field.appendChild(lbl);
-      var val = document.createElement("div");
-      val.className = "value";
-      var shown = connectedList.slice(0, 20);
-      shown.forEach(function(cid){
+      var val = document.createElement("div"); val.className = "value";
+      connectedList.slice(0, 20).forEach(function(cid){
         var line = document.createElement("div");
         var cn = nodeMap[cid];
         line.textContent = cn ? cn.name : cid;
@@ -287,33 +813,24 @@ ${legendTypes
         more.textContent = "...and " + (connectedList.length - 20) + " more";
         val.appendChild(more);
       }
-      field.appendChild(val);
-      detailBody.appendChild(field);
+      field.appendChild(val); detailBody.appendChild(field);
     }
 
-    // Insights section
-    var insights = data.insights && data.insights[node.id];
-    if (insights && insights.length > 0) {
-      var insightField = document.createElement("div");
-      insightField.className = "field";
-      var insightLbl = document.createElement("div");
-      insightLbl.className = "label";
-      insightLbl.textContent = "Insights";
+    // Insights in panel
+    var panelInsights = insightsMap[d.id] || [];
+    if (panelInsights.length > 0) {
+      var insightField = document.createElement("div"); insightField.className = "field";
+      var insightLbl = document.createElement("div"); insightLbl.className = "label";
+      insightLbl.textContent = "Insights (" + panelInsights.length + ")";
       insightField.appendChild(insightLbl);
-      insights.forEach(function(ins){
-        var card = document.createElement("div");
-        card.className = "insight-card";
-        var badge = document.createElement("span");
-        badge.className = "insight-type";
-        badge.textContent = ins.type;
+      panelInsights.forEach(function(ins){
+        var card = document.createElement("div"); card.className = "insight-card";
+        var badge = document.createElement("span"); badge.className = "insight-type"; badge.textContent = ins.type;
         card.appendChild(badge);
-        var conf = document.createElement("span");
-        conf.className = "insight-confidence";
+        var conf = document.createElement("span"); conf.className = "insight-confidence";
         conf.textContent = Math.round(ins.confidence * 100) + "%";
         card.appendChild(conf);
-        var content = document.createElement("div");
-        content.className = "insight-content";
-        content.textContent = ins.content;
+        var content = document.createElement("div"); content.className = "insight-content"; content.textContent = ins.content;
         card.appendChild(content);
         insightField.appendChild(card);
       });
@@ -323,58 +840,71 @@ ${legendTypes
     panel.classList.add("open");
   }
 
-  // Init force-graph
-  var graph = ForceGraph()(document.getElementById("graph-container"))
-    .graphData({nodes: fgNodes, links: links})
-    .nodeLabel("name")
-    .nodeColor(function(node){
-      if (hoveredNode && !connectedNodes[node.id]) return "#2a2a45";
-      return node.color;
-    })
-    .nodeVal("size")
-    .linkColor(function(link){
-      if (hoveredNode) {
-        var sid = typeof link.source === "object" ? link.source.id : link.source;
-        var tid = typeof link.target === "object" ? link.target.id : link.target;
-        if (connectedNodes[sid] && connectedNodes[tid]) return link.color;
-        return "#1f1f35";
-      }
-      return link.color;
-    })
-    .linkLabel("label")
-    .linkDirectionalArrowLength(4)
-    .linkDirectionalArrowRelPos(1)
-    .linkWidth(function(link){
-      if (hoveredNode) {
-        var sid = typeof link.source === "object" ? link.source.id : link.source;
-        var tid = typeof link.target === "object" ? link.target.id : link.target;
-        if (connectedNodes[sid] && connectedNodes[tid]) return 2;
-        return 0.3;
-      }
-      return 1;
-    })
-    .backgroundColor("#1a1a2e")
-    .onNodeClick(function(node){ showDetail(node); })
-    .onNodeHover(function(node){ highlightNode(node); })
-    .onBackgroundClick(function(){ closeDetail(); });
-
-  // Search
+  // ══════════════════════════════════════════════════════════
+  //  SEARCH — highlight + zoom
+  // ══════════════════════════════════════════════════════════
   var searchBox = document.getElementById("search-box");
+  var searchResultsEl = document.createElement("div");
+  searchResultsEl.id = "search-results";
+  searchResultsEl.style.cssText = "position:fixed;top:52px;left:16px;z-index:10;font-size:12px;color:#64748b;padding:0 4px;display:none";
+  document.body.appendChild(searchResultsEl);
+
+  var searchTimer = null;
   searchBox.addEventListener("input", function(){
-    var q = searchBox.value.trim().toLowerCase();
-    if (!q) {
-      graph.nodeColor(function(node){
-        if (hoveredNode && !connectedNodes[node.id]) return "#2a2a45";
-        return node.color;
-      });
-      return;
-    }
-    var matches = fgNodes.filter(function(n){
-      return n.name.toLowerCase().indexOf(q) >= 0;
-    });
-    if (matches.length > 0) {
-      graph.centerAt(matches[0].x, matches[0].y, 300).zoom(3, 300);
-    }
+    if (searchTimer) clearTimeout(searchTimer);
+    searchTimer = setTimeout(function(){
+      var q = searchBox.value.trim().toLowerCase();
+      searchMatches = {};
+      searchActive = false;
+      focusedNodeId = null;
+      focusedSet = {};
+      searchResultsEl.style.display = "none";
+      if (q) {
+        searchActive = true;
+        var directMatches = [];
+        currentNodes.forEach(function(n){
+          var name = (n.name || n.id || "").toLowerCase();
+          var type = (n.type || "").toLowerCase();
+          var primary = (n.primary_attribute || "").toLowerCase();
+          if (name.indexOf(q) >= 0 || type.indexOf(q) >= 0 || primary.indexOf(q) >= 0) {
+            searchMatches[n.id] = true;
+            directMatches.push(n);
+          }
+        });
+        // 1st-degree neighbors
+        currentLinks.forEach(function(l){
+          var sid = typeof l.source === "object" ? l.source.id : l.source;
+          var tid = typeof l.target === "object" ? l.target.id : l.target;
+          if (searchMatches[sid]) searchMatches[tid] = true;
+          if (searchMatches[tid]) searchMatches[sid] = true;
+        });
+        searchResultsEl.textContent = directMatches.length + " result" + (directMatches.length !== 1 ? "s" : "");
+        searchResultsEl.style.display = "block";
+        // Zoom to matches
+        if (directMatches.length === 1 && directMatches[0].x != null) {
+          var t = d3.zoomIdentity.translate(width/2 - directMatches[0].x*2, height/2 - directMatches[0].y*2).scale(2);
+          svg.transition().duration(400).call(zoomBehavior.transform, t);
+        } else if (directMatches.length > 1) {
+          var minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+          directMatches.forEach(function(n){
+            if (n.x != null) { if (n.x < minX) minX = n.x; if (n.x > maxX) maxX = n.x; if (n.y < minY) minY = n.y; if (n.y > maxY) maxY = n.y; }
+          });
+          var cx = (minX+maxX)/2, cy = (minY+maxY)/2;
+          var bw = maxX-minX+200, bh = maxY-minY+200;
+          var z = Math.min(width/bw, height/bh, 4);
+          var t2 = d3.zoomIdentity.translate(width/2-cx*z, height/2-cy*z).scale(Math.max(z, 0.3));
+          svg.transition().duration(400).call(zoomBehavior.transform, t2);
+        }
+      }
+      applyVisualState();
+    }, 150);
+  });
+
+  // ── Handle window resize ──
+  window.addEventListener("resize", function(){
+    width = window.innerWidth;
+    height = window.innerHeight;
+    svg.attr("width", width).attr("height", height).attr("viewBox", "0 0 " + width + " " + height);
   });
 })();
 </script>

--- a/cli/src/lib/graph-html.ts
+++ b/cli/src/lib/graph-html.ts
@@ -721,7 +721,8 @@ ${legendTypes
     }
 
     applyVisualState();
-    zoomToNeighborhood(d);
+    // Delay zoom so simulation can position newly-added insight nodes
+    setTimeout(function(){ zoomToNeighborhood(d); }, 300);
   }
 
   function rebuildAndRestart() {
@@ -740,7 +741,7 @@ ${legendTypes
     });
     if (connectedNodes.length < 1) return;
 
-    var padding = 80;
+    var padding = 150;
     var minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
     connectedNodes.forEach(function(n){
       if (n.x < minX) minX = n.x;
@@ -750,7 +751,7 @@ ${legendTypes
     });
     minX -= padding; minY -= padding; maxX += padding; maxY += padding;
     var bw = maxX - minX, bh = maxY - minY;
-    var scale = 0.9 * Math.min(width / bw, height / bh);
+    var scale = Math.min(0.9 * Math.min(width / bw, height / bh), 1.5);
     var midX = (minX + maxX) / 2, midY = (minY + maxY) / 2;
     if (!isFinite(scale) || !isFinite(midX)) return;
     var transform = d3.zoomIdentity

--- a/cli/src/lib/graph-html.ts
+++ b/cli/src/lib/graph-html.ts
@@ -1,5 +1,5 @@
 /**
- * Self-contained HTML graph visualization using Sigma.js v3 + Graphology.
+ * Self-contained HTML graph visualization using Cytoscape.js.
  * Generates a single HTML string that can be opened in any browser.
  */
 
@@ -61,11 +61,9 @@ function escapeJsonForHtml(data: unknown): string {
 export function generateGraphHtml(data: GraphData): string {
   const nodeColors = { ...NODE_COLORS };
   const typeSet = new Set<string>();
-  for (const n of data.nodes) {
-    typeSet.add(n.type);
-  }
+  for (const n of data.nodes) typeSet.add(n.type);
 
-  // Build degree map
+  // Build degree map for sizing
   const degree: Record<string, number> = {};
   for (const n of data.nodes) degree[n.id] = 0;
   for (const e of data.edges) {
@@ -74,27 +72,34 @@ export function generateGraphHtml(data: GraphData): string {
   }
   const maxDeg = Math.max(1, ...Object.values(degree));
 
-  // Build safe node data for embedding
-  const safeNodes = data.nodes.map((n) => ({
-    id: n.id,
-    name: escapeHtml(n.name),
-    rawName: n.name,
-    type: n.type,
-    primary_attribute: n.primary_attribute ? escapeHtml(n.primary_attribute) : undefined,
-    color: nodeColors[n.type] ?? DEFAULT_COLOR,
-    size: 5 + ((degree[n.id] ?? 0) / maxDeg) * 15,
-    created_at: n.created_at,
-  }));
+  // Node set for filtering dangling edges
+  const nodeIds = new Set(data.nodes.map((n) => n.id));
 
-  const safeEdges = data.edges.map((e) => ({
-    id: e.id,
-    source: e.source,
-    target: e.target,
-    label: escapeHtml(e.label),
-    definition_id: e.definition_id,
-  }));
+  // Build Cytoscape elements
+  const elements = {
+    nodes: data.nodes.map((n) => ({
+      data: {
+        id: n.id,
+        label: n.name,
+        type: n.type,
+        primary_attribute: n.primary_attribute ?? "",
+        created_at: n.created_at ?? "",
+        color: nodeColors[n.type] ?? DEFAULT_COLOR,
+        size: 20 + ((degree[n.id] ?? 0) / maxDeg) * 40,
+      },
+    })),
+    edges: data.edges
+      .filter((e) => nodeIds.has(e.source) && nodeIds.has(e.target))
+      .map((e) => ({
+        data: {
+          id: "e" + e.id,
+          source: e.source,
+          target: e.target,
+          label: e.label,
+        },
+      })),
+  };
 
-  // Build legend from actual types
   const legendTypes = Array.from(typeSet).sort();
 
   return `<!DOCTYPE html>
@@ -106,7 +111,7 @@ export function generateGraphHtml(data: GraphData): string {
 <style>
 *{margin:0;padding:0;box-sizing:border-box}
 body{background:#1a1a2e;color:#e0e0e0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;overflow:hidden}
-#graph-container{width:100vw;height:100vh}
+#cy{width:100vw;height:100vh}
 #search-box{position:fixed;top:16px;left:16px;z-index:10;background:#25253e;border:1px solid #3a3a5c;border-radius:8px;padding:8px 12px;color:#e0e0e0;font-size:14px;width:240px;outline:none}
 #search-box::placeholder{color:#6a6a8a}
 #search-box:focus{border-color:#4F87E0}
@@ -140,130 +145,137 @@ ${legendTypes
 <h3 id="detail-name"></h3>
 <div id="detail-body"></div>
 </div>
-<div id="graph-container"></div>
+<div id="cy"></div>
 
-<script src="https://unpkg.com/graphology@0.25.4/dist/graphology.umd.min.js"></script>
-<script src="https://unpkg.com/graphology-layout-forceatlas2@0.10.1/dist/graphology-layout-forceatlas2.min.js"></script>
-<script src="https://unpkg.com/sigma@3.0.0-beta.9/build/sigma.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/cytoscape/3.30.4/cytoscape.min.js"></script>
 
-<script id="graph-data" type="application/json">${escapeJsonForHtml({ nodes: safeNodes, edges: safeEdges })}</script>
+<script id="graph-data" type="application/json">${escapeJsonForHtml(elements)}</script>
 
 <script>
 (function(){
-  var raw = JSON.parse(document.getElementById("graph-data").textContent);
-  var graph = new graphology.Graph({multi:true});
+  var elements = JSON.parse(document.getElementById("graph-data").textContent);
 
-  raw.nodes.forEach(function(n){
-    graph.addNode(n.id,{
-      label:n.name,
-      x:Math.random()*100,
-      y:Math.random()*100,
-      size:n.size,
-      color:n.color,
-      type:n.type,
-      rawName:n.rawName,
-      primary_attribute:n.primary_attribute,
-      created_at:n.created_at
-    });
-  });
-
-  raw.edges.forEach(function(e){
-    if(graph.hasNode(e.source)&&graph.hasNode(e.target)){
-      graph.addEdge(e.source,e.target,{label:e.label,size:1,color:"#3a3a5c"});
-    }
-  });
-
-  // ForceAtlas2 layout
-  var fa2=graphologyLayoutForceAtlas2;
-  var settings=fa2.inferSettings(graph);
-  settings.gravity=1;
-  settings.scalingRatio=10;
-  fa2.assign(graph,{settings:settings,iterations:150});
-
-  var container=document.getElementById("graph-container");
-  var renderer=new Sigma(graph,container,{
-    renderEdgeLabels:true,
-    labelColor:{color:"#c0c0d0"},
-    labelSize:12,
-    labelRenderedSizeThreshold:8,
-    edgeLabelColor:{color:"#6a6a8a"},
-    edgeLabelSize:10,
-    defaultEdgeType:"line",
-    stagePadding:40
+  var cy = cytoscape({
+    container: document.getElementById("cy"),
+    elements: elements,
+    style: [
+      {
+        selector: "node",
+        style: {
+          "background-color": "data(color)",
+          "label": "data(label)",
+          "width": "data(size)",
+          "height": "data(size)",
+          "color": "#c0c0d0",
+          "font-size": "11px",
+          "text-valign": "bottom",
+          "text-margin-y": "6px",
+          "text-outline-color": "#1a1a2e",
+          "text-outline-width": "2px",
+          "min-zoomed-font-size": 10
+        }
+      },
+      {
+        selector: "edge",
+        style: {
+          "width": 1.5,
+          "line-color": "#3a3a5c",
+          "target-arrow-color": "#3a3a5c",
+          "target-arrow-shape": "triangle",
+          "curve-style": "bezier",
+          "label": "data(label)",
+          "font-size": "9px",
+          "color": "#6a6a8a",
+          "text-rotation": "autorotate",
+          "text-outline-color": "#1a1a2e",
+          "text-outline-width": "1.5px",
+          "min-zoomed-font-size": 12
+        }
+      },
+      {
+        selector: "node.highlighted",
+        style: {
+          "border-width": "3px",
+          "border-color": "#fff"
+        }
+      },
+      {
+        selector: "node.faded",
+        style: {
+          "opacity": 0.15
+        }
+      },
+      {
+        selector: "edge.faded",
+        style: {
+          "opacity": 0.08
+        }
+      }
+    ],
+    layout: {
+      name: "cose",
+      animate: false,
+      nodeRepulsion: function(){ return 8000; },
+      idealEdgeLength: function(){ return 120; },
+      gravity: 0.3,
+      numIter: 300,
+      padding: 40
+    },
+    wheelSensitivity: 0.3
   });
 
   // Hover: highlight neighbors
-  var hoveredNode=null;
-  var hoveredNeighbors=new Set();
-
-  renderer.on("enterNode",function(e){
-    hoveredNode=e.node;
-    hoveredNeighbors=new Set(graph.neighbors(e.node));
-    renderer.refresh();
-  });
-  renderer.on("leaveNode",function(){
-    hoveredNode=null;
-    hoveredNeighbors.clear();
-    renderer.refresh();
+  cy.on("mouseover", "node", function(e){
+    var node = e.target;
+    var neighborhood = node.neighborhood().add(node);
+    cy.elements().addClass("faded");
+    neighborhood.removeClass("faded");
+    node.addClass("highlighted");
   });
 
-  renderer.setSetting("nodeReducer",function(node,data){
-    var res=Object.assign({},data);
-    if(hoveredNode){
-      if(node===hoveredNode){
-        res.highlighted=true;
-      }else if(!hoveredNeighbors.has(node)){
-        res.color="#2a2a3e";
-        res.label=null;
-      }
-    }
-    if(searchQuery){
-      var name=(graph.getNodeAttribute(node,"rawName")||"").toLowerCase();
-      if(!name.includes(searchQuery)){
-        res.color="#2a2a3e";
-        res.label=null;
-      }
-    }
-    return res;
-  });
-
-  renderer.setSetting("edgeReducer",function(edge,data){
-    var res=Object.assign({},data);
-    if(hoveredNode){
-      var src=graph.source(edge);
-      var tgt=graph.target(edge);
-      if(src!==hoveredNode&&tgt!==hoveredNode){
-        res.hidden=true;
-      }else{
-        res.color="#6a6a8a";
-        res.size=2;
-      }
-    }
-    return res;
+  cy.on("mouseout", "node", function(e){
+    cy.elements().removeClass("faded").removeClass("highlighted");
   });
 
   // Search
-  var searchQuery="";
-  var searchBox=document.getElementById("search-box");
-  searchBox.addEventListener("input",function(){
-    searchQuery=searchBox.value.trim().toLowerCase();
-    if(searchQuery){
-      graph.forEachNode(function(node,attrs){
-        if((attrs.rawName||"").toLowerCase().includes(searchQuery)){
-          var pos=renderer.getNodeDisplayData(node);
-          if(pos)renderer.getCamera().animate({x:pos.x,y:pos.y,ratio:0.3},{duration:300});
-          return true;
-        }
-      });
+  var searchBox = document.getElementById("search-box");
+  searchBox.addEventListener("input", function(){
+    var q = searchBox.value.trim().toLowerCase();
+    if (!q) {
+      cy.elements().removeClass("faded");
+      return;
     }
-    renderer.refresh();
+    cy.nodes().forEach(function(n){
+      var name = (n.data("label") || "").toLowerCase();
+      if (name.includes(q)) {
+        n.removeClass("faded");
+        n.neighborhood().add(n).removeClass("faded");
+      } else {
+        n.addClass("faded");
+      }
+    });
+    cy.edges().forEach(function(e){
+      if (e.source().hasClass("faded") && e.target().hasClass("faded")) {
+        e.addClass("faded");
+      } else {
+        e.removeClass("faded");
+      }
+    });
+    // Center on first match
+    var matches = cy.nodes().filter(function(n){
+      return (n.data("label") || "").toLowerCase().includes(q);
+    });
+    if (matches.length > 0) {
+      cy.animate({ center: { eles: matches.first() }, zoom: 1.5, duration: 300 });
+    }
   });
 
-  // Detail panel — uses textContent and DOM methods to avoid innerHTML XSS
-  var panel=document.getElementById("detail-panel");
-  var detailName=document.getElementById("detail-name");
-  var detailBody=document.getElementById("detail-body");
-  document.getElementById("detail-close").addEventListener("click",function(){
+  // Detail panel
+  var panel = document.getElementById("detail-panel");
+  var detailName = document.getElementById("detail-name");
+  var detailBody = document.getElementById("detail-body");
+
+  document.getElementById("detail-close").addEventListener("click", function(){
     panel.classList.remove("open");
   });
 
@@ -281,32 +293,33 @@ ${legendTypes
     parent.appendChild(field);
   }
 
-  renderer.on("clickNode",function(e){
-    var attrs=graph.getNodeAttributes(e.node);
-    var neighbors=graph.neighbors(e.node);
-    detailName.textContent=attrs.rawName||attrs.label||e.node;
-    detailBody.textContent="";
-    addField(detailBody, "Type", attrs.type||"");
-    if(attrs.primary_attribute) addField(detailBody, "Primary", attrs.primary_attribute);
-    if(attrs.created_at) addField(detailBody, "Created", attrs.created_at);
+  cy.on("tap", "node", function(e){
+    var node = e.target;
+    var d = node.data();
+    var neighbors = node.neighborhood("node");
+    detailName.textContent = d.label || d.id;
+    detailBody.textContent = "";
+    addField(detailBody, "Type", d.type || "");
+    if (d.primary_attribute) addField(detailBody, "Primary", d.primary_attribute);
+    if (d.created_at) addField(detailBody, "Created", d.created_at);
     addField(detailBody, "Connections", String(neighbors.length));
-    if(neighbors.length>0){
-      var field=document.createElement("div");
-      field.className="field";
-      var lbl=document.createElement("div");
-      lbl.className="label";
-      lbl.textContent="Connected to";
+    if (neighbors.length > 0) {
+      var field = document.createElement("div");
+      field.className = "field";
+      var lbl = document.createElement("div");
+      lbl.className = "label";
+      lbl.textContent = "Connected to";
       field.appendChild(lbl);
-      var val=document.createElement("div");
-      val.className="value";
-      neighbors.slice(0,20).forEach(function(n){
-        var line=document.createElement("div");
-        line.textContent=graph.getNodeAttribute(n,"rawName")||n;
+      var val = document.createElement("div");
+      val.className = "value";
+      neighbors.slice(0, 20).forEach(function(n){
+        var line = document.createElement("div");
+        line.textContent = n.data("label") || n.id();
         val.appendChild(line);
       });
-      if(neighbors.length>20){
-        var more=document.createElement("em");
-        more.textContent="...and "+(neighbors.length-20)+" more";
+      if (neighbors.length > 20) {
+        var more = document.createElement("em");
+        more.textContent = "...and " + (neighbors.length - 20) + " more";
         val.appendChild(more);
       }
       field.appendChild(val);
@@ -315,8 +328,8 @@ ${legendTypes
     panel.classList.add("open");
   });
 
-  renderer.on("clickStage",function(){
-    panel.classList.remove("open");
+  cy.on("tap", function(e){
+    if (e.target === cy) panel.classList.remove("open");
   });
 })();
 </script>

--- a/cli/tests/commands/setup.test.ts
+++ b/cli/tests/commands/setup.test.ts
@@ -1,0 +1,44 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { fallbackIntegrations } from "../../src/commands/setup.js";
+import type { IntegrationEntry } from "../../src/commands/setup.js";
+
+describe("fallbackIntegrations", () => {
+  it("returns a non-empty list of integrations", () => {
+    const result = fallbackIntegrations();
+    assert.ok(Array.isArray(result), "should return an array");
+    assert.ok(result.length > 0, "should not be empty");
+  });
+
+  it("each entry has required fields", () => {
+    const result = fallbackIntegrations();
+    for (const entry of result) {
+      assert.ok(typeof entry.type === "string" && entry.type.length > 0, `type should be non-empty string, got: ${entry.type}`);
+      assert.ok(typeof entry.provider === "string" && entry.provider.length > 0, `provider should be non-empty string, got: ${entry.provider}`);
+      assert.ok(typeof entry.display_name === "string" && entry.display_name.length > 0, `display_name should be non-empty string, got: ${entry.display_name}`);
+      assert.ok(typeof entry.description === "string" && entry.description.length > 0, `description should be non-empty string, got: ${entry.description}`);
+      assert.ok(Array.isArray(entry.connections), "connections should be an array");
+      assert.equal(entry.connections.length, 0, "fallback connections should be empty");
+    }
+  });
+
+  it("includes all expected integrations", () => {
+    const result = fallbackIntegrations();
+    const providers = result.map((e) => `${e.type}/${e.provider}`);
+    assert.ok(providers.includes("email/google"), "should include Gmail");
+    assert.ok(providers.includes("calendar/google"), "should include Google Calendar");
+    assert.ok(providers.includes("email/microsoft"), "should include Outlook");
+    assert.ok(providers.includes("calendar/microsoft"), "should include Outlook Calendar");
+    assert.ok(providers.includes("messaging/slack"), "should include Slack");
+    assert.ok(providers.includes("crm/salesforce"), "should include Salesforce");
+    assert.ok(providers.includes("crm/hubspot"), "should include HubSpot");
+    assert.ok(providers.includes("crm/attio"), "should include Attio");
+  });
+
+  it("has no duplicate type/provider combinations", () => {
+    const result = fallbackIntegrations();
+    const keys = result.map((e) => `${e.type}/${e.provider}`);
+    const unique = new Set(keys);
+    assert.equal(keys.length, unique.size, "should have no duplicates");
+  });
+});

--- a/cli/tests/lib/graph-html.test.ts
+++ b/cli/tests/lib/graph-html.test.ts
@@ -8,6 +8,7 @@ function makeData(overrides?: Partial<GraphData>): GraphData {
     nodes: [],
     edges: [],
     context_edges: [],
+    insight_nodes: [],
     relationship_definitions: [],
     insights: {},
     total_nodes: 0,
@@ -18,9 +19,10 @@ function makeData(overrides?: Partial<GraphData>): GraphData {
 }
 
 describe("generateGraphHtml", () => {
-  it("returns HTML containing force-graph reference", () => {
+  it("returns HTML containing D3 force-graph reference", () => {
     const html = generateGraphHtml(makeData());
-    assert.ok(html.includes("force-graph"), "should reference force-graph");
+    assert.ok(html.includes("d3@7"), "should reference D3.js v7");
+    assert.ok(html.includes("forceSimulation"), "should use D3 force-graph simulation");
     assert.ok(html.includes("<!DOCTYPE html>"), "should be a full HTML document");
   });
 
@@ -29,7 +31,6 @@ describe("generateGraphHtml", () => {
     assert.ok(html.length > 0);
     assert.ok(html.includes("0 entities"));
     assert.ok(html.includes("0 connections"));
-    assert.ok(html.includes("0 insights"));
   });
 
   it("embeds node data as JSON", () => {
@@ -59,37 +60,53 @@ describe("generateGraphHtml", () => {
     );
   });
 
-  it("includes context edge and triplet edge legend items", () => {
+  it("includes edge type legend items including insight", () => {
     const html = generateGraphHtml(makeData());
-    assert.ok(html.includes("Formal"), "should have Formal edge legend");
-    assert.ok(html.includes("Context"), "should have Context edge legend");
-    assert.ok(html.includes("Triplet"), "should have Triplet edge legend");
+    assert.ok(html.includes("Formal"), "should include Formal edge legend");
+    assert.ok(html.includes("Context"), "should include Context edge legend");
+    assert.ok(html.includes("Triplet"), "should include Triplet edge legend");
+    assert.ok(html.includes("Insight"), "should include Insight edge legend");
   });
 
   it("computes stats bar with combined connection count", () => {
-    const data = makeData({
-      total_nodes: 5,
-      total_edges: 3,
-      total_context_edges: 2,
-    });
+    const data = makeData({ total_edges: 3, total_context_edges: 7 });
     const html = generateGraphHtml(data);
-    assert.ok(html.includes("5 entities"), "should show total nodes");
-    assert.ok(html.includes("5 connections"), "should show combined edge count (3+2)");
+    assert.ok(html.includes("10 connections"), "should show sum of edges + context_edges");
   });
 
-  it("counts total insights across all entities", () => {
+  it("counts total insights across all entities and insight nodes", () => {
     const data = makeData({
       insights: {
-        "1": [
-          { content: "Likes coffee", confidence: 0.9, type: "preference" },
-          { content: "Works remotely", confidence: 0.8, type: "behavior" },
-        ],
-        "2": [
-          { content: "CEO", confidence: 0.95, type: "role" },
-        ],
+        "1": [{ content: "a", confidence: 0.9, type: "fact" }],
+        "2": [{ content: "b", confidence: 0.8, type: "context" }, { content: "c", confidence: 0.7, type: "status" }],
       },
+      insight_nodes: [
+        { id: "ei:1", content: "test", type: "fact", confidence: 0.9, source: "entity_insight" },
+      ],
     });
     const html = generateGraphHtml(data);
-    assert.ok(html.includes("3 insights"), "should show total insight count");
+    assert.ok(html.includes("4 insights"), "should count 3 from map + 1 from insight_nodes");
+  });
+
+  it("renders ghost nodes in legend when present", () => {
+    const data = makeData({
+      nodes: [
+        { id: "ghost:123", name: "Some Topic", type: "ghost", definition_slug: "ghost" },
+      ],
+      total_nodes: 1,
+    });
+    const html = generateGraphHtml(data);
+    assert.ok(html.includes("ghost"), "should include ghost in legend");
+    assert.ok(html.includes("#8B5CF6"), "should use purple color for ghost");
+  });
+
+  it("renders insight nodes in legend when present", () => {
+    const data = makeData({
+      insight_nodes: [
+        { id: "ei:1", content: "test insight", type: "fact", confidence: 0.9, source: "entity_insight" },
+      ],
+    });
+    const html = generateGraphHtml(data);
+    assert.ok(html.includes("entity_insight"), "should include entity_insight in legend");
   });
 });

--- a/cli/tests/lib/graph-html.test.ts
+++ b/cli/tests/lib/graph-html.test.ts
@@ -7,17 +7,20 @@ function makeData(overrides?: Partial<GraphData>): GraphData {
   return {
     nodes: [],
     edges: [],
+    context_edges: [],
     relationship_definitions: [],
+    insights: {},
     total_nodes: 0,
     total_edges: 0,
+    total_context_edges: 0,
     ...overrides,
   };
 }
 
 describe("generateGraphHtml", () => {
-  it("returns HTML containing cytoscape reference", () => {
+  it("returns HTML containing force-graph reference", () => {
     const html = generateGraphHtml(makeData());
-    assert.ok(html.includes("cytoscape"), "should reference cytoscape");
+    assert.ok(html.includes("force-graph"), "should reference force-graph");
     assert.ok(html.includes("<!DOCTYPE html>"), "should be a full HTML document");
   });
 
@@ -25,7 +28,8 @@ describe("generateGraphHtml", () => {
     const html = generateGraphHtml(makeData());
     assert.ok(html.length > 0);
     assert.ok(html.includes("0 entities"));
-    assert.ok(html.includes("0 relationships"));
+    assert.ok(html.includes("0 connections"));
+    assert.ok(html.includes("0 insights"));
   });
 
   it("embeds node data as JSON", () => {
@@ -53,5 +57,39 @@ describe("generateGraphHtml", () => {
       html.includes("\\u003cscript\\u003e") || html.includes("&lt;script&gt;"),
       "script tag should be escaped",
     );
+  });
+
+  it("includes context edge and triplet edge legend items", () => {
+    const html = generateGraphHtml(makeData());
+    assert.ok(html.includes("Formal"), "should have Formal edge legend");
+    assert.ok(html.includes("Context"), "should have Context edge legend");
+    assert.ok(html.includes("Triplet"), "should have Triplet edge legend");
+  });
+
+  it("computes stats bar with combined connection count", () => {
+    const data = makeData({
+      total_nodes: 5,
+      total_edges: 3,
+      total_context_edges: 2,
+    });
+    const html = generateGraphHtml(data);
+    assert.ok(html.includes("5 entities"), "should show total nodes");
+    assert.ok(html.includes("5 connections"), "should show combined edge count (3+2)");
+  });
+
+  it("counts total insights across all entities", () => {
+    const data = makeData({
+      insights: {
+        "1": [
+          { content: "Likes coffee", confidence: 0.9, type: "preference" },
+          { content: "Works remotely", confidence: 0.8, type: "behavior" },
+        ],
+        "2": [
+          { content: "CEO", confidence: 0.95, type: "role" },
+        ],
+      },
+    });
+    const html = generateGraphHtml(data);
+    assert.ok(html.includes("3 insights"), "should show total insight count");
   });
 });

--- a/cli/tests/lib/graph-html.test.ts
+++ b/cli/tests/lib/graph-html.test.ts
@@ -1,0 +1,58 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { generateGraphHtml } from "../../src/lib/graph-html.js";
+import type { GraphData } from "../../src/lib/graph-html.js";
+
+function makeData(overrides?: Partial<GraphData>): GraphData {
+  return {
+    nodes: [],
+    edges: [],
+    relationship_definitions: [],
+    total_nodes: 0,
+    total_edges: 0,
+    ...overrides,
+  };
+}
+
+describe("generateGraphHtml", () => {
+  it("returns HTML containing sigma and graphology references", () => {
+    const html = generateGraphHtml(makeData());
+    assert.ok(html.includes("sigma"), "should reference sigma");
+    assert.ok(html.includes("graphology"), "should reference graphology");
+    assert.ok(html.includes("<!DOCTYPE html>"), "should be a full HTML document");
+  });
+
+  it("renders empty graph without error", () => {
+    const html = generateGraphHtml(makeData());
+    assert.ok(html.length > 0);
+    assert.ok(html.includes("0 entities"));
+    assert.ok(html.includes("0 relationships"));
+  });
+
+  it("embeds node data as JSON", () => {
+    const data = makeData({
+      nodes: [
+        { id: "1", name: "Alice", type: "person", definition_slug: "person", primary_attribute: "alice@co.com" },
+      ],
+      total_nodes: 1,
+    });
+    const html = generateGraphHtml(data);
+    assert.ok(html.includes("Alice"), "node name should appear in output");
+    assert.ok(html.includes("graph-data"), "should contain graph-data script block");
+  });
+
+  it("escapes HTML special characters to prevent XSS", () => {
+    const data = makeData({
+      nodes: [
+        { id: "1", name: '<script>alert(1)</script>', type: "person", definition_slug: "person" },
+      ],
+      total_nodes: 1,
+    });
+    const html = generateGraphHtml(data);
+    assert.ok(!html.includes("<script>alert(1)</script>"), "raw script tag must not appear");
+    assert.ok(
+      html.includes("\\u003cscript\\u003e") || html.includes("&lt;script&gt;"),
+      "script tag should be escaped",
+    );
+  });
+});

--- a/cli/tests/lib/graph-html.test.ts
+++ b/cli/tests/lib/graph-html.test.ts
@@ -15,10 +15,9 @@ function makeData(overrides?: Partial<GraphData>): GraphData {
 }
 
 describe("generateGraphHtml", () => {
-  it("returns HTML containing sigma and graphology references", () => {
+  it("returns HTML containing cytoscape reference", () => {
     const html = generateGraphHtml(makeData());
-    assert.ok(html.includes("sigma"), "should reference sigma");
-    assert.ok(html.includes("graphology"), "should reference graphology");
+    assert.ok(html.includes("cytoscape"), "should reference cytoscape");
     assert.ok(html.includes("<!DOCTYPE html>"), "should be a full HTML document");
   });
 


### PR DESCRIPTION
## Summary
- `nex graph` CLI command that fetches the workspace graph and opens an interactive D3.js visualization
- D3.js v7 with SVG rendering — force-directed layout with curved Bezier edges, zoom-gated labels, insight badges, and detail sidebar
- Setup integration flow simplified: single API call with graceful fallback instead of silent failure
- New test coverage for graph HTML generation and setup fallback integrations

## Graph visualization features
- Force layout: charge -3000/-500, link distance 200, collision radius 50
- Zoom-gated labels: node labels at zoom >= 0.6, link labels at zoom >= 0.9
- Click-to-focus with neighborhood zoom (includes connected insight nodes)
- Insight badges on entity nodes showing count
- Detail sidebar with entity/insight information
- Edge type legend, search, stats bar
- XSS-safe HTML escaping

## Key files
- `src/lib/graph-html.ts` — D3.js SVG graph HTML generator
- `src/commands/graph.ts` — CLI command (`--out`, `--limit`, `--no-open`)
- `src/commands/setup.ts` — simplified integration onboarding
- `scripts/gen-graph-db.ts` — DB-driven graph generation with full_name parsing
- `tests/lib/graph-html.test.ts` — 9 tests
- `tests/commands/setup.test.ts` — 4 tests

## Dependencies
- Requires [core PR #690: GET /v1/graph endpoint](https://github.com/nex-crm/core/pull/690)

## Test plan
- [x] `npm run build` — clean
- [x] All 13 tests pass (9 graph + 4 setup)
- [x] `nex graph` opens browser with interactive graph
- [x] Edge labels show meaningful predicates (status, role_detail, activity, etc.)
- [x] Click on node zooms to show connected insights in view
- [x] `nex setup` shows integration fallback message gracefully
- [x] Published as `@nex-ai/nex@0.1.21`

🤖 Generated with [Claude Code](https://claude.com/claude-code)