### PR TITLE
Add CLI integration tests against mock API server

### DIFF
--- a/cli/tests/integration/context.test.ts
+++ b/cli/tests/integration/context.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { runNex, nexEnv } from "./helpers.js";
+import { startMockServer } from "./mock-server.js";
+
+let env: Record<string, string>;
+let closeMock: () => void;
+
+before(() => {
+  const mock = startMockServer();
+  env = nexEnv(mock.url);
+  closeMock = mock.close;
+});
+
+after(() => closeMock());
+
+describe("context commands", () => {
+  it("ask — returns AI answer as JSON", async () => {
+    const { stdout, exitCode } = await runNex(["ask", "What is the meaning of life?"], { env });
+    assert.equal(exitCode, 0);
+    const data = JSON.parse(stdout);
+    assert.equal(data.answer, "The answer is 42");
+  });
+
+  it("ask — text format shows answer", async () => {
+    const { stdout, exitCode } = await runNex(
+      ["ask", "What is the meaning of life?", "--format", "text"],
+      { env },
+    );
+    assert.equal(exitCode, 0);
+    assert.ok(stdout.includes("42"), "output should contain the answer");
+  });
+
+  it("remember — stores context", async () => {
+    const { stdout, exitCode } = await runNex(
+      ["remember", "Important project context"],
+      { env },
+    );
+    assert.equal(exitCode, 0);
+    const data = JSON.parse(stdout);
+    assert.equal(data.status, "completed");
+    assert.equal(data.artifact_id, "art-1");
+  });
+
+  it("artifact — retrieves artifact by ID", async () => {
+    const { stdout, exitCode } = await runNex(["artifact", "art-1"], { env });
+    assert.equal(exitCode, 0);
+    const data = JSON.parse(stdout);
+    assert.equal(data.id, "art-1");
+    assert.ok(data.content, "should have content");
+  });
+});

--- a/cli/tests/integration/error-handling.test.ts
+++ b/cli/tests/integration/error-handling.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { runNex, nexEnv } from "./helpers.js";
+import { startMockServer } from "./mock-server.js";
+
+let mockUrl: string;
+let closeMock: () => void;
+
+before(() => {
+  const mock = startMockServer();
+  mockUrl = mock.url;
+  closeMock = mock.close;
+});
+
+after(() => closeMock());
+
+describe("error handling", () => {
+  it("auth error — fails with exit code 2 when no API key", async () => {
+    const { exitCode, stderr } = await runNex(
+      ["object", "list"],
+      { env: { NEX_DEV_URL: mockUrl } },
+    );
+    assert.notEqual(exitCode, 0);
+    assert.ok(stderr.includes("API key") || stderr.includes("setup"), "should mention API key or setup");
+  });
+
+  it("auth error — fails with bad API key", async () => {
+    const { exitCode, stderr } = await runNex(
+      ["object", "list"],
+      { env: { NEX_DEV_URL: mockUrl, NEX_API_KEY: "wrong-key" } },
+    );
+    assert.notEqual(exitCode, 0);
+    assert.ok(stderr.length > 0, "should have error output");
+  });
+
+  it("missing required arg — record get with no ID", async () => {
+    const { exitCode, stderr } = await runNex(
+      ["record", "get"],
+      { env: nexEnv(mockUrl) },
+    );
+    assert.notEqual(exitCode, 0);
+    assert.ok(stderr.length > 0, "should have error output");
+  });
+
+  it("missing required option — record create without --data", async () => {
+    const { exitCode, stderr } = await runNex(
+      ["record", "create", "company"],
+      { env: nexEnv(mockUrl) },
+    );
+    assert.notEqual(exitCode, 0);
+    assert.ok(stderr.length > 0, "should have error output");
+  });
+
+  it("unknown command — exits with error", async () => {
+    const { exitCode, stderr } = await runNex(
+      ["notacommand"],
+      { env: nexEnv(mockUrl) },
+    );
+    assert.notEqual(exitCode, 0);
+    assert.ok(stderr.length > 0, "should have error output");
+  });
+});

