### PR TITLE
fix(ci): stash rsync changes before git pull --rebase in publish workflow

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -99,11 +99,16 @@ jobs:
 
       - name: Commit version bump
         if: steps.bump.outputs.bumped == 'true'
+        env:
+          BUMP_VERSION: ${{ steps.bump.outputs.version }}
         run: |
           cd ..
-          git pull --rebase
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add cli/package.json cli/src/plugin/ cli/plugin-commands/
-          git commit -m "chore(cli): bump to v${{ steps.bump.outputs.version }} [skip ci]"
+          git stash
+          git pull --rebase
+          git stash pop
+          git add cli/package.json cli/src/plugin/ cli/plugin-commands/
+          git commit -m "chore(cli): bump to v${BUMP_VERSION} [skip ci]"
           git push


### PR DESCRIPTION
## Summary
- The rsync step copies `claude-code-plugin/src/` → `cli/src/plugin/` and `commands/` → `plugin-commands/`, creating unstaged changes
- `git pull --rebase` then fails with "cannot pull with rebase: You have unstaged changes"
- Fix: stash before pull, pop after, then re-add and commit

## Test plan
- [x] CI should pass on this PR itself (workflow only runs on main push, but syntax is valid)
- [ ] After merge, the next push to main touching `cli/**` should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CLI publishing workflow reliability and process handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->