### PR TITLE
Fix Node 25 CLI version lookup

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nex-ai/nex",
-  "version": "0.1.35",
+  "version": "0.1.58",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nex-ai/nex",
-      "version": "0.1.35",
+      "version": "0.1.58",
       "license": "MIT",
       "dependencies": {
         "@inkjs/ui": "^2.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nex-ai/nex",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "description": "Nex CLI provides organizational context & memory to AI agents. Connect email, CRM, Slack, meetings, and 100+ tools into one knowledge graph.",
   "mcpName": "io.github.nex-crm/nex",
   "type": "module",

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -11,6 +11,10 @@
 import { dispatch, dispatchTokens, commandNames } from "./commands/dispatch.js";
 import { resolveFormat } from "./lib/config.js";
 import type { Format } from "./lib/output.js";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const { version } = require("../package.json") as { version: string };
 
 /**
  * Extract global flags (--format, --api-key, --timeout) from args.
@@ -56,8 +60,6 @@ async function main(): Promise<void> {
 
   // --version flag
   if (args.includes("--version") || args.includes("-v")) {
-    const pkg: any = await import("../package.json");
-    const version = pkg.default?.version ?? pkg.version;
     console.log(version);
     process.exit(0);
   }


### PR DESCRIPTION
## Summary
- replace the CLI `--version` JSON import with `createRequire(...)`
- avoid Node 25 `ERR_IMPORT_ATTRIBUTE_MISSING` when loading `package.json`
- bump the CLI package version to `0.1.58`

## Testing
- bun test tests/lib/recall-filter.test.ts
- npm run build
- node dist/index.js --version
- npm pack --dry-run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped CLI package version to 0.1.58

<!-- end of auto-generated comment: release notes by coderabbit.ai -->