### PR TITLE
CI: secret scanning, bun enforcement, attribution removal

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,19 @@
+{
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.command' | grep -qE '(^|\\s|&&|\\|\\||;|\\|)\\s*(npm|npx|pnpm|yarn)\\b' && echo '{\"decision\":\"block\",\"reason\":\"Use bun/bunx instead of npm/npx/pnpm/yarn. This project uses bun as its package manager.\"}' || true"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,7 +10,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_input.command' | grep -qE '(^|\\s|&&|\\|\\||;|\\|)\\s*(npm|npx|pnpm|yarn)\\b' && echo '{\"decision\":\"block\",\"reason\":\"Use bun/bunx instead of npm/npx/pnpm/yarn. This project uses bun as its package manager.\"}' || true"
+            "command": "cmd=$(jq -r '.tool_input.command // empty'); if [ -z \"$cmd\" ]; then echo '{\"decision\":\"block\",\"reason\":\"Unable to inspect command.\"}'; elif printf '%s' \"$cmd\" | grep -qE '(^|\\s|&&|\\|\\||;|\\|)\\s*(npm|npx|pnpm|yarn)\\b'; then echo '{\"decision\":\"block\",\"reason\":\"Use bun/bunx instead of npm/npx/pnpm/yarn. This project uses bun as its package manager.\"}'; fi"
           }
         ]
       }

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -6,13 +6,54 @@ on:
     branches: [main]
 
 jobs:
-  gitleaks:
+  secret-scan:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Scan for secrets in diff
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            DIFF=$(git diff origin/${{ github.base_ref }}...HEAD)
+          else
+            DIFF=$(git diff HEAD~1..HEAD)
+          fi
+
+          PATTERNS=(
+            'AKIA[0-9A-Z]{16}'                          # AWS Access Key ID
+            '[0-9a-zA-Z/+]{40}'                         # AWS Secret Key (40-char base64)
+            'sk-[a-zA-Z0-9]{20,}'                       # OpenAI / Anthropic API key
+            'ghp_[a-zA-Z0-9]{36}'                       # GitHub personal access token
+            'gho_[a-zA-Z0-9]{36}'                       # GitHub OAuth token
+            'ghs_[a-zA-Z0-9]{36}'                       # GitHub server token
+            'ghr_[a-zA-Z0-9]{36}'                       # GitHub refresh token
+            'github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}' # GitHub fine-grained PAT
+            'xox[boaprs]-[0-9a-zA-Z-]{10,}'             # Slack token
+            'sk_live_[a-zA-Z0-9]{24,}'                  # Stripe secret key
+            'rk_live_[a-zA-Z0-9]{24,}'                  # Stripe restricted key
+            'SG\.[a-zA-Z0-9_-]{22}\.[a-zA-Z0-9_-]{43}' # SendGrid API key
+            '-----BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----' # Private keys
+            'nex_[a-zA-Z0-9]{32,}'                      # Nex API keys
+          )
+
+          FOUND=0
+          for pattern in "${PATTERNS[@]}"; do
+            # Only scan added lines (starting with +), skip file headers
+            MATCHES=$(echo "$DIFF" | grep -E '^\+[^+]' | grep -oE "$pattern" || true)
+            if [ -n "$MATCHES" ]; then
+              echo "::error::Potential secret found matching pattern: $pattern"
+              echo "$MATCHES" | head -3 | sed 's/./*/g'  # mask the actual value
+              FOUND=1
+            fi
+          done
+
+          if [ "$FOUND" -eq 1 ]; then
+            echo ""
+            echo "::error::Secrets detected in the diff. Remove them before merging."
+            echo "If these are false positives, add them to .secret-scan-allowlist (one pattern per line)."
+            exit 1
+          fi
+
+          echo "No secrets found."

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,18 @@
+name: Secret Scan
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -18,30 +18,42 @@ jobs:
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             DIFF=$(git diff origin/${{ github.base_ref }}...HEAD)
           else
