### PR TITLE
feat: add X-Nex-Source header to all API clients

### DIFF
--- a/cli/src/lib/client.ts
+++ b/cli/src/lib/client.ts
@@ -53,6 +53,7 @@ export class NexClient {
     try {
       const headers: Record<string, string> = {
         Authorization: `Bearer ${this.apiKey}`,
+        "X-Nex-Source": "skill-cli",
       };
       if (body !== undefined) {
         headers["Content-Type"] = "application/json";

--- a/cli/src/mcp/client.ts
+++ b/cli/src/mcp/client.ts
@@ -55,6 +55,7 @@ export class NexApiClient {
     const url = `${getBaseUrl()}${path}`;
     const headers: Record<string, string> = {
       Authorization: `Bearer ${this.apiKey}`,
+      "X-Nex-Source": "mcp",
     };
     if (body !== undefined) {
       headers["Content-Type"] = "application/json";

--- a/openclaw-plugin/src/nex-client.ts
+++ b/openclaw-plugin/src/nex-client.ts
@@ -75,6 +75,7 @@ export class NexClient {
     try {
       const headers: Record<string, string> = {
         Authorization: `Bearer ${this.apiKey}`,
+        "X-Nex-Source": "skill",
       };
       if (body !== undefined) {
         headers["Content-Type"] = "application/json";


### PR DESCRIPTION
## Summary
- Adds `X-Nex-Source` header to all three HTTP clients for server-side source attribution:
  - MCP server → `X-Nex-Source: mcp`
  - Skill CLI → `X-Nex-Source: skill-cli`
  - OpenClaw plugin → `X-Nex-Source: skill`
- Foundational for COGS tracking — core can read this header to attribute AI costs per client surface

## Test plan
- [ ] Type check all packages (`tsc --noEmit` in mcp/, cli/, openclaw-plugin/)
- [ ] Verify API requests include the correct `X-Nex-Source` header per client

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved internal API request tracking by adding source identification headers to outbound requests across multiple client implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->