### PR TITLE
feat: transform npm package into thin nex-cli shim

### DIFF
--- a/bin/nex-mcp.js
+++ b/bin/nex-mcp.js
@@ -29,7 +29,10 @@ if (tryExec("nex-cli", args)) {
   process.exit(0);
 }
 
-const commonPaths = ["/usr/local/bin/nex-cli", `${process.env.HOME}/.local/bin/nex-cli`];
+const commonPaths = ["/usr/local/bin/nex-cli"];
+if (process.env.HOME) {
+  commonPaths.push(`${process.env.HOME}/.local/bin/nex-cli`);
+}
 for (const p of commonPaths) {
   if (existsSync(p) && tryExec(p, args)) {
     process.exit(0);

--- a/bin/nex-mcp.js
+++ b/bin/nex-mcp.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+
+/**
+ * Thin shim for nex-mcp — delegates to nex-cli mcp.
+ *
+ * This entry point exists for MCP registry compatibility.
+ * Platforms like Claude Desktop install MCP servers via: npx @nex-ai/nex
+ * which resolves to this shim, which delegates to the nex-cli binary.
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+
+const args = ["mcp", ...process.argv.slice(2)];
+
+function tryExec(command, commandArgs) {
+  try {
+    execFileSync(command, commandArgs, { stdio: "inherit" });
+    return true;
+  } catch (err) {
+    if (err.status !== null && err.status !== undefined) {
+      process.exit(err.status);
+    }
+    return false;
+  }
+}
+
+if (tryExec("nex-cli", args)) {
+  process.exit(0);
+}
+
+const commonPaths = ["/usr/local/bin/nex-cli", `${process.env.HOME}/.local/bin/nex-cli`];
+for (const p of commonPaths) {
+  if (existsSync(p) && tryExec(p, args)) {
+    process.exit(0);
+  }
+}
+
+console.error(`
+  nex-cli binary not found.
+
+  Install it with:
+    curl -fsSL https://raw.githubusercontent.com/nex-crm/nex-cli/main/install.sh | sh
+
+  Then run your command again.
+`);
+process.exit(1);

--- a/bin/nex.js
+++ b/bin/nex.js
@@ -31,7 +31,10 @@ if (tryExec("nex-cli", args)) {
 }
 
 // 2. Try common install locations
-const commonPaths = ["/usr/local/bin/nex-cli", `${process.env.HOME}/.local/bin/nex-cli`];
+const commonPaths = ["/usr/local/bin/nex-cli"];
+if (process.env.HOME) {
+  commonPaths.push(`${process.env.HOME}/.local/bin/nex-cli`);
+}
 for (const p of commonPaths) {
   if (existsSync(p) && tryExec(p, args)) {
     process.exit(0);

--- a/bin/nex.js
+++ b/bin/nex.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+
+/**
+ * Thin shim for @nex-ai/nex — delegates all commands to the nex-cli binary.
+ *
+ * Install the binary: curl -fsSL https://raw.githubusercontent.com/nex-crm/nex-cli/main/install.sh | sh
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+
+const args = process.argv.slice(2);
+
+// Try nex-cli on PATH first
+function tryExec(command, commandArgs) {
+  try {
+    execFileSync(command, commandArgs, { stdio: "inherit" });
+    return true;
+  } catch (err) {
+    // If the command was found but returned non-zero, propagate the exit code
+    if (err.status !== null && err.status !== undefined) {
+      process.exit(err.status);
+    }
+    return false;
+  }
+}
+
+// 1. Try nex-cli directly (installed via curl | sh)
+if (tryExec("nex-cli", args)) {
+  process.exit(0);
+}
+
+// 2. Try common install locations
+const commonPaths = ["/usr/local/bin/nex-cli", `${process.env.HOME}/.local/bin/nex-cli`];
+for (const p of commonPaths) {
+  if (existsSync(p) && tryExec(p, args)) {
+    process.exit(0);
+  }
+}
+
+// 3. Not found — show install instructions
+console.error(`
+  nex-cli binary not found.
+
+  Install it with:
+    curl -fsSL https://raw.githubusercontent.com/nex-crm/nex-cli/main/install.sh | sh
+
+  Then run your command again.
+`);
+process.exit(1);

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@nex-ai/nex",
-  "version": "0.1.40",
-  "description": "Nex CLI provides organizational context & memory to AI agents. Connect email, CRM, Slack, meetings, and 100+ tools into one knowledge graph.",
+  "version": "0.2.0",
+  "description": "Nex CLI provides organizational context & memory to AI agents. This package delegates to the nex-cli binary.",
   "mcpName": "io.github.nex-crm/nex",
   "type": "module",
   "bin": {
-    "nex": "dist/index.js",
-    "nex-mcp": "dist/mcp/index.js"
+    "nex": "bin/nex.js",
+    "nex-mcp": "bin/nex-mcp.js"
   },
   "files": [
-    "dist",
+    "bin",
     "plugin-commands",
     "platform-rules",
     "platform-plugins",
@@ -22,7 +22,6 @@
     "ai-agent",
     "ai-memory",
     "knowledge-graph",
-    "crm",
     "context",
     "nex",
     "organizational-memory",
@@ -30,30 +29,14 @@
     "claude",
     "cursor",
     "copilot",
-    "openai",
-    "integrations",
-    "slack",
-    "email"
+    "integrations"
   ],
   "scripts": {
-    "build": "tsc",
-    "start": "bun dist/index.js",
-    "dev": "bun src/index.ts",
-    "test": "bun test",
-    "prepublishOnly": "bun run build"
-  },
-  "devDependencies": {
-    "@types/bun": "latest",
-    "@types/node": "^22.0.0",
-    "@types/react": "^18.3.18",
-    "ink-testing-library": "^4.0.0",
-    "tsx": "^4.19.0",
-    "typescript": "^5.7.0"
+    "test": "node bin/nex.js --version"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/nex-crm/nex-as-a-skill.git",
-    "directory": "cli"
+    "url": "https://github.com/nex-crm/nex-as-a-skill.git"
   },
   "homepage": "https://nex.ai",
   "bugs": {
@@ -65,13 +48,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "license": "MIT",
-  "dependencies": {
-    "@inkjs/ui": "^2.0.0",
-    "@modelcontextprotocol/sdk": "^1.12.0",
-    "commander": "^14.0.3",
-    "ink": "^5.2.1",
-    "react": "^18.3.1",
-    "zod": "^3.25.0"
-  }
+  "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nex-ai/nex",
   "version": "0.2.0",
-  "description": "Nex CLI provides organizational context & memory to AI agents. This package delegates to the nex-cli binary.",
+  "description": "Nex CLI provides organizational context & memory to AI agents. Connect email, CRM, Slack, meetings, and 100+ tools into one knowledge graph. Delegates to the nex-cli binary.",
   "mcpName": "io.github.nex-crm/nex",
   "type": "module",
   "bin": {
@@ -32,7 +32,7 @@
     "integrations"
   ],
   "scripts": {
-    "test": "node bin/nex.js --version"
+    "test": "node --check bin/nex.js && node --check bin/nex-mcp.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Replace full CLI implementation with thin bin shims that delegate to `nex-cli` binary
- `bin/nex.js` tries `nex-cli` on PATH, falls back to install instructions
- `bin/nex-mcp.js` delegates to `nex-cli mcp` for MCP registry compatibility
- Remove all runtime dependencies — package drops from ~2MB to ~50KB
- Bump to v0.2.0 to signal the architectural change

This is the nex-as-a-skill side of the migration. The companion PR ([nex-crm/nex-cli#59](https://github.com/nex-crm/nex-cli/pull/59)) adds the MCP server, hooks, and installers to the nex-cli binary.

## What stays open source
- `platform-rules/` — 10 platform instruction files
- `plugin-commands/` — 7 slash command definitions
- `platform-plugins/` — Windsurf workflows
- `bin/` — Thin shims (visible delegation logic)

## Migration path for users
1. Install nex-cli: `curl -fsSL https://raw.githubusercontent.com/nex-crm/nex-cli/main/install.sh | sh`
2. `npx @nex-ai/nex` and `nex-mcp` continue to work (delegate to binary)
3. `nex-cli setup` handles platform detection and hook installation

## Test plan
- [x] `bin/nex.js --version` delegates correctly when nex-cli is on PATH
- [x] `bin/nex-mcp.js` delegates to `nex-cli mcp`
- [ ] Verify `npx @nex-ai/nex setup` works after npm publish
- [ ] Verify MCP registry entry still resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New CLI entrypoints that forward commands to the main CLI binary, with fallback detection of common install locations and clear install/help messaging when not available.

* **Chores**
  * Version bumped to 0.2.0.
  * Simplified package metadata, reduced build/dev scripts, and adjusted published files to include the new CLI wrappers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->