### PR TITLE
feat(mcp): notification channel for daily digests and proactive alerts

### DIFF
--- a/docs/superpowers/specs/2026-03-22-workspace-management-design.md
+++ b/docs/superpowers/specs/2026-03-22-workspace-management-design.md
@@ -1,0 +1,412 @@
+# Workspace Management — Design Spec
+
+**Date:** 2026-03-22
+**Status:** Draft
+**Scope:** `nex workspace` CLI command + storage migration + auto-registration
+
+---
+
+## Problem
+
+Users with multiple Nex workspaces (e.g., personal + team) on the same machine must re-run `nex setup` with a different email to switch. This overwrites the current config, losing the previous workspace's credentials and state. There's no way to list, switch between, or label workspaces.
+
+## Solution
+
+Add `nex workspace` subcommands backed by per-workspace isolated storage. Migrate from the current flat `~/.nex/config.json` to a workspace-aware directory structure. Auto-register workspaces during `nex register` and `nex setup`.
+
+---
+
+## Architecture
+
+### Storage Layout
+
+```
+~/.nex/
+  config.json                          # Global config: active_workspace pointer + settings
+  workspaces/
+    <slug>/                            # One directory per workspace
+      credentials.json                 # api_key, email, workspace_id, workspace_slug
+      file-scan-manifest.json          # Scan state (shared across plugin contexts)
+      claude-sessions.json             # Claude Code plugin session mappings
+      mcp-sessions.json                # MCP server session mappings
+      cli-sessions.json                # CLI session mappings
+      recall-state.json                # Recall debounce state
+      rate-limiter.json                # API rate limiter state (shared)
+```
+
+**Note:** `file-scan-manifest.json`, `rate-limiter.json`, and `recall-state.json` are intentionally shared across plugin contexts (claude-code-plugin, cli plugin, mcp) within the same workspace — they track the same workspace's API quota and ingested files. Session files are per-plugin because each plugin tracks its own session mappings.
+
+### `config.json` (new format)
+
+```json
+{
+  "active_workspace": "cli_nazz_f96292",
+  "workspaces": {
+    "cli_nazz_f96292": {
+      "nickname": "personal",
+      "added_at": 1711100000000
+    },
+    "cli_team_nex_ai": {
+      "nickname": "Nex AI Team",
+      "added_at": 1711200000000
+    }
+  },
+  "default_format": "text",
+  "default_timeout": 120000
+}
+```
+
+- `active_workspace` — slug of the currently active workspace
+- `workspaces` — registry of all known workspaces with local metadata (nickname, timestamp)
+- Global settings (`default_format`, `default_timeout`) remain at the top level
+- Credentials move out of `config.json` into `workspaces/<slug>/credentials.json`
+
+### `credentials.json` (per workspace)
+
+```json
+{
+  "api_key": "sk-...",
+  "email": "nazz@gmail.com",
+  "workspace_id": "62866327953583100",
+  "workspace_slug": "cli_nazz_f96292"
+}
+```
+
+---
+
+## Migration
+
+Migration runs once, triggered explicitly by `loadRegistry()`. It is idempotent — if `config.json` already has `active_workspace`, migration is skipped.
+
+**Important:** `loadRegistry()` must NOT be called at module import time. It is called lazily by `resolveApiKey()`, `getActiveCredentials()`, and workspace commands. This avoids triggering file system writes as a side effect of module imports (the current `loadConfig()` is called at import time for `BASE_URL` — that call remains unchanged and does not go through the registry).
+
+### Step 1: Detect migration trigger
+
+If `~/.nex/config.json` contains `api_key` at the top level → migrate.
+
+### Step 2: Migrate `~/.nex/config.json`
+
+1. Read existing `api_key`, `email`, `workspace_id`, `workspace_slug` from `config.json`
+2. Create `~/.nex/workspaces/<workspace_slug>/credentials.json` with those fields
+3. Move existing state files into `~/.nex/workspaces/<workspace_slug>/`:
+   - `file-scan-manifest.json`
+   - `claude-sessions.json`, `mcp-sessions.json`, `cli-sessions.json` (whichever exist)
+   - `recall-state.json`
+   - `rate-limiter.json`
+4. Rewrite `config.json` to the new format with `active_workspace` set to the migrated slug
+5. Preserve global settings (`default_format`, `default_timeout`, `llm_provider`, `dev_url`, `gemini_api_key`, etc.) at the top level
+
+### Step 3: Migrate `~/.nex-mcp.json` (legacy plugin config)
+
+The `claude-code-plugin` and `cli/src/plugin` packages read credentials from `~/.nex-mcp.json`. This file may contain a different API key than `~/.nex/config.json` if the user registered via the plugin's `/register` slash command.
+
+1. If `~/.nex-mcp.json` exists and contains an `api_key`:
+   - If its `workspace_slug` matches an already-migrated workspace → update credentials if the `api_key` is newer (higher `ingestedAt` or just overwrite — the most recent registration is authoritative)
+   - If its `workspace_slug` is different → add as a second workspace entry
+2. After migration, delete `~/.nex-mcp.json` (or rename to `~/.nex-mcp.json.bak` for safety)
+3. Update `auto-register.ts` (both copies) to persist via `addWorkspace()` instead of writing to `~/.nex-mcp.json`
+
+---
+
+## Components
+
+### 1. Workspace Registry (`cli/src/lib/workspace-registry.ts`)
+
+Core data layer. No UI, no side effects beyond file I/O.
+
+```typescript
+interface WorkspaceEntry {
+  slug: string;
+  nickname?: string;
+  added_at: number;
+}
+
+interface WorkspaceCredentials {
+  api_key: string;
+  email: string;
+  workspace_id: string;
+  workspace_slug: string;
+}
+
+interface WorkspaceRegistry {
+  active_workspace: string;
+  workspaces: Record<string, { nickname?: string; added_at: number }>;
+}
+```
+
+**Functions:**
+
+| Function | Purpose |
+|----------|---------|
+| `loadRegistry(): WorkspaceRegistry` | Load config.json, run migration if needed |
+| `saveRegistry(registry)` | Write config.json |
+| `addWorkspace(slug, credentials, nickname?)` | Create workspace dir + credentials, add to registry |
+| `removeWorkspace(slug)` | Remove workspace dir and registry entry |
+| `switchWorkspace(slug)` | Set `active_workspace`, return credentials |
+| `renameWorkspace(slug, nickname)` | Update nickname in registry |
+| `getActiveCredentials(): WorkspaceCredentials` | Load credentials for active workspace |
+| `listWorkspaces(): WorkspaceEntry[]` | Return all workspaces sorted by added_at |
+| `migrateIfNeeded()` | One-time migration from flat config |
+
+### 2. Config Integration
+
+`resolveApiKey()` in `cli/src/lib/config.ts` changes to:
+
+```
+Priority: CLI flag → NEX_API_KEY env var → active workspace credentials → undefined
+```
+
+`loadConfig()` returns the active workspace's credentials merged with global settings. All existing callers work unchanged.
+
+### 3. Plugin Config Integration
+
+`claude-code-plugin/src/config.ts` and `cli/src/plugin/config.ts` currently read from `~/.nex-mcp.json` and `~/.nex/config.json`. Updated to:
+
+```
+Priority: NEX_API_KEY env var → active workspace credentials (via registry) → legacy fallback
+```
+
+State file paths (`readManifest`, `SessionStore`, `RateLimiter`, `RecallFilter`) updated to resolve from `~/.nex/workspaces/<active_slug>/` instead of `~/.nex/`.
+
+### 4. Workspace Picker (`cli/src/commands/workspace.ts`)
+
+Interactive UI using the raw stdin pattern from `nex integrate list`. Not an Ink/React component — direct ANSI rendering with raw mode input for maximum control.
+
+**Render:**
+
+```
+  Workspaces                                       (q to exit)
+  ─────────────────────────────────────────────────
+
+  ● personal (cli_nazz_f96292)
+    nazz@gmail.com
+
+    Nex AI Team (cli_team_nex_ai)
+    najmuzzaman@nex.ai
+
+  [↑↓] navigate  [enter] switch  [r] rename  [d] delete
+```
+
+**State machine:**
+
+```
+normal → (enter) → switch workspace, exit
+normal → (r) → renaming mode (inline text input replaces nickname)
+normal → (d) → confirming-delete mode ("Remove <name>? y/n")
+normal → (q / Ctrl+C) → exit
+renaming → (enter) → commit rename, back to normal
+renaming → (esc) → cancel, back to normal
+confirming-delete → (y) → remove workspace, back to normal
+confirming-delete → (n / esc) → cancel, back to normal
+```
+
+**Active workspace indicator:** `●` (green) for active, blank for inactive.
+
+**Delete guard:** Cannot delete the active workspace. Show error inline: "Cannot remove active workspace. Switch first."
+
+### 5. Commander Registration
+
+```typescript
+program
+  .command("workspace")
+  .description("Manage workspaces")
+  .addCommand(
+    new Command("list").description("Interactive workspace manager").action(workspaceList)
+  )
+  .addCommand(
+    new Command("switch")
+      .description("Switch active workspace")
+      .argument("[slug]", "Workspace slug or nickname")
+      .action(workspaceSwitch)
+  )
+  .addCommand(
+    new Command("rename")
+      .description("Rename a workspace")
+      .argument("<slug>", "Workspace slug or nickname")
+      .argument("<name>", "New nickname")
+      .action(workspaceRename)
+  )
+  .addCommand(
+    new Command("current").description("Show active workspace").action(workspaceCurrent)
+  );
+```
+
+`workspace` added to `INTERACTIVE_COMMANDS` set in `cli/src/index.ts`.
+
+### 6. Auto-Registration
+
+**`nex register`:** After successful registration, call `addWorkspace(slug, credentials)`. If workspace already exists (re-registration), update credentials only.
+
+**`nex setup`:** Same — after registration or re-authentication step, call `addWorkspace()`. If the user is re-authenticating an existing workspace, update credentials in place.
+
+---
+
+## Command Behaviors
+
+### `nex workspace list`
+
+- Interactive picker (raw stdin, full-screen)
+- Shows all workspaces with nickname, slug, email, active indicator
+- Keybindings: navigate, switch, rename, delete
+- Non-TTY fallback: print plain list and exit
+
+### `nex workspace switch [slug]`
+
+- With argument: switch immediately, print confirmation
+- Without argument: launch interactive picker (same as `workspace list` but enter switches)
+- Accepts slug or nickname. Resolution order: exact slug match → exact nickname match (case-insensitive) → error. No fuzzy matching — ambiguity is worse than requiring the user to be specific.
+
+### `nex workspace rename <slug> <name>`
+
+- Direct rename, no interactive UI
+- Accepts slug or nickname for the first argument
+- Print confirmation
+
+### `nex workspace current`
+
+- Print: nickname, slug, email, workspace_id
+- Non-interactive, suitable for scripts
+
+---
+
+## State File Resolution
+
+All state file readers/writers need a workspace-aware path resolver:
+
+```typescript
+// Cached at module level after first resolution — avoids re-reading config.json on every call.
+let _cachedDataDir: string | undefined;
+
+export function workspaceDataDir(slug?: string): string {
+  if (slug) {
+    return join(homedir(), ".nex", "workspaces", slug);
+  }
+  if (!_cachedDataDir) {
+    const registry = loadRegistry();
+    _cachedDataDir = join(homedir(), ".nex", "workspaces", registry.active_workspace);
+  }
+  return _cachedDataDir;
+}
+```
+
+The active workspace slug is cached after first resolution. This is safe because a process (hook or CLI command) never switches workspaces mid-execution.
+
+**Refactoring state modules:**
+
+`session-store.ts` and `rate-limiter.ts` already accept a `dataDir` option in their constructors — pass `workspaceDataDir()`.
+
+`file-manifest.ts` and `recall-filter.ts` use module-level `const` paths. Refactor to lazy functions:
+
+```typescript
+// Before:
+const MANIFEST_PATH = join(DATA_DIR, "file-scan-manifest.json");
+
+// After:
+function manifestPath(): string {
+  return join(workspaceDataDir(), "file-scan-manifest.json");
+}
+```
+
+Affected modules (in all 3 packages):
+- `file-manifest.ts` — `MANIFEST_PATH` → `manifestPath()`
+- `session-store.ts` — pass `workspaceDataDir()` to constructor
+- `rate-limiter.ts` — pass `workspaceDataDir()` to constructor
+- `recall-filter.ts` — `STATE_PATH` → lazy function
+
+---
+
+## Edge Cases
+
+1. **No workspaces registered:** `loadRegistry()` returns empty. `getActiveCredentials()` returns undefined. Same behavior as current "no API key" path — hooks show registration prompt.
+
+2. **Active workspace deleted externally:** If `active_workspace` points to a missing directory, fall back to first available workspace or undefined.
+
+3. **Legacy installs:** Migration handles the transition. Users who never registered have an empty config and see the registration prompt as before.
+
+4. **Concurrent hook access:** Multiple hooks may read state files simultaneously. File writes are atomic (write-to-temp + rename) in the manifest module already.
+
+5. **Nickname collisions:** Allowed — nicknames are display-only labels, not identifiers. Slug is the canonical key.
+
+6. **Removing the last workspace:** Allowed. Leaves the user with zero workspaces and no credentials. `getActiveCredentials()` returns undefined, hooks show registration prompt. Same UX as a fresh install.
+
+7. **Non-TTY output for `workspace list`:** Uses `resolveFormat()` like other commands. Default non-TTY format is JSON. Example: `[{"slug":"cli_nazz_f96292","nickname":"personal","email":"nazz@gmail.com","active":true}]`
+
+---
+
+## Testing
+
+### Unit Tests (`cli/tests/lib/workspace-registry.test.ts`)
+
+- Migration from flat config → workspace structure
+- Add/remove/switch/rename workspace operations
+- `getActiveCredentials()` resolves correctly
+- Edge cases: missing dirs, empty registry, re-registration
+
+### Integration Tests (`cli/tests/integration/workspace.test.ts`)
+
+- `nex workspace current` outputs active workspace info
+- `nex workspace switch <slug>` changes active workspace
+- `nex workspace rename <slug> <name>` updates nickname
+- Unknown slug exits with error
+
+### Manual Test Plan
+
+1. Fresh install → `nex register` → verify workspace created in `~/.nex/workspaces/`
+2. Register second workspace with different email → verify both in `nex workspace list`
+3. Switch between workspaces → verify `nex workspace current` changes
+4. Rename workspace → verify picker shows new nickname
+5. Delete non-active workspace → verify removal
+6. Try deleting active workspace → verify error
+7. Start Claude Code session → verify hooks use active workspace's credentials and state
+
+---
+
+## Files Changed
+
+### New Files
+- `cli/src/lib/workspace-registry.ts` — Registry data layer
+- `cli/src/commands/workspace.ts` — Commander commands + interactive picker
+- `cli/tests/lib/workspace-registry.test.ts` — Unit tests
+- `cli/tests/integration/workspace.test.ts` — Integration tests
+
+### Modified Files
+
+**CLI core:**
+- `cli/src/lib/config.ts` — `resolveApiKey()` uses registry; `loadConfig()` merges active credentials with global settings. `BASE_URL` resolution unchanged (stays at import time, no registry call).
+- `cli/src/index.ts` — Add `workspace` to `INTERACTIVE_COMMANDS`
+- `cli/src/commands/register.ts` — Auto-add to registry after registration
+- `cli/src/commands/setup.ts` — Auto-add to registry after setup
+
+**claude-code-plugin (5 files):**
+- `claude-code-plugin/src/config.ts` — Workspace-aware credential loading, remove `~/.nex-mcp.json` reads
+- `claude-code-plugin/src/auto-register.ts` — Persist via `addWorkspace()` instead of `~/.nex-mcp.json`
+- `claude-code-plugin/src/file-manifest.ts` — Workspace-aware paths (lazy function)
+- `claude-code-plugin/src/session-store.ts` — Pass `workspaceDataDir()` to constructor
+- `claude-code-plugin/src/rate-limiter.ts` — Pass `workspaceDataDir()` to constructor
+- `claude-code-plugin/src/recall-filter.ts` — Workspace-aware paths (lazy function)
+
+**cli/src/plugin (synced copy of claude-code-plugin — same changes):**
+- `cli/src/plugin/config.ts`
+- `cli/src/plugin/auto-register.ts`
+- `cli/src/plugin/file-manifest.ts`
+- `cli/src/plugin/session-store.ts`
+- `cli/src/plugin/rate-limiter.ts`
+- `cli/src/plugin/recall-filter.ts`
+
+**MCP server (4 files):**
+- `mcp/src/config.ts` — Workspace-aware credential loading
+- `mcp/src/file-manifest.ts` — Workspace-aware paths
+- `mcp/src/session-store.ts` — Workspace-aware paths
+- `mcp/src/rate-limiter.ts` — Workspace-aware paths
+
+**Unaffected:**
+- `openclaw-plugin/` — Uses in-memory state and receives API key via plugin config injection, not file system. No changes needed.
+
+---
+
+## Non-Goals
+
+- Server-side workspace management (create/delete workspaces via API)
+- Multi-workspace concurrent access (only one active at a time)
+- Workspace-specific `.nex.toml` overrides (project config stays project-level)
+- Team member invite flow (separate feature)

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,0 +1,1202 @@
+{
+  "name": "@nex-ai/mcp-server",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@nex-ai/mcp-server",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.0",
+        "zod": "^3.25.0"
+      },
+      "bin": {
+        "nex-mcp": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "@types/node": "^22.0.0",
+        "typescript": "^5.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@types/bun": {
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/@types/bun/-/bun-1.3.11.tgz",
+      "integrity": "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bun-types": "1.3.11"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bun-types": {
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.3.11.tgz",
+      "integrity": "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.8",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
+      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
+      }
+    }
+  }
+}

