### PR TITLE
Fix CI: use free OIDC auth instead of API key

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -28,7 +28,6 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,7 +38,5 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-
           additional_permissions: |
             actions: read


### PR DESCRIPTION
## Summary
- Remove `anthropic_api_key` from `claude-code-review.yml` and `claude.yml`
- Public repos get free claude-code-action usage via OIDC (`id-token: write` permission already set)
- The org secret `ANTHROPIC_API_KEY` wasn't scoped to this repo, causing [CI failures](https://github.com/nex-crm/nex-as-a-skill/actions/runs/23271352947/job/67664612549)

## Test plan
- [ ] Verify claude-code-review workflow passes on this PR
- [ ] Verify @claude mentions work in PRs/issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)