--- a/cli/tests/integration/helpers.ts
+++ b/cli/tests/integration/helpers.ts
@@ -1,0 +1,53 @@
+/**
+ * Subprocess test helpers for nex CLI integration tests.
+ */
+
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLI_DIR = resolve(__dirname, "../..");
+
+export interface RunResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+/**
+ * Run the nex CLI as a subprocess and capture output.
+ */
+export function runNex(
+  args: string[],
+  opts: { env?: Record<string, string> } = {},
+): Promise<RunResult> {
+  return new Promise((res) => {
+    const proc = spawn("node", ["--import", "tsx", "src/index.ts", ...args], {
+      cwd: CLI_DIR,
+      env: {
+        ...process.env,
+        ...opts.env,
+        NODE_NO_WARNINGS: "1",
+      },
+    });
+
+    let stdout = "";
+    let stderr = "";
+    proc.stdout.on("data", (d: Buffer) => { stdout += d; });
+    proc.stderr.on("data", (d: Buffer) => { stderr += d; });
+    proc.on("close", (code) => {
+      res({ stdout: stdout.trim(), stderr: stderr.trim(), exitCode: code ?? 1 });
+    });
+  });
+}
+
+/**
+ * Standard env vars pointing at the mock server.
+ */
+export function nexEnv(mockUrl: string): Record<string, string> {
+  return {
+    NEX_DEV_URL: mockUrl,
+    NEX_API_KEY: "test-key",
+  };
+}

