### PR TITLE
feat: add invite command with interactive picker and MCP tools

### DIFF
--- a/claude-code-plugin/commands/nex:invite.md
+++ b/claude-code-plugin/commands/nex:invite.md
@@ -1,0 +1,12 @@
+---
+description: Manage workspace invitations — send, list, revoke, or resend invites
+---
+Help the user manage workspace invitations using these MCP tools:
+
+- **Send invitations**: Use `mcp__nex__send_invite` with `invitees` array of `{email, role}` objects. Role is either `WORKSPACE_ROLE_MEMBER` or `WORKSPACE_ROLE_ADMIN`.
+- **List invitations**: Use `mcp__nex__list_invites` to see all pending and accepted invitations.
+- **Revoke an invitation**: Use `mcp__nex__revoke_invite` with the invitation `id` to cancel a pending invite.
+- **Resend an invitation**: Use `mcp__nex__resend_invite` with the invitation `id` to re-send the email.
+
+If $ARGUMENTS contains emails, send invitations to those addresses with member role by default.
+If $ARGUMENTS is empty, list current invitations first, then ask what the user wants to do.

--- a/cli/plugin-commands/nex:invite.md
+++ b/cli/plugin-commands/nex:invite.md
@@ -1,0 +1,12 @@
+---
+description: Manage workspace invitations — send, list, revoke, or resend invites
+---
+Help the user manage workspace invitations using these MCP tools:
+
+- **Send invitations**: Use `mcp__nex__send_invite` with `invitees` array of `{email, role}` objects. Role is either `WORKSPACE_ROLE_MEMBER` or `WORKSPACE_ROLE_ADMIN`.
+- **List invitations**: Use `mcp__nex__list_invites` to see all pending and accepted invitations.
+- **Revoke an invitation**: Use `mcp__nex__revoke_invite` with the invitation `id` to cancel a pending invite.
+- **Resend an invitation**: Use `mcp__nex__resend_invite` with the invitation `id` to re-send the email.
+
+If $ARGUMENTS contains emails, send invitations to those addresses with member role by default.
+If $ARGUMENTS is empty, list current invitations first, then ask what the user wants to do.

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -9,6 +9,7 @@ const require = createRequire(import.meta.url);
 const { version } = require("../package.json") as { version: string };
 
 import { workspace } from "./commands/workspace.js";
+import { invite } from "./commands/invite.js";
 
 export const program = new Command();
 
@@ -23,3 +24,4 @@ program
   .option("--debug", "Debug output on stderr");
 
 program.addCommand(workspace);
+program.addCommand(invite);