-            DIFF=$(git diff HEAD~1..HEAD)
+            if git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
+              DIFF=$(git diff HEAD~1..HEAD)
+            else
+              DIFF=$(git diff $(git hash-object -t tree /dev/null)..HEAD)
+            fi
           fi
 
           PATTERNS=(
-            'AKIA[0-9A-Z]{16}'                          # AWS Access Key ID
-            '[0-9a-zA-Z/+]{40}'                         # AWS Secret Key (40-char base64)
-            'sk-[a-zA-Z0-9]{20,}'                       # OpenAI / Anthropic API key
-            'ghp_[a-zA-Z0-9]{36}'                       # GitHub personal access token
-            'gho_[a-zA-Z0-9]{36}'                       # GitHub OAuth token
-            'ghs_[a-zA-Z0-9]{36}'                       # GitHub server token
-            'ghr_[a-zA-Z0-9]{36}'                       # GitHub refresh token
-            'github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}' # GitHub fine-grained PAT
-            'xox[boaprs]-[0-9a-zA-Z-]{10,}'             # Slack token
-            'sk_live_[a-zA-Z0-9]{24,}'                  # Stripe secret key
-            'rk_live_[a-zA-Z0-9]{24,}'                  # Stripe restricted key
-            'SG\.[a-zA-Z0-9_-]{22}\.[a-zA-Z0-9_-]{43}' # SendGrid API key
+            'AKIA[0-9A-Z]{16}'                                    # AWS Access Key ID
+            '(aws_secret_access_key|AWS_SECRET)[=:]\s*[^\s]{20,}' # AWS Secret Key (in config context)
+            'sk-[a-zA-Z0-9]{20,}'                                 # OpenAI / Anthropic / Nex API key
+            'ghp_[a-zA-Z0-9]{36}'                                 # GitHub personal access token
+            'gho_[a-zA-Z0-9]{36}'                                 # GitHub OAuth token
+            'ghs_[a-zA-Z0-9]{36}'                                 # GitHub server token
+            'ghr_[a-zA-Z0-9]{36}'                                 # GitHub refresh token
+            'github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}'          # GitHub fine-grained PAT
+            'xox[boaprs]-[0-9a-zA-Z-]{10,}'                       # Slack token
+            'sk_live_[a-zA-Z0-9]{24,}'                             # Stripe secret key
+            'rk_live_[a-zA-Z0-9]{24,}'                             # Stripe restricted key
+            'SG\.[a-zA-Z0-9_-]{22}\.[a-zA-Z0-9_-]{43}'            # SendGrid API key
             '-----BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----' # Private keys
-            'nex_[a-zA-Z0-9]{32,}'                      # Nex API keys
           )
+
+          # Load allowlist if it exists
+          ALLOWLIST_FILE=".secret-scan-allowlist"
 
           FOUND=0
           for pattern in "${PATTERNS[@]}"; do
             # Only scan added lines (starting with +), skip file headers
             MATCHES=$(echo "$DIFF" | grep -E '^\+[^+]' | grep -oE "$pattern" || true)
+
+            # Filter out allowlisted patterns
+            if [ -n "$MATCHES" ] && [ -f "$ALLOWLIST_FILE" ]; then
+              MATCHES=$(echo "$MATCHES" | grep -vFf "$ALLOWLIST_FILE" || true)
+            fi
+
             if [ -n "$MATCHES" ]; then
               echo "::error::Potential secret found matching pattern: $pattern"
               echo "$MATCHES" | head -3 | sed 's/./*/g'  # mask the actual value


### PR DESCRIPTION
## Summary
- Add gitleaks secret scanning to CI
- Add PreToolUse hook to enforce bun over npm/npx/pnpm/yarn
- Remove Claude attribution from commits and PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pre-tool-use check that blocks empty/inspectable shell commands and prevents use of npm/npx/pnpm/yarn, guiding use of alternative tooling instead.

* **Chores**
  * Added automated secret scanning on PRs and main pushes to detect and fail on exposed credentials.
  * Updated development configuration settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->