--- a/cli/tests/integration/mock-server.ts
+++ b/cli/tests/integration/mock-server.ts
@@ -1,0 +1,331 @@
+/**
+ * Mock HTTP server for nex-as-a-skill integration tests.
+ * Same data shapes as nex-cli tests for cross-validation.
+ */
+
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+
+// ── Mock data ───────────────────────────────────────────────────────────
+
+const OBJECTS = [
+  {
+    id: "obj-1", name: "Company", name_plural: "Companies", slug: "company",
+    type: "company", created_at: "2025-01-01T00:00:00Z",
+    attributes: [
+      { id: "ad-1", name: "Name", slug: "name", type: "text" },
+      { id: "ad-2", name: "Domains", slug: "domains", type: "domain" },
+    ],
+  },
+  {
+    id: "obj-2", name: "Person", name_plural: "People", slug: "person",
+    type: "person", created_at: "2025-01-01T00:00:00Z",
+    attributes: [{ id: "ad-3", name: "Name", slug: "name", type: "text" }],
+  },
+];
+
+const COMPANY_RECORDS = [
+  {
+    id: "rec-1", object_id: "obj-1", workspace_id: "ws-1", type: "company",
+    attributes: {
+      name: [{ id: "a1", type: "text", text: "Acme Corp" }],
+      domains: [{ id: "a2", type: "domain", domain: "acme.com" }],
+    },
+    created_at: "2025-01-01T00:00:00Z", updated_at: "2025-06-15T12:00:00Z",
+  },
+  {
+    id: "rec-2", object_id: "obj-1", workspace_id: "ws-1", type: "company",
+    attributes: { name: [{ id: "a3", type: "text", text: "Globex" }] },
+    created_at: "2025-01-01T00:00:00Z", updated_at: "2025-06-15T12:00:00Z",
+  },
+];
+
+const PERSON_RECORDS = [
+  {
+    id: "rec-3", object_id: "obj-2", workspace_id: "ws-1", type: "person",
+    attributes: { name: [{ id: "a4", type: "text", text: "John Doe" }] },
+    created_at: "2025-01-01T00:00:00Z", updated_at: "2025-06-15T12:00:00Z",
+  },
+];
+
+const RECORDS_BY_SLUG: Record<string, typeof COMPANY_RECORDS> = {
+  company: COMPANY_RECORDS,
+  person: PERSON_RECORDS,
+};
+
+const ALL_RECORDS = [...COMPANY_RECORDS, ...PERSON_RECORDS];
+const RECORDS_BY_ID: Record<string, typeof ALL_RECORDS[0]> = {};
+for (const r of ALL_RECORDS) RECORDS_BY_ID[r.id] = r;
+
+const TASK = {
+  id: "task-1", title: "Fix bug", description: "Fix the login bug",
+  status: "todo", priority: "high", due_date: null, is_completed: false,
+  record_id: "", record_name: "", assignee_id: "",
+  created_at: "2025-01-01T00:00:00Z", updated_at: "2025-01-01T00:00:00Z",
+};
+
+const NOTE = {
+  id: "note-1", title: "Project note", body: "A note about the project",
+  record_id: "", author_id: "user-1",
+  created_at: "2025-01-01T00:00:00Z", updated_at: "2025-01-01T00:00:00Z",
+};
+
+const CONTEXT_TEXT = { status: "completed", artifact_id: "art-1" };
+
+const CONTEXT_ASK = {
+  answer: "The answer is 42", sources: [], record_ids: [],
+  entityCount: 1, sessionId: "sess-1",
+};
+
+const ARTIFACT = {
+  id: "art-1", content: "Previously remembered context",
+  status: "completed", created_at: "2025-01-01T00:00:00Z",
+};
+
+const SEARCH = {
+  results: [{
+    id: "rec-1", name: "Acme Corp", primary_value: "Acme Corp",
+    matched_value: "Acme Corp", score: 0.95, type: "company",
+    entity_definition_id: "obj-1",
+  }],
+};
+
+const TIMELINE = {
+  events: [{
+    id: "evt-1", type: "created", summary: "Record created", details: {},
+    actor_id: "user-1", actor_name: "System",
+    created_at: "2025-01-01T00:00:00Z",
+  }],
+};
+
+const GRAPH = {
+  nodes: [
+    { id: "rec-1", name: "Acme Corp", type: "company", definition_slug: "company", primary_attribute: "Acme Corp", created_at: "2025-01-01T00:00:00Z" },
+    { id: "rec-3", name: "John Doe", type: "person", definition_slug: "person", primary_attribute: "John Doe", created_at: "2025-01-01T00:00:00Z" },
+  ],
+  edges: [{ source: "rec-1", target: "rec-3", relationship_id: "rel-inst-1", relationship_name: "employs", predicate: "employs" }],
+  context_edges: [],
+  relationship_definitions: [{ id: "rel-1", type: "one_to_many", predicate: "employs" }],
+  total_nodes: 2, total_edges: 1,
+};
+
+const RELATIONSHIPS = {
+  data: [{
+    id: "rel-1", type: "one_to_many",
+    entity_definition_1_id: "obj-1", entity_definition_2_id: "obj-2",
+    entity_1_to_2_predicate: "employs", entity_2_to_1_predicate: "works at",
+    created_at: "2025-01-01T00:00:00Z",
+  }],
+};
+
+const INSIGHTS = {
+  insights: [{
+    id: "insight-1", title: "Key trend",
+    body: "Revenue is increasing across all segments",
+    category: "growth", priority: "high", record_ids: ["rec-1"],
+    created_at: "2025-01-01T00:00:00Z",
+  }],
+  insight_count: 1,
+};
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+async function readBody(req: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) chunks.push(chunk as Buffer);
+  return Buffer.concat(chunks).toString("utf-8");
+}
+
+function json(res: ServerResponse, data: unknown, status = 200): void {
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(data));
+}
+
+// ── Server ──────────────────────────────────────────────────────────────
+
+export function startMockServer(): { url: string; close: () => void } {
+  const server = createServer(async (req, res) => {
+    const url = new URL(req.url!, `http://localhost`);
+    const path = url.pathname;
+    const method = req.method!;
+    const auth = req.headers.authorization;
+
+    // Auth check
+    if (path.startsWith("/api/developers") && auth !== "Bearer test-key") {
+      return json(res, { error: "Unauthorized", detail: "Invalid API key" }, 401);
+    }
+
+    try {
+      // ── GET ─────────────────────────────────────────────────
+      if (method === "GET") {
+        if (path === "/api/developers/v1/objects") {
+          return json(res, { data: OBJECTS });
+        }
+
+        // GET /v1/objects/:slug
+        let m = path.match(/^\/api\/developers\/v1\/objects\/([^/]+)$/);
+        if (m) {
+          const obj = OBJECTS.find((o) => o.slug === m![1]);
+          return obj ? json(res, obj) : json(res, { error: "Not found" }, 404);
+        }
+
+        // GET /v1/records/:id/timeline
+        m = path.match(/^\/api\/developers\/v1\/records\/([^/]+)\/timeline$/);
+        if (m) return json(res, TIMELINE);
+
+        // GET /v1/records/:id
+        m = path.match(/^\/api\/developers\/v1\/records\/([^/]+)$/);
+        if (m) {
+          const rec = RECORDS_BY_ID[m[1]];
+          return rec ? json(res, rec) : json(res, { error: "Not found" }, 404);
+        }
+
+        if (path === "/api/developers/v1/tasks") return json(res, { data: [TASK], has_more: false, total: 1 });
+
+        // GET /v1/tasks/:id
+        m = path.match(/^\/api\/developers\/v1\/tasks\/([^/]+)$/);
+        if (m) return m[1] === "task-1" ? json(res, TASK) : json(res, { error: "Not found" }, 404);
+
+        if (path === "/api/developers/v1/notes") return json(res, { data: [NOTE] });
+
+        // GET /v1/notes/:id
+        m = path.match(/^\/api\/developers\/v1\/notes\/([^/]+)$/);
+        if (m) return m[1] === "note-1" ? json(res, NOTE) : json(res, { error: "Not found" }, 404);
+
+        if (path === "/api/developers/v1/graph") return json(res, GRAPH);
+        if (path === "/api/developers/v1/relationships") return json(res, RELATIONSHIPS);
+        if (path === "/api/developers/v1/insights") return json(res, INSIGHTS);
+
+        // GET /v1/context/artifacts/:id
+        m = path.match(/^\/api\/developers\/v1\/context\/artifacts\/([^/]+)$/);
+        if (m) return json(res, ARTIFACT);
+      }
+
+      // ── POST ────────────────────────────────────────────────
+      if (method === "POST") {
+        const body = await readBody(req);
+        const parsed = body ? JSON.parse(body) : {};
+
+        // POST /v1/objects/:slug/records (list records)
+        let m = path.match(/^\/api\/developers\/v1\/objects\/([^/]+)\/records$/);
+        if (m) {
+          const records = RECORDS_BY_SLUG[m[1]] ?? [];
+          return json(res, { data: records, limit: 25, offset: 0, has_more: false, total: records.length });
+        }
+
+        // POST /v1/objects (create object definition)
+        if (path === "/api/developers/v1/objects") {
+          return json(res, {
+            id: "obj-new", name: parsed.name ?? "New", name_plural: (parsed.name ?? "New") + "s",
+            slug: parsed.slug ?? "new", type: parsed.type ?? "custom",
+            created_at: "2025-01-01T00:00:00Z", attributes: [],
+          });
+        }
+
+        // POST /v1/objects/:slug (create record)
+        m = path.match(/^\/api\/developers\/v1\/objects\/([^/]+)$/);
+        if (m) {
+          const name = typeof parsed.attributes?.name === "string" ? parsed.attributes.name : "NewRecord";
+          return json(res, {
+            id: `rec-new-${Date.now()}`, object_id: "obj-1", workspace_id: "ws-1",
+            type: m[1],
+            attributes: { name: [{ id: "a-new", type: "text", text: name }] },
+            created_at: "2025-01-01T00:00:00Z", updated_at: "2025-01-01T00:00:00Z",
+          });
+        }
+
+        if (path === "/api/developers/v1/search") return json(res, SEARCH);
+        if (path === "/api/developers/v1/tasks") {
+          return json(res, { ...TASK, id: "task-new", title: parsed.title ?? "" });
+        }
+        if (path === "/api/developers/v1/notes") {
+          return json(res, { ...NOTE, id: "note-new", title: parsed.title ?? "" });
+        }
+        if (path === "/api/developers/v1/context/ask") return json(res, CONTEXT_ASK);
+        if (path === "/api/developers/v1/context/text") return json(res, CONTEXT_TEXT);
+        if (path === "/api/developers/v1/relationships") {
+          return json(res, { ...RELATIONSHIPS.data[0], id: "rel-new" });
+        }
+
+        // POST /v1/records/:id/relationships
+        m = path.match(/^\/api\/developers\/v1\/records\/([^/]+)\/relationships$/);
+        if (m) return json(res, { id: "rel-inst-new" });
+      }
+
+      // ── PUT ─────────────────────────────────────────────────
+      if (method === "PUT") {
+        const body = await readBody(req);
+        const parsed = body ? JSON.parse(body) : {};
+
+        const m = path.match(/^\/api\/developers\/v1\/objects\/([^/]+)$/);
+        if (m) {
+          const name = typeof parsed.attributes?.name === "string" ? parsed.attributes.name : "Upserted";
+          return json(res, {
+            id: "rec-upserted", object_id: "obj-1", workspace_id: "ws-1",
+            type: m[1],
+            attributes: { name: [{ id: "a-up", type: "text", text: name }] },
+            created_at: "2025-01-01T00:00:00Z", updated_at: "2025-01-01T00:00:00Z",
+          });
+        }
+      }
+
+      // ── PATCH ───────────────────────────────────────────────
+      if (method === "PATCH") {
+        const body = await readBody(req);
+        const parsed = body ? JSON.parse(body) : {};
+
+        // PATCH /v1/objects/:slug
+        let m = path.match(/^\/api\/developers\/v1\/objects\/([^/]+)$/);
+        if (m) {
+          const obj = OBJECTS.find((o) => o.slug === m![1]);
+          return obj
+            ? json(res, { ...obj, ...parsed })
+            : json(res, { error: "Not found" }, 404);
+        }
+
+        // PATCH /v1/records/:id
+        m = path.match(/^\/api\/developers\/v1\/records\/([^/]+)$/);
+        if (m) {
+          const rec = RECORDS_BY_ID[m[1]];
+          return rec ? json(res, rec) : json(res, { error: "Not found" }, 404);
+        }
+
+        // PATCH /v1/tasks/:id
+        m = path.match(/^\/api\/developers\/v1\/tasks\/([^/]+)$/);
+        if (m) return json(res, { ...TASK, ...parsed });
+
+        // PATCH /v1/notes/:id
+        m = path.match(/^\/api\/developers\/v1\/notes\/([^/]+)$/);
+        if (m) return json(res, { ...NOTE, ...parsed });
+      }
+
+      // ── DELETE ──────────────────────────────────────────────
+      if (method === "DELETE") {
+        let m = path.match(/^\/api\/developers\/v1\/records\/([^/]+)$/);
+        if (m) return json(res, {});
+
+        m = path.match(/^\/api\/developers\/v1\/objects\/([^/]+)$/);
+        if (m) return json(res, {});
+
+        m = path.match(/^\/api\/developers\/v1\/tasks\/([^/]+)$/);
+        if (m) return json(res, {});
+
+        m = path.match(/^\/api\/developers\/v1\/notes\/([^/]+)$/);
+        if (m) return json(res, {});
+
+        m = path.match(/^\/api\/developers\/v1\/relationships\/([^/]+)$/);
+        if (m) return json(res, {});
+      }
+
+      json(res, { error: "Not found", detail: `No route for ${method} ${path}` }, 404);
+    } catch (err) {
+      json(res, { error: "Internal error", detail: String(err) }, 500);
+    }
+  });
+
+  server.listen(0);
+  const addr = server.address() as { port: number };
+  return {
+    url: `http://localhost:${addr.port}`,
+    close: () => server.close(),
+  };
+}

