### PR TITLE
Refine Claude recall filtering for bare shell commands

### DIFF
--- a/claude-code-plugin/src/auto-recall.ts
+++ b/claude-code-plugin/src/auto-recall.ts
@@ -13,7 +13,7 @@ import { loadConfig, isHookEnabled } from "./config.js";
 import { NexClient } from "./nex-client.js";
 import { formatNexContext } from "./context-format.js";
 import { SessionStore } from "./session-store.js";
-import { shouldRecall, recordRecall } from "./recall-filter.js";
+import { shouldRecall } from "./recall-filter.js";
 
 const sessions = new SessionStore();
 
@@ -104,9 +104,6 @@ async function main(): Promise<void> {
     if (result.session_id && sessionKey) {
       sessions.set(sessionKey, result.session_id);
     }
-
-    // Record successful recall for debounce
-    recordRecall(result.session_id);
 
     const entityCount = result.entity_references?.length ?? 0;
     const context = formatNexContext({

--- a/claude-code-plugin/src/auto-session-start.ts
+++ b/claude-code-plugin/src/auto-session-start.ts
@@ -17,7 +17,6 @@ import { NexClient } from "./nex-client.js";
 import { RateLimiter } from "./rate-limiter.js";
 import { formatNexContext } from "./context-format.js";
 import { SessionStore } from "./session-store.js";
-import { recordRecall } from "./recall-filter.js";
 import { scanAndIngest } from "./file-scanner.js";
 import { ingestContextFiles } from "./context-files.js";
 import { readManifest as readScanManifest, isScanFresh, markScanned, writeManifest as writeScanManifest } from "./file-manifest.js";
@@ -159,9 +158,6 @@ async function main(): Promise<void> {
     if (result.session_id && input.session_id) {
       sessions.set(input.session_id, result.session_id);
     }
-
-    // Record this as a successful recall for debounce
-    recordRecall(result.session_id);
 
     const entityCount = result.entity_references?.length ?? 0;
     const context = formatNexContext({

--- a/claude-code-plugin/src/recall-filter.ts
+++ b/claude-code-plugin/src/recall-filter.ts
@@ -1,125 +1,55 @@
 /**
- * Smart prompt classifier for selective recall.
+ * Minimal recall filter for Claude Code.
  *
- * Determines whether a prompt is likely knowledge-seeking (needs recall)
- * or a pure coding directive (skip recall). Also handles debounce —
- * skips recall if a successful recall happened within the debounce window,
- * unless the current prompt contains question words.
- *
- * Persistence: last-recall timestamp stored in ~/.nex/recall-state.json
+ * The intended behavior is to query Nex for nearly every user message and
+ * skip only clearly low-signal input such as very short replies, explicit
+ * opt-outs, or raw shell commands. Natural-language coding prompts still go
+ * through Ask so memory is available during regular coding turns.
  */
 
-import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
-import { join } from "node:path";
-import { workspaceDataDir } from "./workspace-data-dir.js";
-
-function dataDir(): string {
-  return workspaceDataDir();
-}
-
-function stateFile(): string {
-  return join(dataDir(), "recall-state.json");
-}
-const DEBOUNCE_MS = 30_000; // 30 seconds
-
-// --- Question words that signal knowledge-seeking intent ---
-const QUESTION_WORDS = /\b(who|what|when|where|why|how|which|tell|explain|describe|summarize|summarise|list|find|show|get|any|does|did|is|are|was|were|have|has|do|can|could|should|would|will)\b/i;
-
-// --- Tool/action commands that are pure coding directives ---
-const TOOL_COMMANDS = /^\s*(run|build|test|lint|format|deploy|install|uninstall|start|stop|restart|commit|push|pull|merge|rebase|checkout|fetch|init|fix|refactor|rename|move|delete|remove|add|create|update|upgrade|downgrade|migrate|generate|scaffold|compile|bundle|watch|serve|debug|profile|bench|clean|reset|undo|redo|revert|squash|cherry-pick|tag|release|publish|npm|npx|yarn|pnpm|bun|pip|cargo|go|make|docker|kubectl|terraform|git|gh|cd|ls|cat|grep|find|mkdir|rm|cp|mv|touch|echo|export|source|chmod|chown|curl|wget|ssh|scp)\b/i;
-
-// --- File reference pattern (paths, extensions) ---
-const FILE_REF = /(?:[\w./\\-]+\.\w{1,10}|src\/|lib\/|dist\/|node_modules\/|\.\/|\.\.\/)/;
-
-// --- Code-heavy: >50% non-alpha characters (brackets, operators, etc.) ---
-function isCodeHeavy(text: string): boolean {
-  const alpha = text.replace(/[^a-zA-Z]/g, "").length;
-  return alpha < text.length * 0.5;
-}
+const MIN_RECALL_LENGTH = 15;
+const NATURAL_LANGUAGE_HINTS =
+  /\b(please|can|could|would|should|what|when|where|why|how|who|tell|explain|describe|summarize|check|review|look|find|show|help|about|for|to|with|without|into|from|before|after|need|want|current|my|our|this|that)\b/i;
+const BARE_SHELL_COMMAND =
+  /^(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)*(?:ls|pwd|cd|cat|grep|rg|find|mkdir|rm|cp|mv|touch|echo|git|npm|npx|yarn|pnpm|bun|node|python|python3|pytest|make|docker|kubectl|terraform)\b/i;
+const COMMAND_TOKEN = /^(?:[A-Za-z_][A-Za-z0-9_]*=\S+|--?[\w./:=@%+,~-]+|[\w./:=@%+,~-]+|["'][^"']*["'])$/;
 
 export interface RecallDecision {
   shouldRecall: boolean;
   reason: string;
 }
 
-interface RecallState {
-  lastRecallAt: number; // epoch ms
-  lastRecallSessionId?: string;
-}
-
-function readState(): RecallState {
-  try {
-    const raw = readFileSync(stateFile(), "utf-8");
-    return JSON.parse(raw) as RecallState;
-  } catch {
-    return { lastRecallAt: 0 };
+function looksLikeBareShellCommand(prompt: string): boolean {
+  if (!BARE_SHELL_COMMAND.test(prompt)) {
+    return false;
   }
-}
 
-function writeState(state: RecallState): void {
-  try {
-    mkdirSync(dataDir(), { recursive: true });
-    writeFileSync(stateFile(), JSON.stringify(state), "utf-8");
-  } catch {
-    // best-effort
+  if (NATURAL_LANGUAGE_HINTS.test(prompt)) {
+    return false;
   }
+
+  return prompt.split(/\s+/).every((token) => COMMAND_TOKEN.test(token));
 }
 
-/**
- * Record that a successful recall just happened.
- * Call this after a non-empty /ask response.
- */
-export function recordRecall(sessionId?: string): void {
-  writeState({ lastRecallAt: Date.now(), lastRecallSessionId: sessionId });
-}
-
-/**
- * Determine whether this prompt should trigger a Nex /ask recall.
- */
 export function shouldRecall(prompt: string, isFirstPrompt: boolean): RecallDecision {
   const trimmed = prompt.trim();
-
-  // Always recall on first prompt of session
-  if (isFirstPrompt) {
-    return { shouldRecall: true, reason: "first-prompt" };
-  }
 
   // Explicit opt-out: prompt starts with !
   if (trimmed.startsWith("!")) {
     return { shouldRecall: false, reason: "opt-out" };
   }
 
-  // Too short — likely a directive like "yes", "ok", "done"
-  if (trimmed.length < 15) {
+  if (trimmed.length < MIN_RECALL_LENGTH) {
     return { shouldRecall: false, reason: "too-short" };
   }
 
-  // Has question words — likely knowledge-seeking
-  const hasQuestion = QUESTION_WORDS.test(trimmed);
-
-  // Check debounce: skip if recent successful recall, unless question
-  if (!hasQuestion) {
-    const state = readState();
-    if (state.lastRecallAt > 0 && Date.now() - state.lastRecallAt < DEBOUNCE_MS) {
-      return { shouldRecall: false, reason: "debounce" };
-    }
+  if (looksLikeBareShellCommand(trimmed)) {
+    return { shouldRecall: false, reason: "bare-shell-command" };
   }
 
-  // Tool/action commands — pure coding directives
-  if (TOOL_COMMANDS.test(trimmed) && !hasQuestion) {
-    return { shouldRecall: false, reason: "tool-command" };
+  if (isFirstPrompt) {
+    return { shouldRecall: true, reason: "first-prompt" };
   }
 
-  // Code-heavy with file references and no question words
-  if (isCodeHeavy(trimmed) && FILE_REF.test(trimmed) && !hasQuestion) {
-    return { shouldRecall: false, reason: "code-prompt" };
-  }
-
-  // Has question words — always recall
-  if (hasQuestion) {
-    return { shouldRecall: true, reason: "question" };
-  }
-
-  // Default: recall (err on the side of providing context)
   return { shouldRecall: true, reason: "default" };
 }

--- a/cli/src/commands/context.ts
+++ b/cli/src/commands/context.ts
@@ -8,7 +8,7 @@ import { resolveApiKey, resolveFormat, resolveTimeout } from "../lib/config.js";
 import { printOutput } from "../lib/output.js";
 import type { Format } from "../lib/output.js";
 import { box, keyValue, style, sym, isTTY } from "../lib/tui.js";
-import { shouldRecall, recordRecall } from "../lib/recall-filter.js";
+import { shouldRecall } from "../lib/recall-filter.js";
 import { formatNexContext } from "../lib/context-format.js";
 import type { NexRecallResult } from "../lib/context-format.js";
 import { captureFilter } from "../lib/capture-filter.js";
@@ -160,7 +160,6 @@ program
     }
 
     const result = await client.post<NexRecallResult>("/v1/context/ask", body);
-    recordRecall();
 
     const formatted = formatNexContext({
       answer: result.answer ?? "",

--- a/cli/src/lib/recall-filter.ts
+++ b/cli/src/lib/recall-filter.ts
@@ -1,51 +1,20 @@
-import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
-import { join } from "node:path";
-import { homedir } from "node:os";
-
-const DATA_DIR = join(homedir(), ".nex");
-const STATE_FILE = join(DATA_DIR, "recall-state.json");
-const DEBOUNCE_MS = 30_000;
-
-const QUESTION_WORDS =
-  /\b(who|what|when|where|why|how|which|tell|explain|describe|summarize|summarise|list|find|show|get|any|does|did|is|are|was|were|have|has|do|can|could|should|would|will)\b/i;
-const TOOL_COMMANDS =
-  /^\s*(run|build|test|lint|format|deploy|install|uninstall|start|stop|restart|commit|push|pull|merge|rebase|checkout|fetch|init|fix|refactor|rename|move|delete|remove|add|create|update|upgrade|downgrade|migrate|generate|scaffold|compile|bundle|watch|serve|debug|profile|bench|clean|reset|undo|redo|revert|squash|cherry-pick|tag|release|publish|npm|npx|yarn|pnpm|bun|pip|cargo|go|make|docker|kubectl|terraform|git|gh|cd|ls|cat|grep|find|mkdir|rm|cp|mv|touch|echo|export|source|chmod|chown|curl|wget|ssh|scp)\b/i;
-const FILE_REF =
-  /(?:[\w./\\-]+\.\w{1,10}|src\/|lib\/|dist\/|node_modules\/|\.\/|\.\.\/)/;
-
-function isCodeHeavy(text: string): boolean {
-  const alpha = text.replace(/[^a-zA-Z]/g, "").length;
-  return alpha < text.length * 0.5;
-}
+const MIN_RECALL_LENGTH = 15;
+const NATURAL_LANGUAGE_HINTS =
+  /\b(please|can|could|would|should|what|when|where|why|how|who|tell|explain|describe|summarize|check|review|look|find|show|help|about|for|to|with|without|into|from|before|after|need|want|current|my|our|this|that)\b/i;
+const BARE_SHELL_COMMAND =
+  /^(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)*(?:ls|pwd|cd|cat|grep|rg|find|mkdir|rm|cp|mv|touch|echo|git|npm|npx|yarn|pnpm|bun|node|python|python3|pytest|make|docker|kubectl|terraform)\b/i;
+const COMMAND_TOKEN =
+  /^(?:[A-Za-z_][A-Za-z0-9_]*=\S+|--?[\w./:=@%+,~-]+|[\w./:=@%+,~-]+|["'][^"']*["'])$/;
 
 export interface RecallDecision {
   shouldRecall: boolean;
   reason: string;
 }
 
-interface RecallState {
-  lastRecallAt: number;
-}
-
-function readState(): RecallState {
-  try {
-    return JSON.parse(readFileSync(STATE_FILE, "utf-8")) as RecallState;
-  } catch {
-    return { lastRecallAt: 0 };
-  }
-}
-
-function writeState(state: RecallState): void {
-  try {
-    mkdirSync(DATA_DIR, { recursive: true });
-    writeFileSync(STATE_FILE, JSON.stringify(state), "utf-8");
-  } catch {
-    /* best-effort */
-  }
-}
-
-export function recordRecall(): void {
-  writeState({ lastRecallAt: Date.now() });
+function looksLikeBareShellCommand(prompt: string): boolean {
+  if (!BARE_SHELL_COMMAND.test(prompt)) return false;
+  if (NATURAL_LANGUAGE_HINTS.test(prompt)) return false;
+  return prompt.split(/\s+/).every((token) => COMMAND_TOKEN.test(token));
 }
 
 export function shouldRecall(
@@ -53,28 +22,12 @@ export function shouldRecall(
   isFirstPrompt: boolean,
 ): RecallDecision {
   const trimmed = prompt.trim();
-  if (isFirstPrompt) return { shouldRecall: true, reason: "first-prompt" };
   if (trimmed.startsWith("!"))
     return { shouldRecall: false, reason: "opt-out" };
-  if (trimmed.length < 15)
+  if (trimmed.length < MIN_RECALL_LENGTH)
     return { shouldRecall: false, reason: "too-short" };
-
-  const hasQuestion = QUESTION_WORDS.test(trimmed);
-
-  if (!hasQuestion) {
-    const state = readState();
-    if (
-      state.lastRecallAt > 0 &&
-      Date.now() - state.lastRecallAt < DEBOUNCE_MS
-    ) {
-      return { shouldRecall: false, reason: "debounce" };
-    }
-  }
-
-  if (TOOL_COMMANDS.test(trimmed) && !hasQuestion)
-    return { shouldRecall: false, reason: "tool-command" };
-  if (isCodeHeavy(trimmed) && FILE_REF.test(trimmed) && !hasQuestion)
-    return { shouldRecall: false, reason: "code-prompt" };
-  if (hasQuestion) return { shouldRecall: true, reason: "question" };
+  if (looksLikeBareShellCommand(trimmed))
+    return { shouldRecall: false, reason: "bare-shell-command" };
+  if (isFirstPrompt) return { shouldRecall: true, reason: "first-prompt" };
   return { shouldRecall: true, reason: "default" };
 }

--- a/cli/src/plugin/auto-recall.ts
+++ b/cli/src/plugin/auto-recall.ts
@@ -13,7 +13,7 @@ import { loadConfig, isHookEnabled } from "./config.js";
 import { NexClient } from "./nex-client.js";
 import { formatNexContext } from "./context-format.js";
 import { SessionStore } from "./session-store.js";
-import { shouldRecall, recordRecall } from "./recall-filter.js";
+import { shouldRecall } from "./recall-filter.js";
 
 const sessions = new SessionStore();
 
@@ -104,9 +104,6 @@ async function main(): Promise<void> {
     if (result.session_id && sessionKey) {
       sessions.set(sessionKey, result.session_id);
     }
-
-    // Record successful recall for debounce
-    recordRecall(result.session_id);
 
     const entityCount = result.entity_references?.length ?? 0;
     const context = formatNexContext({

--- a/cli/src/plugin/auto-session-start.ts
+++ b/cli/src/plugin/auto-session-start.ts
@@ -17,7 +17,6 @@ import { NexClient } from "./nex-client.js";
 import { RateLimiter } from "./rate-limiter.js";
 import { formatNexContext } from "./context-format.js";
 import { SessionStore } from "./session-store.js";
-import { recordRecall } from "./recall-filter.js";
 import { scanAndIngest } from "./file-scanner.js";
 import { ingestContextFiles } from "./context-files.js";
 import { readManifest as readScanManifest, isScanFresh, markScanned, writeManifest as writeScanManifest } from "./file-manifest.js";
@@ -159,9 +158,6 @@ async function main(): Promise<void> {
     if (result.session_id && input.session_id) {
       sessions.set(input.session_id, result.session_id);
     }
-
-    // Record this as a successful recall for debounce
-    recordRecall(result.session_id);
 
     const entityCount = result.entity_references?.length ?? 0;
     const context = formatNexContext({

--- a/cli/src/plugin/recall-filter.ts
+++ b/cli/src/plugin/recall-filter.ts
@@ -1,125 +1,55 @@
 /**
- * Smart prompt classifier for selective recall.
+ * Minimal recall filter for Claude Code.
  *
- * Determines whether a prompt is likely knowledge-seeking (needs recall)
- * or a pure coding directive (skip recall). Also handles debounce —
- * skips recall if a successful recall happened within the debounce window,
- * unless the current prompt contains question words.
- *
- * Persistence: last-recall timestamp stored in ~/.nex/recall-state.json
+ * The intended behavior is to query Nex for nearly every user message and
+ * skip only clearly low-signal input such as very short replies, explicit
+ * opt-outs, or raw shell commands. Natural-language coding prompts still go
+ * through Ask so memory is available during regular coding turns.
  */
 
-import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
-import { join } from "node:path";
-import { workspaceDataDir } from "./workspace-data-dir.js";
-
-function dataDir(): string {
-  return workspaceDataDir();
-}
-
-function stateFile(): string {
-  return join(dataDir(), "recall-state.json");
-}
-const DEBOUNCE_MS = 30_000; // 30 seconds
-
-// --- Question words that signal knowledge-seeking intent ---
-const QUESTION_WORDS = /\b(who|what|when|where|why|how|which|tell|explain|describe|summarize|summarise|list|find|show|get|any|does|did|is|are|was|were|have|has|do|can|could|should|would|will)\b/i;
-
-// --- Tool/action commands that are pure coding directives ---
-const TOOL_COMMANDS = /^\s*(run|build|test|lint|format|deploy|install|uninstall|start|stop|restart|commit|push|pull|merge|rebase|checkout|fetch|init|fix|refactor|rename|move|delete|remove|add|create|update|upgrade|downgrade|migrate|generate|scaffold|compile|bundle|watch|serve|debug|profile|bench|clean|reset|undo|redo|revert|squash|cherry-pick|tag|release|publish|npm|npx|yarn|pnpm|bun|pip|cargo|go|make|docker|kubectl|terraform|git|gh|cd|ls|cat|grep|find|mkdir|rm|cp|mv|touch|echo|export|source|chmod|chown|curl|wget|ssh|scp)\b/i;
-
-// --- File reference pattern (paths, extensions) ---
-const FILE_REF = /(?:[\w./\\-]+\.\w{1,10}|src\/|lib\/|dist\/|node_modules\/|\.\/|\.\.\/)/;
-
-// --- Code-heavy: >50% non-alpha characters (brackets, operators, etc.) ---
-function isCodeHeavy(text: string): boolean {
-  const alpha = text.replace(/[^a-zA-Z]/g, "").length;
-  return alpha < text.length * 0.5;
-}
+const MIN_RECALL_LENGTH = 15;
+const NATURAL_LANGUAGE_HINTS =
+  /\b(please|can|could|would|should|what|when|where|why|how|who|tell|explain|describe|summarize|check|review|look|find|show|help|about|for|to|with|without|into|from|before|after|need|want|current|my|our|this|that)\b/i;
+const BARE_SHELL_COMMAND =
+  /^(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)*(?:ls|pwd|cd|cat|grep|rg|find|mkdir|rm|cp|mv|touch|echo|git|npm|npx|yarn|pnpm|bun|node|python|python3|pytest|make|docker|kubectl|terraform)\b/i;
+const COMMAND_TOKEN = /^(?:[A-Za-z_][A-Za-z0-9_]*=\S+|--?[\w./:=@%+,~-]+|[\w./:=@%+,~-]+|["'][^"']*["'])$/;
 
 export interface RecallDecision {
   shouldRecall: boolean;
   reason: string;
 }
 
-interface RecallState {
-  lastRecallAt: number; // epoch ms
-  lastRecallSessionId?: string;
-}
-
-function readState(): RecallState {
-  try {
-    const raw = readFileSync(stateFile(), "utf-8");
-    return JSON.parse(raw) as RecallState;
-  } catch {
-    return { lastRecallAt: 0 };
+function looksLikeBareShellCommand(prompt: string): boolean {
+  if (!BARE_SHELL_COMMAND.test(prompt)) {
+    return false;
   }
-}
 
-function writeState(state: RecallState): void {
-  try {
-    mkdirSync(dataDir(), { recursive: true });
-    writeFileSync(stateFile(), JSON.stringify(state), "utf-8");
-  } catch {
-    // best-effort
+  if (NATURAL_LANGUAGE_HINTS.test(prompt)) {
+    return false;
   }
+
+  return prompt.split(/\s+/).every((token) => COMMAND_TOKEN.test(token));
 }
 
-/**
- * Record that a successful recall just happened.
- * Call this after a non-empty /ask response.
- */
-export function recordRecall(sessionId?: string): void {
-  writeState({ lastRecallAt: Date.now(), lastRecallSessionId: sessionId });
-}
-
-/**
- * Determine whether this prompt should trigger a Nex /ask recall.
- */
 export function shouldRecall(prompt: string, isFirstPrompt: boolean): RecallDecision {
   const trimmed = prompt.trim();
-
-  // Always recall on first prompt of session
-  if (isFirstPrompt) {
-    return { shouldRecall: true, reason: "first-prompt" };
-  }
 
   // Explicit opt-out: prompt starts with !
   if (trimmed.startsWith("!")) {
     return { shouldRecall: false, reason: "opt-out" };
   }
 
-  // Too short — likely a directive like "yes", "ok", "done"
-  if (trimmed.length < 15) {
+  if (trimmed.length < MIN_RECALL_LENGTH) {
     return { shouldRecall: false, reason: "too-short" };
   }
 
-  // Has question words — likely knowledge-seeking
-  const hasQuestion = QUESTION_WORDS.test(trimmed);
-
-  // Check debounce: skip if recent successful recall, unless question
-  if (!hasQuestion) {
-    const state = readState();
-    if (state.lastRecallAt > 0 && Date.now() - state.lastRecallAt < DEBOUNCE_MS) {
-      return { shouldRecall: false, reason: "debounce" };
-    }
+  if (looksLikeBareShellCommand(trimmed)) {
+    return { shouldRecall: false, reason: "bare-shell-command" };
   }
 
-  // Tool/action commands — pure coding directives
-  if (TOOL_COMMANDS.test(trimmed) && !hasQuestion) {
-    return { shouldRecall: false, reason: "tool-command" };
+  if (isFirstPrompt) {
+    return { shouldRecall: true, reason: "first-prompt" };
   }
 
-  // Code-heavy with file references and no question words
-  if (isCodeHeavy(trimmed) && FILE_REF.test(trimmed) && !hasQuestion) {
-    return { shouldRecall: false, reason: "code-prompt" };
-  }
-
-  // Has question words — always recall
-  if (hasQuestion) {
-    return { shouldRecall: true, reason: "question" };
-  }
-
-  // Default: recall (err on the side of providing context)
   return { shouldRecall: true, reason: "default" };
 }

--- a/cli/tests/lib/recall-filter.test.ts
+++ b/cli/tests/lib/recall-filter.test.ts
@@ -1,20 +1,8 @@
-import { describe, test, expect, beforeEach } from "bun:test";
-import { writeFileSync, mkdirSync } from "node:fs";
-import { join } from "node:path";
-import { homedir } from "node:os";
+import { describe, test, expect } from "bun:test";
 import { shouldRecall } from "../../src/lib/recall-filter.ts";
 
-const DATA_DIR = join(homedir(), ".nex");
-const STATE_FILE = join(DATA_DIR, "recall-state.json");
-
 describe("shouldRecall", () => {
-  // Reset recall state before each test to avoid debounce interference
-  beforeEach(() => {
-    mkdirSync(DATA_DIR, { recursive: true });
-    writeFileSync(STATE_FILE, JSON.stringify({ lastRecallAt: 0 }), "utf-8");
-  });
-
-  test("always recalls on first prompt", () => {
+  test("recalls on first prompt when message is long enough", () => {
     const result = shouldRecall("anything at all", true);
     expect(result.shouldRecall).toBe(true);
     expect(result.reason).toBe("first-prompt");
@@ -32,28 +20,51 @@ describe("shouldRecall", () => {
     expect(result.reason).toBe("too-short");
   });
 
-  test("recalls on question words", () => {
+  test("still skips short first prompts", () => {
+    const result = shouldRecall("thanks", true);
+    expect(result.shouldRecall).toBe(false);
+    expect(result.reason).toBe("too-short");
+  });
+
+  test("skips bare shell commands", () => {
+    const result = shouldRecall("git status --short", false);
+    expect(result.shouldRecall).toBe(false);
+    expect(result.reason).toBe("bare-shell-command");
+  });
+
+  test("skips bare package-manager commands", () => {
+    const result = shouldRecall("bun test tests/lib/recall-filter.test.ts", false);
+    expect(result.shouldRecall).toBe(false);
+    expect(result.reason).toBe("bare-shell-command");
+  });
+
+  test("recalls normal questions", () => {
     const result = shouldRecall("What is the status of my contacts?", false);
     expect(result.shouldRecall).toBe(true);
-    expect(result.reason).toBe("question");
+    expect(result.reason).toBe("default");
   });
 
-  test("skips tool commands without questions", () => {
+  test("recalls tool-style prompts", () => {
     const result = shouldRecall("run the build script for production", false);
-    expect(result.shouldRecall).toBe(false);
-    expect(result.reason).toBe("tool-command");
-  });
-
-  test("skips code-heavy content without questions", () => {
-    // Code-heavy: less than 50% alpha characters + has file references
-    const result = shouldRecall("src/lib/config.ts:42 => { a: 1, b: 2 }", false);
-    expect(result.shouldRecall).toBe(false);
-    expect(result.reason).toBe("code-prompt");
-  });
-
-  test("recalls on question even with tool command", () => {
-    const result = shouldRecall("how do I run the build script?", false);
     expect(result.shouldRecall).toBe(true);
-    expect(result.reason).toBe("question");
+    expect(result.reason).toBe("default");
+  });
+
+  test("recalls code and file-reference prompts", () => {
+    const result = shouldRecall("src/lib/config.ts:42 => { a: 1, b: 2 }", false);
+    expect(result.shouldRecall).toBe(true);
+    expect(result.reason).toBe("default");
+  });
+
+  test("recalls ordinary non-question prompts", () => {
+    const result = shouldRecall("please check the Slack thread for Acme context", false);
+    expect(result.shouldRecall).toBe(true);
+    expect(result.reason).toBe("default");
+  });
+
+  test("recalls natural-language coding prompts", () => {
+    const result = shouldRecall("run the build script for production", false);
+    expect(result.shouldRecall).toBe(true);
+    expect(result.reason).toBe("default");
   });
 });


### PR DESCRIPTION
## Summary
- replace the old selective recall/debounce heuristics with a narrower filter
- skip only explicit opt-out, short prompts, and prompts that look like bare shell commands
- keep Ask enabled for natural-language coding prompts and align the Claude plugin, CLI helper, and tests

## Testing
- bun test tests/lib/recall-filter.test.ts
- npx tsc -p tsconfig.json --noEmit
- npx tsc -p tsconfig.json --noEmit
- verified the installed Claude hook skips `git status --short`
- verified the installed Claude hook still recalls for `run the build script for production`
- verified the installed Claude hook still recalls for `fix src/app.ts to handle nulls safely`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified recall decision-making logic. Recall now activates by default for most inputs and only disables for explicit opt-outs, very short prompts, or bare shell commands.
  * Removed persistent recall state tracking for a more straightforward behavior model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->