### PR TITLE
feat(cli): add Codex CLI platform detection and setup support

### DIFF
--- a/cli/src/commands/setup.ts
+++ b/cli/src/commands/setup.ts
@@ -60,6 +60,9 @@ function getClient(): { client: NexClient; format: Format } {
 function hasNexMcpInConfig(platform: Platform): boolean {
   try {
     const raw = readFileSync(platform.configPath, "utf-8");
+    if (platform.configFormat === "codex") {
+      return raw.includes("[mcp_servers.nex]");
+    }
     const config = JSON.parse(raw);
     return !!(config?.mcpServers?.nex || config?.context_servers?.nex);
   } catch {

--- a/cli/src/lib/installers.ts
+++ b/cli/src/lib/installers.ts
@@ -89,6 +89,10 @@ export function installMcpServer(
     return installContinueMcp(platform.configPath, apiKey);
   }
 
+  if (platform.configFormat === "codex") {
+    return installCodexMcp(platform.configPath, apiKey);
+  }
+
   // Standard JSON format (Cursor, Claude Desktop, VS Code, Windsurf, Cline, Kilo Code, OpenCode)
   const config = readJsonFile(platform.configPath);
 
@@ -135,6 +139,66 @@ function installContinueMcp(
 
   writeJsonFile(mcpPath, config);
   return { installed: true, configPath: mcpPath };
+}
+
+function installCodexMcp(
+  configPath: string,
+  apiKey: string,
+): { installed: boolean; configPath: string } {
+  let content = "";
+  try {
+    content = readFileSync(configPath, "utf-8");
+  } catch {
+    // File doesn't exist — will create
+  }
+
+  const nexBlock = [
+    `[mcp_servers.nex]`,
+    `command = "nex-mcp"`,
+    ``,
+    `[mcp_servers.nex.env]`,
+    `NEX_API_KEY = "${apiKey}"`,
+  ].join("\n");
+
+  if (content.includes("[mcp_servers.nex]")) {
+    // Remove existing nex section(s) and re-add
+    const lines = content.split("\n");
+    const filtered: string[] = [];
+    let inNexSection = false;
+
+    for (const line of lines) {
+      const trimmed = line.trimStart();
+      if (trimmed.startsWith("[")) {
+        if (trimmed.startsWith("[mcp_servers.nex]") || trimmed.startsWith("[mcp_servers.nex.")) {
+          inNexSection = true;
+          continue;
+        } else {
+          inNexSection = false;
+        }
+      }
+
+      if (!inNexSection) {
+        filtered.push(line);
+      }
+    }
+
+    // Remove trailing blank lines before appending
+    while (filtered.length > 0 && filtered[filtered.length - 1].trim() === "") {
+      filtered.pop();
+    }
+
+    content = filtered.join("\n") + "\n\n" + nexBlock + "\n";
+  } else {
+    // Append to file
+    const separator = content && !content.endsWith("\n\n")
+      ? (content.endsWith("\n") ? "\n" : "\n\n")
+      : "";
+    content = content + separator + nexBlock + "\n";
+  }
+
+  mkdirSync(dirname(configPath), { recursive: true });
+  writeFileSync(configPath, content, "utf-8");
+  return { installed: true, configPath };
 }
 
 // ── 2. Claude Code Plugin Installer ────────────────────────────────────
@@ -629,13 +693,14 @@ const RULES_TEMPLATE_MAP: Record<string, string> = {
   kilocode: "kilocode-rules.md",
   opencode: "opencode-agents.md",
   aider: "aider-conventions.md",
+  codex: "codex-agents.md",
 };
 
 /**
  * Platforms where rules are APPENDED to an existing file (with markers)
  * rather than written as a standalone file.
  */
-const APPEND_PLATFORMS = new Set(["zed", "opencode", "aider"]);
+const APPEND_PLATFORMS = new Set(["zed", "opencode", "aider", "codex"]);
 
 export function installRulesFile(
   platform: Platform,

--- a/cli/src/lib/platform-detect.ts
+++ b/cli/src/lib/platform-detect.ts
@@ -21,7 +21,7 @@ export interface Platform {
   hookConfigPath: string | null;
   rulesPath: string | null;
   configPath: string;
-  configFormat: "standard" | "zed" | "continue";
+  configFormat: "standard" | "zed" | "continue" | "codex";
 }
 
 const home = homedir();
@@ -48,6 +48,19 @@ function hasNexMcpEntry(configPath: string, key = "nex"): boolean {
   } catch {
     return false;
   }
+}
+
+function hasNexMcpInToml(configPath: string): boolean {
+  try {
+    const content = readFileSync(configPath, "utf-8");
+    return content.includes("[mcp_servers.nex]");
+  } catch {
+    return false;
+  }
+}
+
+function codexHome(): string {
+  return process.env.CODEX_HOME || join(home, ".codex");
 }
 
 function hasNexRules(rulesPath: string | null): boolean {
@@ -330,6 +343,22 @@ export function detectPlatforms(): Platform[] {
       configPath: "", // Aider has no MCP support
       configFormat: "standard",
     },
+    {
+      id: "codex",
+      displayName: "Codex",
+      detected: whichExists("codex") || exists(codexHome()),
+      nexInstalled: hasNexMcpInToml(join(codexHome(), "config.toml")) || hasNexRules(join(cwd, "AGENTS.md")),
+      pluginSupport: false,
+      supportsRules: true,
+      supportsHooks: false,
+      supportsCustomTools: false,
+      supportsCustomAgents: false,
+      supportsWorkflows: false,
+      hookConfigPath: null,
+      rulesPath: join(cwd, "AGENTS.md"),
+      configPath: join(codexHome(), "config.toml"),
+      configFormat: "codex",
+    },
   ];
 
   return platforms;
@@ -356,4 +385,5 @@ export const VALID_PLATFORM_IDS = [
   "opencode",
   "openclaw",
   "aider",
+  "codex",
 ];


### PR DESCRIPTION
## Summary
- Adds OpenAI Codex CLI as a detected platform in `nex setup`
- Writes MCP server config to `~/.codex/config.toml` in TOML format (`[mcp_servers.nex]`)
- Appends Nex rules to project-root `AGENTS.md` with idempotent markers
- Detects Codex via `codex` binary or `~/.codex/` directory (respects `$CODEX_HOME`)

## Test plan
- [ ] Run `nex setup --platform codex` and verify `~/.codex/config.toml` gets the `[mcp_servers.nex]` section
- [ ] Verify `AGENTS.md` gets Nex rules appended with markers
- [ ] Run `nex setup status` and confirm Codex shows as detected with MCP/rules status
- [ ] Re-run setup to verify idempotent TOML section replacement
- [ ] Test with no existing `config.toml` (fresh install)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Codex platform support: CLI now automatically detects Codex installations, installs and configures MCP servers for Codex, and enables rules file management for Codex environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->