--- a/cli/tests/integration/note.test.ts
+++ b/cli/tests/integration/note.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { runNex, nexEnv } from "./helpers.js";
+import { startMockServer } from "./mock-server.js";
+
+let env: Record<string, string>;
+let closeMock: () => void;
+
+before(() => {
+  const mock = startMockServer();
+  env = nexEnv(mock.url);
+  closeMock = mock.close;
+});
+
+after(() => closeMock());
+
+describe("note commands", () => {
+  it("note list — returns notes", async () => {
+    const { stdout, exitCode } = await runNex(["note", "list"], { env });
+    assert.equal(exitCode, 0);
+    const data = JSON.parse(stdout);
+    assert.ok(data.data, "should have data array");
+    assert.equal(data.data.length, 1);
+    assert.equal(data.data[0].id, "note-1");
+  });
+
+  it("note get — returns a single note", async () => {
+    const { stdout, exitCode } = await runNex(["note", "get", "note-1"], { env });
+    assert.equal(exitCode, 0);
+    const data = JSON.parse(stdout);
+    assert.equal(data.id, "note-1");
+    assert.ok(data.body, "should have body");
+  });
+
+  it("note create — creates a note", async () => {
+    const { stdout, exitCode } = await runNex(
+      ["note", "create", "--title", "New observation"],
+      { env },
+    );
+    assert.equal(exitCode, 0);
+    const data = JSON.parse(stdout);
+    assert.ok(data.id, "should have an id");
+  });
+
+  it("note update — updates a note", async () => {
+    const { stdout, exitCode } = await runNex(
+      ["note", "update", "note-1", "--title", "Updated note"],
+      { env },
+    );
+    assert.equal(exitCode, 0);
+    const data = JSON.parse(stdout);
+    assert.equal(data.title, "Updated note");
+  });
+
+  it("note delete — deletes a note", async () => {
+    const { stdout, exitCode } = await runNex(["note", "delete", "note-1"], { env });
+    assert.equal(exitCode, 0);
+  });
+});

