### PR TITLE
fix: skip file scanning on session start if recently scanned

### DIFF
--- a/claude-code-plugin/src/auto-scan.ts
+++ b/claude-code-plugin/src/auto-scan.ts
@@ -12,6 +12,7 @@ import { loadConfig, loadScanConfig } from "./config.js";
 import { NexClient } from "./nex-client.js";
 import { RateLimiter } from "./rate-limiter.js";
 import { scanAndIngest } from "./file-scanner.js";
+import { readManifest, markScanned, writeManifest } from "./file-manifest.js";
 
 async function main(): Promise<void> {
   try {
@@ -37,6 +38,11 @@ async function main(): Promise<void> {
 
     console.log(`Scanning ${targetDir} ...`);
     const result = await scanAndIngest(client, rateLimiter, targetDir, scanConfig);
+
+    // Mark scan time so session start can skip if fresh
+    const manifest = readManifest();
+    markScanned(manifest);
+    writeManifest(manifest);
 
     console.log(`Scan complete:`);
     console.log(`  Scanned: ${result.scanned} files`);

--- a/claude-code-plugin/src/auto-session-start.ts
+++ b/claude-code-plugin/src/auto-session-start.ts
@@ -20,6 +20,7 @@ import { SessionStore } from "./session-store.js";
 import { recordRecall } from "./recall-filter.js";
 import { scanAndIngest } from "./file-scanner.js";
 import { ingestContextFiles } from "./context-files.js";
+import { readManifest as readScanManifest, isScanFresh, markScanned, writeManifest as writeScanManifest } from "./file-manifest.js";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
@@ -97,39 +98,52 @@ async function main(): Promise<void> {
     const shouldScan = source === "startup" || source === "clear";
 
     if (shouldScan) {
-      const rateLimiter = new RateLimiter();
-      const cwd = process.cwd();
+      // Skip expensive file scanning if a scan completed recently (within 1 hour).
+      // The context query below still runs — only the file walk + ingest is skipped.
+      const scanManifest = readScanManifest();
+      const scanFresh = isScanFresh(scanManifest);
 
-      // --- Ingest CLAUDE.md + memory files (highest priority) ---
-      try {
-        const ctxResult = await ingestContextFiles(client, rateLimiter, cwd);
-        if (ctxResult.ingested > 0) {
-          contextParts.push(
-            `[Context files: ${ctxResult.ingested} ingested (${ctxResult.files.join(", ")})]`
-          );
-        }
-      } catch (err) {
-        process.stderr.write(
-          `[nex-session-start] Context files error: ${err instanceof Error ? err.message : String(err)}\n`
-        );
-      }
+      if (scanFresh) {
+        process.stderr.write("[nex-session-start] Scan fresh — skipping file scan\n");
+      } else {
+        const rateLimiter = new RateLimiter();
+        const cwd = process.cwd();
 
-      // --- Project file scan ---
-      try {
-        const scanConfig = loadScanConfig();
-        if (scanConfig.enabled) {
-          const scanResult = await scanAndIngest(client, rateLimiter, cwd, scanConfig);
-
-          if (scanResult.ingested > 0) {
+        // --- Ingest CLAUDE.md + memory files (highest priority) ---
+        try {
+          const ctxResult = await ingestContextFiles(client, rateLimiter, cwd);
+          if (ctxResult.ingested > 0) {
             contextParts.push(
-              `[File scan: ${scanResult.ingested} file${scanResult.ingested === 1 ? "" : "s"} ingested, ${scanResult.scanned} scanned]`
+              `[Context files: ${ctxResult.ingested} ingested (${ctxResult.files.join(", ")})]`
             );
           }
+        } catch (err) {
+          process.stderr.write(
+            `[nex-session-start] Context files error: ${err instanceof Error ? err.message : String(err)}\n`
+          );
         }
-      } catch (err) {
-        process.stderr.write(
-          `[nex-session-start] File scan error: ${err instanceof Error ? err.message : String(err)}\n`
-        );
+
+        // --- Project file scan ---
+        try {
+          const scanConfig = loadScanConfig();
+          if (scanConfig.enabled) {
+            const scanResult = await scanAndIngest(client, rateLimiter, cwd, scanConfig);
+
+            if (scanResult.ingested > 0) {
+              contextParts.push(
+                `[File scan: ${scanResult.ingested} file${scanResult.ingested === 1 ? "" : "s"} ingested, ${scanResult.scanned} scanned]`
+              );
+            }
+          }
+        } catch (err) {
+          process.stderr.write(
+            `[nex-session-start] File scan error: ${err instanceof Error ? err.message : String(err)}\n`
+          );
+        }
+
+        // Mark scan as complete so subsequent sessions skip it
+        markScanned(scanManifest);
+        writeScanManifest(scanManifest);
       }
     }
 

--- a/claude-code-plugin/src/file-manifest.ts
+++ b/claude-code-plugin/src/file-manifest.ts
@@ -18,6 +18,7 @@ export interface FileManifestEntry {
 
 export interface FileManifest {
   version: 1;
+  lastScanAt?: number; // Date.now() of last completed scan
   files: Record<string, FileManifestEntry>; // key = absolute path
 }
 
@@ -64,4 +65,22 @@ export function markIngested(
     ingestedAt: Date.now(),
     context,
   };
+}
+
+/**
+ * Record that a full scan completed at this moment.
+ */
+export function markScanned(manifest: FileManifest): void {
+  manifest.lastScanAt = Date.now();
+}
+
+/**
+ * Check if a scan completed recently (within the given window).
+ * Default window: 1 hour.
+ */
+const DEFAULT_SCAN_FRESHNESS_MS = 60 * 60 * 1000; // 1 hour
+
+export function isScanFresh(manifest: FileManifest, windowMs = DEFAULT_SCAN_FRESHNESS_MS): boolean {
+  if (!manifest.lastScanAt) return false;
+  return Date.now() - manifest.lastScanAt < windowMs;
 }

--- a/cli/src/plugin/file-manifest.ts
+++ b/cli/src/plugin/file-manifest.ts
@@ -18,6 +18,7 @@ export interface FileManifestEntry {
 
 export interface FileManifest {
   version: 1;
+  lastScanAt?: number; // Date.now() of last completed scan
   files: Record<string, FileManifestEntry>; // key = absolute path
 }
 
@@ -64,4 +65,22 @@ export function markIngested(
     ingestedAt: Date.now(),
     context,
   };
+}
+
+/**
+ * Record that a full scan completed at this moment.
+ */
+export function markScanned(manifest: FileManifest): void {
+  manifest.lastScanAt = Date.now();
+}
+
+/**
+ * Check if a scan completed recently (within the given window).
+ * Default window: 1 hour.
+ */
+const DEFAULT_SCAN_FRESHNESS_MS = 60 * 60 * 1000; // 1 hour
+
+export function isScanFresh(manifest: FileManifest, windowMs = DEFAULT_SCAN_FRESHNESS_MS): boolean {
+  if (!manifest.lastScanAt) return false;
+  return Date.now() - manifest.lastScanAt < windowMs;
 }

--- a/cli/src/plugin/shared.ts
+++ b/cli/src/plugin/shared.ts
@@ -15,7 +15,7 @@ import { shouldRecall, recordRecall } from "./recall-filter.js";
 import { RateLimiter } from "./rate-limiter.js";
 import { scanAndIngest } from "./file-scanner.js";
 import { ingestContextFiles } from "./context-files.js";
-import { readManifest, writeManifest, isChanged, markIngested } from "./file-manifest.js";
+import { readManifest, writeManifest, isChanged, markIngested, isScanFresh, markScanned } from "./file-manifest.js";
 import { readdirSync, statSync, readFileSync } from "node:fs";
 import { join, extname } from "node:path";
 import { homedir } from "node:os";
@@ -304,34 +304,45 @@ export async function doSessionStart(
   // File scan on startup or clear
   const shouldScan = source === "startup" || source === "clear";
   if (shouldScan) {
-    const rateLimiter = new RateLimiter();
-    const cwd = process.cwd();
+    // Skip expensive file scanning if a scan completed recently (within 1 hour).
+    // The context query below still runs — only the file walk + ingest is skipped.
+    const scanManifest = readManifest();
+    const scanFresh = isScanFresh(scanManifest);
 
-    try {
-      const ctxResult = await ingestContextFiles(client, rateLimiter, cwd);
-      if (ctxResult.ingested > 0) {
-        contextParts.push(
-          `[Context files: ${ctxResult.ingested} ingested (${ctxResult.files.join(", ")})]`
-        );
-      }
-    } catch {
-      // non-fatal
-    }
+    if (!scanFresh) {
+      const rateLimiter = new RateLimiter();
+      const cwd = process.cwd();
 
-    try {
-      const scanConfig = loadScanConfig();
-      if (scanConfig.enabled) {
-        const scanResult = await scanAndIngest(client, rateLimiter, cwd, scanConfig);
-        if (scanResult.ingested > 0) {
+      try {
+        const ctxResult = await ingestContextFiles(client, rateLimiter, cwd);
+        if (ctxResult.ingested > 0) {
           contextParts.push(
-            `[File scan: ${scanResult.ingested} file${scanResult.ingested === 1 ? "" : "s"} ingested, ${scanResult.scanned} scanned]`
+            `[Context files: ${ctxResult.ingested} ingested (${ctxResult.files.join(", ")})]`
           );
-          // Trigger compounding intelligence after ingestion (non-blocking, best-effort)
-          triggerCompounding(cfg).catch(() => {});
         }
+      } catch {
+        // non-fatal
       }
-    } catch {
-      // non-fatal
+
+      try {
+        const scanConfig = loadScanConfig();
+        if (scanConfig.enabled) {
+          const scanResult = await scanAndIngest(client, rateLimiter, cwd, scanConfig);
+          if (scanResult.ingested > 0) {
+            contextParts.push(
+              `[File scan: ${scanResult.ingested} file${scanResult.ingested === 1 ? "" : "s"} ingested, ${scanResult.scanned} scanned]`
+            );
+            // Trigger compounding intelligence after ingestion (non-blocking, best-effort)
+            triggerCompounding(cfg).catch(() => {});
+          }
+        }
+      } catch {
+        // non-fatal
+      }
+
+      // Mark scan as complete so subsequent sessions skip it
+      markScanned(scanManifest);
+      writeManifest(scanManifest);
     }
   }
 

--- a/mcp/src/file-manifest.ts
+++ b/mcp/src/file-manifest.ts
@@ -20,6 +20,7 @@ export interface FileManifestEntry {
 
 export interface FileManifest {
   version: 1;
+  lastScanAt?: number; // Date.now() of last completed scan
   files: Record<string, FileManifestEntry>;
 }
 
@@ -58,4 +59,22 @@ export function markIngested(path: string, stat: Stats, context: string, manifes
     ingestedAt: Date.now(),
     context,
   };
+}
+
+/**
+ * Record that a full scan completed at this moment.
+ */
+export function markScanned(manifest: FileManifest): void {
+  manifest.lastScanAt = Date.now();
+}
+
+/**
+ * Check if a scan completed recently (within the given window).
+ * Default window: 1 hour.
+ */
+const DEFAULT_SCAN_FRESHNESS_MS = 60 * 60 * 1000; // 1 hour
+
+export function isScanFresh(manifest: FileManifest, windowMs = DEFAULT_SCAN_FRESHNESS_MS): boolean {
+  if (!manifest.lastScanAt) return false;
+  return Date.now() - manifest.lastScanAt < windowMs;
 }

--- a/mcp/src/tools/scan.ts
+++ b/mcp/src/tools/scan.ts
@@ -4,6 +4,7 @@ import { NexApiClient } from "../client.js";
 import { RateLimiter } from "../rate-limiter.js";
 import { scanAndIngest } from "../file-scanner.js";
 import { ingestContextFiles } from "../context-files.js";
+import { readManifest, markScanned, writeManifest } from "../file-manifest.js";
 
 const rateLimiter = new RateLimiter();
 
@@ -28,6 +29,12 @@ export function registerScanTools(server: McpServer, client: NexApiClient) {
       };
       const cwd = directory || process.cwd();
       const result = await scanAndIngest(client, rateLimiter, cwd, scanConfig);
+
+      // Mark scan time so session start can skip if fresh
+      const manifest = readManifest();
+      markScanned(manifest);
+      writeManifest(manifest);
+
       return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
     },
   );


### PR DESCRIPTION
## Summary
- **Root cause:** SessionStart hook was synchronous (no `async: true`), blocking Claude for up to 70s while scanning files + making API calls
- **Fix:** Added `lastScanAt` tracking to file manifest. Session start now skips file walk + ingest if a scan completed within the last hour. Context query still runs every session (~1-2s).
- **Scope:** Applied across all 3 packages (claude-code-plugin, cli plugin, mcp server)

## Test plan
- [ ] Start a new Claude session — verify first session scans normally
- [ ] Start another session within 1 hour — verify scan is skipped (check stderr for "Scan fresh — skipping file scan")
- [ ] Run `nex scan` or `nex setup` — verify it resets the freshness timer
- [ ] Start session after 1+ hours — verify scan runs again

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sessions now track and intelligently reuse recently completed file scans (within the last hour), automatically skipping redundant file processing during startup for improved performance.

* **Performance**
  * Faster startup times and reduced resource consumption. The system maintains a record of scan completion across sessions, preventing unnecessary file re-processing while keeping project context current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->