--- a/cli/src/commands/invite.ts
+++ b/cli/src/commands/invite.ts
@@ -1,0 +1,347 @@
+/**
+ * nex invite — manage workspace invitations.
+ *
+ * Subcommands: send, list, revoke, resend.
+ * Bare `nex invite` launches interactive picker.
+ */
+
+import { Command } from "commander";
+import { NexClient } from "../lib/client.js";
+import {
+  getActiveCredentials,
+  listWorkspaces,
+  switchWorkspace,
+  resetDataDirCache,
+  loadRegistry,
+} from "../lib/workspace-registry.js";
+import { style, sym, interactiveSelect, table } from "../lib/tui.js";
+import { resolveApiKey, resolveFormat } from "../lib/config.js";
+
+// Types for API responses
+interface Invitation {
+  id: string;
+  email: string;
+  status: string;
+  role: string;
+}
+
+interface InvitationsResponse {
+  invitations: Invitation[];
+}
+
+interface InvitationResponse {
+  invitation: Invitation;
+}
+
+function makeClient(): NexClient {
+  const apiKey = resolveApiKey();
+  if (!apiKey) {
+    process.stderr.write("No API key found. Run: nex setup\n");
+    process.exit(1);
+  }
+  return new NexClient(apiKey);
+}
+
+function formatRole(role: string): string {
+  return role.replace("WORKSPACE_ROLE_", "").toLowerCase();
+}
+
+function formatStatus(status: string): string {
+  const s = status.replace("INVITATION_STATUS_", "").toLowerCase();
+  switch (s) {
+    case "pending":
+      return style.yellow(s);
+    case "accepted":
+      return style.green(s);
+    case "revoked":
+      return style.red(s);
+    default:
+      return s;
+  }
+}
+
+const invite = new Command("invite").description(
+  "Manage workspace invitations",
+);
+
+// --- send ---
+invite
+  .command("send")
+  .description("Send workspace invitations")
+  .option("--email <emails...>", "Email addresses to invite")
+  .option("--role <role>", "Role: member or admin", "member")
+  .action(async (opts: { email?: string[]; role: string }) => {
+    let emails = opts.email;
+    let role = opts.role;
+
+    if (!emails || emails.length === 0) {
+      if (!process.stdin.isTTY) {
+        process.stderr.write("No emails provided. Use --email\n");
+        process.exit(1);
+      }
+      // Interactive: prompt for emails
+      const input = await promptLine("Email addresses (comma-separated): ");
+      if (!input) return;
+      emails = input
+        .split(",")
+        .map((e) => e.trim())
+        .filter(Boolean);
+      if (emails.length === 0) {
+        process.stderr.write("No valid emails provided.\n");
+        process.exit(1);
+      }
+
+      // Role picker
+      const selectedRole = await interactiveSelect({
+        title: "Select role",
+        items: ["member", "admin"] as const,
+        render: (item: string) => item,
+      });
+      if (selectedRole) role = selectedRole;
+    }
+
+    const protoRole =
+      role === "admin" ? "WORKSPACE_ROLE_ADMIN" : "WORKSPACE_ROLE_MEMBER";
+    const invitees = emails.map((email) => ({ email, role: protoRole }));
+
+    const client = makeClient();
+    const result = await client.post<InvitationsResponse>("/v1/invitations", {
+      invitees,
+    });
+
+    const format = resolveFormat();
+    if (format === "json") {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      const invitations = result.invitations || [];
+      if (invitations.length === 0) {
+        console.log(
+          `${sym.error} No invitations created (emails may already have pending invites).`,
+        );
+      } else {
+        console.log(
+          `${sym.success} Sent ${style.bold(String(invitations.length))} invitation(s):`,
+        );
+        for (const inv of invitations) {
+          console.log(
+            `  ${style.dim("\u2022")} ${inv.email} (${formatRole(inv.role)})`,
+          );
+        }
+      }
+    }
+  });
+
+// --- list ---
+invite
+  .command("list")
+  .description("List workspace invitations")
+  .action(async () => {
+    const client = makeClient();
+    const result = await client.get<InvitationsResponse>("/v1/invitations");
+
+    const format = resolveFormat();
+    if (format === "json") {
+      console.log(JSON.stringify(result, null, 2));
+      return;
+    }
+
+    const invitations = result.invitations || [];
+    if (invitations.length === 0) {
+      console.log("No invitations found.");
+      return;
+    }
+
+    const output = table({
+      headers: ["Email", "Status", "Role", "ID"],
+      rows: invitations.map((inv) => [
+        inv.email,
+        formatStatus(inv.status),
+        formatRole(inv.role),
+        style.dim(inv.id),
+      ]),
+    });
+
+    console.log(`\n  ${style.bold("Workspace Invitations")}\n`);
+    console.log(output);
+    console.log();
+  });
+
+// --- revoke ---
+invite
+  .command("revoke")
+  .description("Revoke a pending invitation")
+  .argument("[id]", "Invitation ID to revoke")
+  .action(async (id?: string) => {
+    const client = makeClient();
+
+    if (!id) {
+      if (!process.stdin.isTTY) {
+        process.stderr.write("No invitation ID provided.\n");
+        process.exit(1);
+      }
+      // Interactive: fetch pending and let user pick
+      const result = await client.get<InvitationsResponse>("/v1/invitations");
+      const pending = (result.invitations || []).filter(
+        (inv) => inv.status === "INVITATION_STATUS_PENDING",
+      );
+      if (pending.length === 0) {
+        console.log("No pending invitations to revoke.");
+        return;
+      }
+      const selected = await interactiveSelect({
+        title: "Select invitation to revoke",
+        items: pending,
+        render: (inv: Invitation) =>
+          `${inv.email} (${formatRole(inv.role)})`,
+      });
+      if (!selected) return;
+      id = selected.id;
+    }
+
+    await client.post(`/v1/invitations/${encodeURIComponent(id)}/revoke`);
+    console.log(`${sym.success} Invitation ${style.bold(id)} revoked.`);
+  });
+
+// --- resend ---
+invite
+  .command("resend")
+  .description("Resend an invitation email")
+  .argument("[id]", "Invitation ID to resend")
+  .action(async (id?: string) => {
+    const client = makeClient();
+
+    if (!id) {
+      if (!process.stdin.isTTY) {
+        process.stderr.write("No invitation ID provided.\n");
+        process.exit(1);
+      }
+      const result = await client.get<InvitationsResponse>("/v1/invitations");
+      const pending = (result.invitations || []).filter(
+        (inv) => inv.status === "INVITATION_STATUS_PENDING",
+      );
+      if (pending.length === 0) {
+        console.log("No pending invitations to resend.");
+        return;
+      }
+      const selected = await interactiveSelect({
+        title: "Select invitation to resend",
+        items: pending,
+        render: (inv: Invitation) =>
+          `${inv.email} (${formatRole(inv.role)})`,
+      });
+      if (!selected) return;
+      id = selected.id;
+    }
+
+    const result = await client.post<InvitationResponse>(
+      `/v1/invitations/${encodeURIComponent(id)}/resend`,
+    );
+    const format = resolveFormat();
+    if (format === "json") {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.log(
+        `${sym.success} Invitation resent to ${style.bold(result.invitation?.email || id)}.`,
+      );
+    }
+  });
+
+// --- bare `nex invite` interactive mode ---
+invite.action(async () => {
+  if (!process.stdin.isTTY) {
+    process.stderr.write(
+      "Interactive mode requires a TTY. Use subcommands: send, list, revoke, resend\n",
+    );
+    process.exit(1);
+  }
+
+  // Step 1: Confirm workspace
+  const creds = getActiveCredentials();
+  if (!creds) {
+    process.stderr.write(
+      "No active workspace. Run: nex register --email <email>\n",
+    );
+    process.exit(1);
+  }
+
+  const registry = loadRegistry();
+  const meta = registry.workspaces[creds.workspace_slug];
+  const display = meta?.nickname
+    ? `${meta.nickname} (${creds.workspace_slug})`
+    : creds.workspace_slug;
+
+  console.log(`\n  ${style.bold("Workspace Invitations")}\n`);
+  console.log(`  Current workspace: ${style.bold(display)}\n`);
+
+  const workspaceConfirm = await interactiveSelect({
+    title: "Invite to this workspace?",
+    items: ["Yes, continue", "Switch workspace"] as const,
+    render: (item: string) => item,
+  });
+
+  if (!workspaceConfirm) return;
+
+  if (workspaceConfirm === "Switch workspace") {
+    const workspaces = listWorkspaces();
+    if (workspaces.length <= 1) {
+      console.log("No other workspaces available.");
+      return;
+    }
+    const selected = await interactiveSelect({
+      title: "Select workspace",
+      items: workspaces,
+      render: (ws: (typeof workspaces)[number]) => {
+        const name = ws.nickname
+          ? `${ws.nickname} (${ws.slug})`
+          : ws.slug;
+        const active =
+          ws.slug === registry.active_workspace ? style.green(" \u25CF") : "";
+        return `${name}${active}`;
+      },
+    });
+    if (!selected) return;
+    switchWorkspace(selected.slug);
+    resetDataDirCache();
+    console.log(
+      `${sym.success} Switched to ${style.bold(selected.nickname || selected.slug)}\n`,
+    );
+  }
+
+  // Step 2: Action picker
+  const actions = [
+    { label: "Send invitations", command: "send" },
+    { label: "List invitations", command: "list" },
+    { label: "Revoke an invitation", command: "revoke" },
+    { label: "Resend an invitation", command: "resend" },
+  ] as const;
+
+  const action = await interactiveSelect({
+    title: "What would you like to do?",
+    items: [...actions],
+    render: (item: (typeof actions)[number]) => item.label,
+  });
+
+  if (!action) return;
+
+  // Execute the selected subcommand
+  const sub = invite.commands.find((c) => c.name() === action.command);
+  if (sub) {
+    await sub.parseAsync([], { from: "user" });
+  }
+});
+
+export { invite };
+
+// --- Helpers ---
+
+function promptLine(message: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    process.stdout.write(message);
+    process.stdin.setEncoding("utf-8");
+    process.stdin.resume();
+    process.stdin.once("data", (data: string) => {
+      process.stdin.pause();
+      resolve(data.trim() || null);
+    });
+  });
+}