--- a/cli/tests/integration/object.test.ts
+++ b/cli/tests/integration/object.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { runNex, nexEnv } from "./helpers.js";
+import { startMockServer } from "./mock-server.js";
+
+let env: Record<string, string>;
+let closeMock: () => void;
+
+before(() => {
+  const mock = startMockServer();
+  env = nexEnv(mock.url);
+  closeMock = mock.close;
+});
+
+after(() => closeMock());
+
+describe("object commands", () => {
+  it("object list — returns all objects", async () => {
+    const { stdout, exitCode } = await runNex(["object", "list"], { env });
+    assert.equal(exitCode, 0);
+    const data = JSON.parse(stdout);
+    assert.ok(data.data, "should have data array");
+    assert.equal(data.data.length, 2);
+    assert.equal(data.data[0].slug, "company");
+    assert.equal(data.data[1].slug, "person");
+  });
+
+  it("object get — returns a single object", async () => {
+    const { stdout, exitCode } = await runNex(["object", "get", "company"], { env });
+    assert.equal(exitCode, 0);
+    const data = JSON.parse(stdout);
+    assert.equal(data.slug, "company");
+    assert.equal(data.name, "Company");
+  });
+
+  it("object create — creates an object", async () => {
+    const { stdout, exitCode } = await runNex(
+      ["object", "create", "--name", "Deal", "--slug", "deal", "--type", "deal"],
+      { env },
+    );
+    assert.equal(exitCode, 0);
+    const data = JSON.parse(stdout);
+    assert.ok(data.id, "should have an id");
+    assert.equal(data.slug, "deal");
+  });
+
+  it("object update — updates an object", async () => {
+    const { stdout, exitCode } = await runNex(
+      ["object", "update", "company", "--name", "Companies Updated"],
+      { env },
+    );
+    assert.equal(exitCode, 0);
+    const data = JSON.parse(stdout);
+    assert.equal(data.slug, "company");
+  });
+
+  it("object delete — deletes an object", async () => {
+    const { stdout, exitCode } = await runNex(["object", "delete", "company"], { env });
+    assert.equal(exitCode, 0);
+  });
+});