--- a/mcp/src/channel.ts
+++ b/mcp/src/channel.ts
@@ -1,0 +1,218 @@
+/**
+ * Nex Channel — pushes daily digests and proactive notifications
+ * into active Claude Code sessions via the Channels API.
+ *
+ * Uses the existing Nex API client to query context and insights,
+ * then forwards results as channel notifications.
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { NexApiClient } from "./client.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface ChannelState {
+  lastDigestAt: number;        // epoch ms — last daily digest push
+  lastNotifyCheckAt: number;   // epoch ms — last proactive notification poll
+}
+
+/**
+ * Minimal interface for the underlying MCP Server's notification method.
+ * We use this instead of importing the full Server type to avoid coupling
+ * to the SDK's internal type hierarchy.
+ */
+interface NotificationSender {
+  notification(notification: {
+    method: string;
+    params?: Record<string, unknown>;
+  }): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const STATE_DIR = join(homedir(), ".nex");
+const STATE_PATH = join(STATE_DIR, "channel-state.json");
+
+/** How often to check whether a daily digest is due (1 hour). */
+const DIGEST_CHECK_INTERVAL_MS = 60 * 60 * 1000;
+
+/** Minimum gap between daily digests (24 hours). */
+const DIGEST_COOLDOWN_MS = 24 * 60 * 60 * 1000;
+
+/** How often to poll for proactive notifications (5 minutes). */
+const NOTIFY_INTERVAL_MS = 5 * 60 * 1000;
+
+/** Delay before the first digest check after startup (10 seconds). */
+const INITIAL_DIGEST_DELAY_MS = 10_000;
+
+/** Delay before the first notification check after startup (15 seconds). */
+const INITIAL_NOTIFY_DELAY_MS = 15_000;
+
+// ---------------------------------------------------------------------------
+// State persistence
+// ---------------------------------------------------------------------------
+
+function loadState(): ChannelState {
+  try {
+    if (existsSync(STATE_PATH)) {
+      return JSON.parse(readFileSync(STATE_PATH, "utf-8"));
+    }
+  } catch {
+    // Corrupted or unreadable — start fresh
+  }
+  return { lastDigestAt: 0, lastNotifyCheckAt: 0 };
+}
+
+function saveState(state: ChannelState): void {
+  try {
+    if (!existsSync(STATE_DIR)) mkdirSync(STATE_DIR, { recursive: true });
+    writeFileSync(STATE_PATH, JSON.stringify(state));
+  } catch {
+    // Best-effort — don't crash if write fails
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Push helper
+// ---------------------------------------------------------------------------
+
+async function pushChannelEvent(
+  server: NotificationSender,
+  content: string,
+  meta: Record<string, string> = {},
+): Promise<void> {
+  await server.notification({
+    method: "notifications/claude/channel",
+    params: { content, meta },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Digest logic
+// ---------------------------------------------------------------------------
+
+async function checkDigest(
+  server: NotificationSender,
+  client: NexApiClient,
+  state: ChannelState,
+): Promise<void> {
+  const now = Date.now();
+  if (now - state.lastDigestAt < DIGEST_COOLDOWN_MS) return;
+
+  try {
+    const result = (await client.post("/v1/context/ask", {
+      query:
+        "Provide a comprehensive daily digest: summarize all key context " +
+        "collected in the last 24 hours, including important updates, new " +
+        "relationships, deal changes, upcoming events, and any actionable " +
+        "items. Be specific with names, dates, and numbers.",
+    })) as { answer?: string };
+
+    if (result.answer && result.answer.trim().length > 0) {
+      await pushChannelEvent(server, result.answer, {
+        type: "daily_digest",
+        period: "24h",
+      });
+      state.lastDigestAt = now;
+      saveState(state);
+    }
+  } catch (err) {
+    console.error("[nex-channel] digest check failed:", err);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Proactive notification logic
+// ---------------------------------------------------------------------------
+
+async function checkNotifications(
+  server: NotificationSender,
+  client: NexApiClient,
+  state: ChannelState,
+): Promise<void> {
+  const now = Date.now();
+
+  try {
+    const lastCheck = state.lastNotifyCheckAt || now - NOTIFY_INTERVAL_MS;
+    const minutesSinceLastCheck = Math.max(
+      5,
+      Math.ceil((now - lastCheck) / 60_000),
+    );
+
+    const result = (await client.get(
+      `/v1/insights?last=${minutesSinceLastCheck}m&limit=10`,
+    )) as {
+      insights?: Array<{
+        content?: string;
+        type?: string;
+        importance?: string;
+      }>;
+    };
+
+    state.lastNotifyCheckAt = now;
+    saveState(state);
+
+    if (result.insights && result.insights.length > 0) {
+      const summary = result.insights
+        .map(
+          (i) =>
+            `- [${i.type || "update"}${i.importance ? ` | ${i.importance}` : ""}] ${i.content || JSON.stringify(i)}`,
+        )
+        .join("\n");
+
+      await pushChannelEvent(server, summary, {
+        type: "proactive_notification",
+        count: String(result.insights.length),
+      });
+    }
+  } catch (err) {
+    console.error("[nex-channel] notification check failed:", err);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Start the Nex notification channel. Call this after the MCP server
+ * has connected to its transport.
+ *
+ * @param server  The underlying MCP `Server` instance (mcpServer.server)
+ * @param client  An authenticated NexApiClient
+ */
+export function startChannel(
+  server: NotificationSender,
+  client: NexApiClient,
+): void {
+  if (!client.isAuthenticated) return;
+
+  const state = loadState();
+
+  // --- Daily digest ---
+  // Initial check after a short delay to let the session settle
+  setTimeout(() => checkDigest(server, client, state), INITIAL_DIGEST_DELAY_MS);
+  // Then check hourly (only fires digest if 24h have passed)
+  setInterval(
+    () => checkDigest(server, client, state),
+    DIGEST_CHECK_INTERVAL_MS,
+  );
+
+  // --- Proactive notifications ---
+  setTimeout(
+    () => checkNotifications(server, client, state),
+    INITIAL_NOTIFY_DELAY_MS,
+  );
+  setInterval(
+    () => checkNotifications(server, client, state),
+    NOTIFY_INTERVAL_MS,
+  );
+
+  console.error("[nex-channel] started (digest: 24h, notifications: 5m)");
+}

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -5,6 +5,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { createServer } from "./server.js";
 import { createServer as createHttpServer } from "node:http";
 import { loadApiKey } from "./config.js";
+import { startChannel } from "./channel.js";
 
 const apiKey = loadApiKey();
 if (!apiKey) {
@@ -14,7 +15,7 @@ if (!apiKey) {
 const transport = process.env.MCP_TRANSPORT ?? "stdio";
 
 async function main() {
-  const server = createServer(apiKey);
+  const { server, client } = createServer(apiKey);
 
   if (transport === "http") {
     const port = parseInt(process.env.MCP_PORT ?? "3001", 10);
@@ -37,12 +38,14 @@ async function main() {
     });
 
     await server.connect(httpTransport);
+    startChannel(server.server, client);
     httpServer.listen(port, () => {
       console.error(`Nex MCP server running on http://localhost:${port}/mcp`);
     });
   } else {
     const stdioTransport = new StdioServerTransport();
     await server.connect(stdioTransport);
+    startChannel(server.server, client);
     console.error("Nex MCP server running on stdio");
   }
 }

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -13,11 +13,25 @@ import { registerRegistrationTools } from "./tools/register.js";
 import { registerScanTools } from "./tools/scan.js";
 import { registerIntegrationTools } from "./tools/integrations.js";
 
-export function createServer(apiKey?: string): McpServer {
-  const server = new McpServer({
-    name: "nex",
-    version: "0.1.0",
-  });
+export function createServer(apiKey?: string): {
+  server: McpServer;
+  client: NexApiClient;
+} {
+  const server = new McpServer(
+    { name: "nex", version: "0.1.0" },
+    {
+      capabilities: {
+        experimental: { "claude/channel": {} },
+      },
+      instructions:
+        'Events from the nex channel arrive as <channel source="nex" type="...">. ' +
+        "They contain daily digest summaries (type=daily_digest) and proactive " +
+        "notifications (type=proactive_notification) about important context " +
+        "changes — deals, meetings, relationships, tasks. These are one-way " +
+        "informational: acknowledge them naturally and incorporate into your " +
+        "awareness. No reply expected.",
+    },
+  );
 
   const client = new NexApiClient(apiKey);
 
@@ -34,5 +48,5 @@ export function createServer(apiKey?: string): McpServer {
   registerScanTools(server, client);
   registerIntegrationTools(server, client);
 
-  return server;
+  return { server, client };
 }


### PR DESCRIPTION
## Summary
- Extends the existing `@nex-ai/mcp-server` with Claude SDK Channels capability (`claude/channel`)
- Pushes **daily context digests** (queries Nex context graph every 24h) into active Claude Code sessions as `<channel>` events
- Pushes **proactive notifications** (polls `/v1/insights` every 5 minutes) for deal changes, relationship updates, upcoming events

## Changes
- **New**: `mcp/src/channel.ts` — digest timer, notification poller, file-based state persistence (`~/.nex/channel-state.json`)
- **Modified**: `mcp/src/server.ts` — declares `experimental: { "claude/channel": {} }` capability + system instructions
- **Modified**: `mcp/src/index.ts` — calls `startChannel()` after transport connects

## Test plan
- [x] Integration test against live Nex API — daily digest (2,198 chars), 10 proactive insights, 3 scenario queries all returned real data
- [x] `tsc --noEmit` and `npm run build` pass with zero errors
- [ ] Manual test with `claude --dangerously-load-development-channels server:nex`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added channel notification system to deliver periodic updates and insights from the Nex API to your Claude interface.

* **Documentation**
  * Added comprehensive workspace management design specification outlining planned multi-workspace architecture and configuration improvements for future releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->