### PR TITLE
feat: detect expired/invalid API keys and surface recovery instructions

### DIFF
--- a/cli/src/lib/errors.ts
+++ b/cli/src/lib/errors.ts
@@ -6,7 +6,7 @@
 export class AuthError extends Error {
   public exitCode = 2;
 
-  constructor(message = "No API key configured. Run 'nex setup' or set NEX_API_KEY.") {
+  constructor(message = "API key missing or invalid. Run 'nex register --email <email>' to get a new key, then run 'nex setup'.") {
     super(message);
     this.name = "AuthError";
   }

--- a/cli/src/plugin/nex-client.ts
+++ b/cli/src/plugin/nex-client.ts
@@ -6,7 +6,7 @@
 // --- Error types ---
 
 export class NexAuthError extends Error {
-  constructor(message = "Invalid or missing API key") {
+  constructor(message = "API key expired or invalid. Run 'nex register --email <email>' to get a new key.") {
     super(message);
     this.name = "NexAuthError";
   }

--- a/cli/src/plugin/shared.ts
+++ b/cli/src/plugin/shared.ts
@@ -7,7 +7,7 @@
  */
 
 import { loadConfig, loadScanConfig, ConfigError, isHookEnabled } from "./config.js";
-import { NexClient } from "./nex-client.js";
+import { NexClient, NexAuthError } from "./nex-client.js";
 import { formatNexContext } from "./context-format.js";
 import { captureFilter } from "./capture-filter.js";
 import { SessionStore } from "./session-store.js";
@@ -60,8 +60,18 @@ export async function doRecall(
   const cfg = loadConfig();
   const client = new NexClient(cfg.apiKey, cfg.baseUrl);
 
-  const nexSessionId = sessionKey ? sessions.get(sessionKey) : undefined;
-  const result = await client.ask(trimmed, nexSessionId, 30_000);
+  let result;
+  try {
+    const nexSessionId = sessionKey ? sessions.get(sessionKey) : undefined;
+    result = await client.ask(trimmed, nexSessionId, 30_000);
+  } catch (err) {
+    if (err instanceof NexAuthError) {
+      return {
+        context: "[Nex] API key expired or invalid. Run: nex register --email <email>",
+      };
+    }
+    throw err;
+  }
 
   if (!result.answer) return null;
 
@@ -110,6 +120,12 @@ export async function doCapture(input: CaptureInput): Promise<void> {
         try {
           await client.ingest(filterResult.text, "claude-code-conversation", INGEST_TIMEOUT_MS);
         } catch (err) {
+          if (err instanceof NexAuthError) {
+            process.stderr.write(
+              `[nex-capture] API key expired or invalid. Run 'nex register --email <email>' to get a new key.\n`
+            );
+            return;
+          }
           process.stderr.write(
             `[nex-capture] Ingest failed: ${err instanceof Error ? err.message : String(err)}\n`
           );
@@ -240,7 +256,18 @@ export async function doSessionStart(
     }
   }
 
-  const result = await client.ask(SESSION_START_QUERY, undefined, 30_000);
+  let result;
+  try {
+    result = await client.ask(SESSION_START_QUERY, undefined, 30_000);
+  } catch (err) {
+    if (err instanceof NexAuthError) {
+      return {
+        context: "",
+        registrationPrompt: buildAuthExpiredPrompt(),
+      };
+    }
+    throw err;
+  }
 
   if (!result.answer && contextParts.length === 0) return null;
 
@@ -270,6 +297,19 @@ function buildRegistrationPrompt(): string {
     "",
     "IMPORTANT: Before proceeding with the user's request, you must set up Nex memory:",
     "1. Ask the user for their email address to register for a Nex account",
+    "2. Run: nex register --email <email>",
+    "3. Then run: nex setup",
+    "",
+    "Keep it brief — just ask for the email and register. No restart needed after registration.",
+  ].join("\n");
+}
+
+function buildAuthExpiredPrompt(): string {
+  return [
+    "[Nex Memory Plugin] API key expired or invalid. Re-registration is required to restore persistent memory.",
+    "",
+    "IMPORTANT: Before proceeding with the user's request, you must renew the Nex API key:",
+    "1. Ask the user for their email address",
     "2. Run: nex register --email <email>",
     "3. Then run: nex setup",
     "",

--- a/cli/tests/lib/errors.test.ts
+++ b/cli/tests/lib/errors.test.ts
@@ -12,7 +12,7 @@ describe("AuthError", () => {
 
   test("uses default message when none provided", () => {
     const err = new AuthError();
-    expect(err.message.includes("No API key configured")).toBeTruthy();
+    expect(err.message.includes("API key missing or invalid")).toBeTruthy();
   });
 });
 

--- a/mcp/src/client.ts
+++ b/mcp/src/client.ts
@@ -67,6 +67,12 @@ export class NexApiClient {
       signal: AbortSignal.timeout(120_000),
     });
 
+    if (res.status === 401 || res.status === 403) {
+      throw new NexApiError(res.status, res.statusText, {
+        message: "API key expired or invalid. Run 'nex register --email <email>' to get a new key.",
+      });
+    }
+
     if (!res.ok) {
       let errorBody: unknown;
       try {


### PR DESCRIPTION
## Summary
- Detect 401/403 auth errors across all plugin hooks, CLI client, and MCP server
- Surface clear recovery instructions instead of silently failing

## Changes
- **Plugin `nex-client.ts`**: `NexAuthError` message now includes `nex register --email <email>` instructions
- **Plugin `shared.ts`**: `doRecall()` returns auth error as context so AI agents can guide the user; `doCapture()` warns on stderr; `doSessionStart()` triggers registration prompt
- **CLI `errors.ts`**: `AuthError` message updated with recovery steps
- **MCP `client.ts`**: Explicit 401/403 detection with actionable error

## Before vs After
| Scenario | Before | After |
|----------|--------|-------|
| Expired key in hook | `{}` (silent) | AI agent sees "API key expired. Run: nex register..." |
| Expired key in CLI | Generic "Unauthorized" | "Run 'nex register --email <email>' to get a new key" |
| Expired key in MCP | Generic fetch error | Specific auth error with recovery steps |

## Test plan
- [ ] Expire an API key and verify `doRecall` returns recovery message
- [ ] Verify `doSessionStart` shows registration prompt on auth failure
- [ ] Verify MCP server surfaces auth error clearly

🤖 Generated with [Claude Code](https://claude.com/claude-code)