--- a/cli/tests/integration/output-formats.test.ts
+++ b/cli/tests/integration/output-formats.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { runNex, nexEnv } from "./helpers.js";
+import { startMockServer } from "./mock-server.js";
+
+let env: Record<string, string>;
+let closeMock: () => void;
+
+before(() => {
+  const mock = startMockServer();
+  env = nexEnv(mock.url);
+  closeMock = mock.close;
+});
+
+after(() => closeMock());
+
+describe("output formats", () => {
+  it("--format json — object list returns valid JSON", async () => {
+    const { stdout, exitCode } = await runNex(
+      ["object", "list", "--format", "json"],
+      { env },
+    );
+    assert.equal(exitCode, 0);
+    const data = JSON.parse(stdout);
+    assert.ok(data.data, "should have data");
+  });
+
+  it("--format quiet — produces no stdout", async () => {
+    const { stdout, exitCode } = await runNex(
+      ["object", "list", "--format", "quiet"],
+      { env },
+    );
+    assert.equal(exitCode, 0);
+    assert.equal(stdout, "", "quiet format should produce no output");
+  });
+
+  it("--format text — task list includes readable output", async () => {
+    const { stdout, exitCode } = await runNex(
+      ["task", "list", "--format", "text"],
+      { env },
+    );
+    assert.equal(exitCode, 0);
+    assert.ok(stdout.includes("Fix bug"), "text output should include task title");
+  });
+
+  it("default format — piped output defaults to JSON", async () => {
+    // When stdout is not a TTY (subprocess), default format is JSON
+    const { stdout, exitCode } = await runNex(["object", "list"], { env });
+    assert.equal(exitCode, 0);
+    // Should be valid JSON
+    const data = JSON.parse(stdout);
+    assert.ok(data.data, "default piped output should be JSON");
+  });
+
+  it("--format json — record get returns all fields", async () => {
+    const { stdout, exitCode } = await runNex(
+      ["record", "get", "rec-1", "--format", "json"],
+      { env },
+    );
+    assert.equal(exitCode, 0);
+    const data = JSON.parse(stdout);
+    assert.equal(data.id, "rec-1");
+    assert.ok(data.attributes, "should include attributes");
+  });
+
+  it("--format json — search returns structured results", async () => {
+    const { stdout, exitCode } = await runNex(
+      ["search", "acme", "--format", "json"],
+      { env },
+    );
+    assert.equal(exitCode, 0);
+    const data = JSON.parse(stdout);
+    assert.ok(data.results, "should have results");
+  });
+
+  it("--format text — remember shows success indicator", async () => {
+    const { stdout, exitCode } = await runNex(
+      ["remember", "some fact", "--format", "text"],
+      { env },
+    );
+    assert.equal(exitCode, 0);
+    assert.ok(stdout.length > 0, "text output should not be empty");
+  });
+
+  it("--format json — graph returns nodes and edges", async () => {
+    const { stdout, exitCode } = await runNex(
+      ["graph", "--format", "json", "--no-open"],
+      { env },
+    );
+    assert.equal(exitCode, 0);
+    const data = JSON.parse(stdout);
+    // Graph command outputs path + metadata in json mode
+    assert.ok(data.path || data.total_nodes !== undefined, "should have graph data");
+  });
+});

