### PR TITLE
feat: trigger compounding intelligence after scan completes

### DIFF
--- a/cli/src/commands/dispatch.ts
+++ b/cli/src/commands/dispatch.ts
@@ -67,7 +67,7 @@ function ok(data: unknown, ctx: CommandContext, extra?: Partial<CommandResult>):
 async function triggerCompounding(client: NexClient): Promise<void> {
   const jobs = ["consolidation", "pattern_detection", "playbook_synthesis"];
   await Promise.allSettled(
-    jobs.map((job) => client.post("/v1/compounding/trigger", { job_type: job, dry_run: false })),
+    jobs.map((job) => client.post("/v1/compounding/trigger", { job_type: job, dry_run: false }, 10_000)),
   );
 }
 
@@ -1295,7 +1295,7 @@ async function executeScan(args: string[], ctx: CommandContext): Promise<Command
 
     // Trigger compounding intelligence after successful ingestion
     if (!dryRun && result.scanned > 0) {
-      await triggerCompounding(client);
+      triggerCompounding(client).catch(() => {});
     }
 
     return ok({ scanned: result.scanned, skipped: result.skipped, errors: result.errors }, ctx);

--- a/cli/src/commands/dispatch.ts
+++ b/cli/src/commands/dispatch.ts
@@ -60,6 +60,17 @@ function ok(data: unknown, ctx: CommandContext, extra?: Partial<CommandResult>):
   return { output: fmt(data, ctx), data, exitCode: 0, ...extra };
 }
 
+/**
+ * Trigger compounding intelligence jobs (pattern detection, playbook synthesis)
+ * after content ingestion. Runs in the background — errors are non-fatal.
+ */
+async function triggerCompounding(client: NexClient): Promise<void> {
+  const jobs = ["consolidation", "pattern_detection", "playbook_synthesis"];
+  await Promise.allSettled(
+    jobs.map((job) => client.post("/v1/compounding/trigger", { job_type: job, dry_run: false })),
+  );
+}
+
 function fail(error: string, exitCode = 1): CommandResult {
   return { output: "", exitCode, error };
 }
@@ -1281,6 +1292,12 @@ async function executeScan(args: string[], ctx: CommandContext): Promise<Command
     const result = await scanFiles(dir, scanOpts, async (content, context) => {
       return client.post("/v1/context/text", { content, context });
     });
+
+    // Trigger compounding intelligence after successful ingestion
+    if (!dryRun && result.scanned > 0) {
+      await triggerCompounding(client);
+    }
+
     return ok({ scanned: result.scanned, skipped: result.skipped, errors: result.errors }, ctx);
   } catch (err) {
     return wrapError(err);

--- a/cli/src/plugin/shared.ts
+++ b/cli/src/plugin/shared.ts
@@ -6,7 +6,7 @@
  * without duplicating filter/client/format code.
  */
 
-import { loadConfig, loadScanConfig, ConfigError, isHookEnabled } from "./config.js";
+import { loadConfig, loadScanConfig, ConfigError, isHookEnabled, type NexConfig } from "./config.js";
 import { NexClient, NexAuthError } from "./nex-client.js";
 import { formatNexContext } from "./context-format.js";
 import { captureFilter } from "./capture-filter.js";
@@ -249,6 +249,8 @@ export async function doSessionStart(
           contextParts.push(
             `[File scan: ${scanResult.ingested} file${scanResult.ingested === 1 ? "" : "s"} ingested, ${scanResult.scanned} scanned]`
           );
+          // Trigger compounding intelligence after ingestion (non-blocking, best-effort)
+          triggerCompounding(cfg).catch(() => {});
         }
       }
     } catch {
@@ -326,6 +328,26 @@ export async function readStdin(): Promise<string> {
     chunks.push(chunk as Buffer);
   }
   return Buffer.concat(chunks).toString("utf-8");
+}
+
+/**
+ * Trigger compounding intelligence jobs after content ingestion.
+ * Runs consolidation, pattern detection, and playbook synthesis.
+ * Best-effort — errors are silently ignored.
+ */
+async function triggerCompounding(cfg: NexConfig): Promise<void> {
+  const jobs = ["consolidation", "pattern_detection", "playbook_synthesis"];
+  const url = `${cfg.baseUrl}/api/developers/v1/compounding/trigger`;
+  await Promise.allSettled(
+    jobs.map((job) =>
+      fetch(url, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${cfg.apiKey}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ job_type: job, dry_run: false }),
+        signal: AbortSignal.timeout(30_000),
+      }),
+    ),
+  );
 }
 
 /** Wrap output in Claude Code hookSpecificOutput format. */


### PR DESCRIPTION
## Summary
After file ingestion (scan command or session start), automatically trigger compounding intelligence jobs so insights are generated immediately.

## Changes
- **`dispatch.ts`**: `executeScan()` calls `triggerCompounding()` after successful ingestion (skipped for dry-run)
- **`plugin/shared.ts`**: `doSessionStart()` triggers compounding after startup file scan

## Jobs triggered
- `consolidation` — merge and deduplicate insights
- `pattern_detection` — identify recurring patterns across insights
- `playbook_synthesis` — generate playbook rules from detected patterns

All calls are non-blocking and best-effort — errors are silently ignored to avoid disrupting the scan flow.

## Depends on
Core PR #740 (compounding trigger endpoint) must be merged first.

## Test plan
- [ ] Run `nex scan` and verify compounding jobs are triggered (check API logs)
- [ ] Start a new session and verify compounding triggers after file scan
- [ ] Verify dry-run scan does NOT trigger compounding

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic triggering of background compounding intelligence jobs (consolidation, pattern detection, playbook synthesis) after successful file scanning/ingestion or session start. Triggers run in parallel as best-effort background work, are non-blocking, and any failures are contained so they do not affect the main scan/ingest flow or session startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->