--- a/cli/src/mcp/server.ts
+++ b/cli/src/mcp/server.ts
@@ -13,6 +13,7 @@ import { registerRegistrationTools } from "./tools/register.js";
 import { registerScanTools } from "./tools/scan.js";
 import { registerIntegrationTools } from "./tools/integrations.js";
 import { registerNotificationTools } from "./tools/notifications.js";
+import { registerInviteTools } from "./tools/invites.js";
 
 export function createServer(apiKey?: string): {
   server: McpServer;
@@ -49,6 +50,7 @@ export function createServer(apiKey?: string): {
   registerScanTools(server, client);
   registerIntegrationTools(server, client);
   registerNotificationTools(server, client);
+  registerInviteTools(server, client);
 
   return { server, client };
 }

--- a/cli/src/mcp/tools/invites.ts
+++ b/cli/src/mcp/tools/invites.ts
@@ -1,0 +1,85 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { NexApiClient } from "../client.js";
+
+export function registerInviteTools(server: McpServer, client: NexApiClient) {
+  server.tool(
+    "send_invite",
+    "Send workspace invitations by email. Each invitee gets an email with a link to join.",
+    {
+      invitees: z
+        .array(
+          z.object({
+            email: z.string().email().describe("Email address to invite"),
+            role: z
+              .enum(["WORKSPACE_ROLE_MEMBER", "WORKSPACE_ROLE_ADMIN"])
+              .describe("Role to assign"),
+          }),
+        )
+        .min(1)
+        .describe("List of people to invite"),
+    },
+    { readOnlyHint: false },
+    async ({ invitees }) => {
+      const result = await client.post("/v1/invitations", { invitees });
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    "list_invites",
+    "List all pending and accepted workspace invitations.",
+    {},
+    { readOnlyHint: true },
+    async () => {
+      const result = await client.get("/v1/invitations");
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    "revoke_invite",
+    "Revoke a pending workspace invitation by ID.",
+    {
+      id: z.string().describe("Invitation ID to revoke"),
+    },
+    { readOnlyHint: false, destructiveHint: true },
+    async ({ id }) => {
+      await client.post(
+        `/v1/invitations/${encodeURIComponent(id)}/revoke`,
+      );
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              success: true,
+              message: `Invitation ${id} revoked`,
+            }),
+          },
+        ],
+      };
+    },
+  );
+
+  server.tool(
+    "resend_invite",
+    "Resend the invitation email for a pending invitation.",
+    {
+      id: z.string().describe("Invitation ID to resend"),
+    },
+    { readOnlyHint: false },
+    async ({ id }) => {
+      const result = await client.post(
+        `/v1/invitations/${encodeURIComponent(id)}/resend`,
+      );
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+      };
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `nex invite` CLI command with interactive workspace confirmation picker and action selector
- 4 subcommands: `send` (with `--email`/`--role` flags), `list`, `revoke`, `resend` — all with interactive fallbacks when run without args
- 4 MCP tools (`send_invite`, `list_invites`, `revoke_invite`, `resend_invite`) for AI agent access
- Plugin command markdown files for Claude Code and IDE integrations

**Depends on:** nex-crm/core#feat/invite-dev-api (developer API endpoints)

## Test plan
- [ ] `nex invite` launches interactive picker (workspace confirm → action select)
- [ ] `nex invite send --email user@example.com --role member` sends invitation
- [ ] `nex invite list` shows pending/accepted invitations in table format
- [ ] `nex invite revoke` fetches pending invites and shows picker
- [ ] `nex invite resend` fetches pending invites and shows picker
- [ ] `--format json` returns structured JSON output for all subcommands
- [ ] MCP tools work via AI IDE integration
- [ ] Non-TTY mode provides helpful error messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added workspace invitation management with send, list, revoke, and resend operations.
  * Interactive mode for managing team invitations and workspace membership.
  * Role assignment support (member or admin) during invitation.

* **Documentation**
  * Added comprehensive guides for invitation management via CLI and MCP integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->