--- a/cli/tests/integration/record.test.ts
+++ b/cli/tests/integration/record.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { runNex, nexEnv } from "./helpers.js";
+import { startMockServer } from "./mock-server.js";
+
+let env: Record<string, string>;
+let closeMock: () => void;
+
+before(() => {
+  const mock = startMockServer();
+  env = nexEnv(mock.url);
+  closeMock = mock.close;
+});
+
+after(() => closeMock());
+
+describe("record commands", () => {
+  it("record list — returns records for an object", async () => {
+    const { stdout, exitCode } = await runNex(["record", "list", "company"], { env });
+    assert.equal(exitCode, 0);
+    const data = JSON.parse(stdout);
+    assert.ok(data.data, "should have data array");
+    assert.equal(data.data.length, 2);
+    assert.equal(data.data[0].id, "rec-1");
+  });
+
+  it("record get — returns a single record", async () => {
+    const { stdout, exitCode } = await runNex(["record", "get", "rec-1"], { env });
+    assert.equal(exitCode, 0);
+    const data = JSON.parse(stdout);
+    assert.equal(data.id, "rec-1");
+    assert.equal(data.type, "company");
+  });
+
+  it("record create — creates a record", async () => {
+    const { stdout, exitCode } = await runNex(
+      ["record", "create", "company", "--data", '{"name":"TestCo"}'],
+      { env },
+    );
+    assert.equal(exitCode, 0);
+    const data = JSON.parse(stdout);
+    assert.ok(data.id, "should have an id");
+    assert.equal(data.type, "company");
+  });
+
+  it("record upsert — upserts a record", async () => {
+    const { stdout, exitCode } = await runNex(
+      ["record", "upsert", "company", "--match", "domains", "--data", '{"name":"Acme","domains":"acme.com"}'],
+      { env },
+    );
+    assert.equal(exitCode, 0);
+    const data = JSON.parse(stdout);
+    assert.ok(data.id, "should have an id");
+  });
+
+  it("record update — updates a record", async () => {
+    const { stdout, exitCode } = await runNex(
+      ["record", "update", "rec-1", "--data", '{"name":"Updated Corp"}'],
+      { env },
+    );
+    assert.equal(exitCode, 0);
+    const data = JSON.parse(stdout);
+    assert.equal(data.id, "rec-1");
+  });
+
+  it("record delete — deletes a record", async () => {
+    const { stdout, exitCode } = await runNex(["record", "delete", "rec-1"], { env });
+    assert.equal(exitCode, 0);
+  });
+
+  it("record timeline — returns timeline events", async () => {
+    const { stdout, exitCode } = await runNex(["record", "timeline", "rec-1"], { env });
+    assert.equal(exitCode, 0);
+    const data = JSON.parse(stdout);
+    assert.ok(data.events, "should have events");
+    assert.equal(data.events.length, 1);
+    assert.equal(data.events[0].summary, "Record created");
+  });
+});

