### PR TITLE
Fix Claude workflow permissions and tool settings

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:
@@ -39,5 +39,19 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          settings: |
+            {
+              "permissions": {
+                "allow": [
+                  "Bash(gh:*)",
+                  "Bash(git diff:*)",
+                  "Bash(git log:*)",
+                  "Bash(git show:*)",
+                  "Read",
+                  "Glob",
+                  "Grep"
+                ]
+              }
+            }
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      actions: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Set `pull-requests: write` and `issues: write` in both `claude-code-review.yml` and `claude.yml` (were set to `read`)
- Add `settings` with tool permissions (`gh`, `git diff/log/show`, `Read`, `Glob`, `Grep`) to the code-review action

## Test plan
- [ ] Verify Claude code review runs on next PR and can post comments
- [ ] Verify `@claude` mentions in issues/PRs trigger the Claude workflow correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)