--- a/cli/tests/integration/search.test.ts
+++ b/cli/tests/integration/search.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { runNex, nexEnv } from "./helpers.js";
+import { startMockServer } from "./mock-server.js";
+
+let env: Record<string, string>;
+let closeMock: () => void;
+
+before(() => {
+  const mock = startMockServer();
+  env = nexEnv(mock.url);
+  closeMock = mock.close;
+});
+
+after(() => closeMock());
+
+describe("search command", () => {
+  it("search — returns matching results as JSON", async () => {
+    const { stdout, exitCode } = await runNex(["search", "acme"], { env });
+    assert.equal(exitCode, 0);
+    const data = JSON.parse(stdout);
+    assert.ok(data.results, "should have results");
+    assert.ok(data.results.length > 0, "should have at least one result");
+    assert.equal(data.results[0].primary_value, "Acme Corp");
+  });
+
+  it("search — text format includes result name", async () => {
+    const { stdout, exitCode } = await runNex(
+      ["search", "acme", "--format", "text"],
+      { env },
+    );
+    assert.equal(exitCode, 0);
+    assert.ok(stdout.includes("Acme Corp"), "output should contain Acme Corp");
+  });
+});

--- a/cli/tests/integration/task.test.ts
+++ b/cli/tests/integration/task.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { runNex, nexEnv } from "./helpers.js";
+import { startMockServer } from "./mock-server.js";
+
+let env: Record<string, string>;
+let closeMock: () => void;
+
+before(() => {
+  const mock = startMockServer();
+  env = nexEnv(mock.url);
+  closeMock = mock.close;
+});
+
+after(() => closeMock());
+
+describe("task commands", () => {
+  it("task list — returns tasks", async () => {
+    const { stdout, exitCode } = await runNex(["task", "list"], { env });
+    assert.equal(exitCode, 0);
+    const data = JSON.parse(stdout);
+    assert.ok(data.data, "should have data array");
+    assert.equal(data.data.length, 1);
+    assert.equal(data.data[0].title, "Fix bug");
+  });
+
+  it("task get — returns a single task", async () => {
+    const { stdout, exitCode } = await runNex(["task", "get", "task-1"], { env });
+    assert.equal(exitCode, 0);
+    const data = JSON.parse(stdout);
+    assert.equal(data.id, "task-1");
+    assert.equal(data.title, "Fix bug");
+  });
+
+  it("task create — creates a task", async () => {
+    const { stdout, exitCode } = await runNex(
+      ["task", "create", "--title", "Ship feature"],
+      { env },
+    );
+    assert.equal(exitCode, 0);
+    const data = JSON.parse(stdout);
+    assert.ok(data.id, "should have an id");
+    assert.equal(data.title, "Ship feature");
+  });
+
+  it("task update — updates a task", async () => {
+    const { stdout, exitCode } = await runNex(
+      ["task", "update", "task-1", "--title", "Fixed bug"],
+      { env },
+    );
+    assert.equal(exitCode, 0);
+    const data = JSON.parse(stdout);
+    assert.equal(data.title, "Fixed bug");
+  });
+
+  it("task delete — deletes a task", async () => {
+    const { stdout, exitCode } = await runNex(["task", "delete", "task-1"], { env });
+    assert.equal(exitCode, 0);
+  });
+});


### PR DESCRIPTION
## Summary
- **41 integration tests** across 8 test files exercising the full Commander CLI surface via subprocess execution (`node --import tsx src/index.ts`) with a `node:http` mock server
- Mock data matches nex-cli test data (Acme Corp, Globex, John Doe) for cross-repo validation
- Tests use `NEX_DEV_URL` + `NEX_API_KEY` env vars to redirect all API calls to the mock

## Test files

| File | Tests | Commands covered |
|---|---|---|
| record.test.ts | 7 | list, get, create, upsert, update, delete, timeline |
| object.test.ts | 5 | list, get, create, update, delete |
| search.test.ts | 2 | JSON + text format |
| task.test.ts | 5 | list, get, create, update, delete |
| context.test.ts | 4 | ask (JSON/text), remember, artifact |
| note.test.ts | 5 | list, get, create, update, delete |
| error-handling.test.ts | 5 | no key, bad key, missing arg/option, unknown cmd |
| output-formats.test.ts | 8 | --format json/quiet/text, piped defaults |

## Infrastructure
- `mock-server.ts` — comprehensive mock with all API routes
- `helpers.ts` — `runNex()` subprocess helper + `nexEnv()` env builder

## Test plan
- [x] `npm test` — all 119 tests pass (78 existing + 41 new), 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)