### PR TITLE
Trigger compounding after real scans

### DIFF
--- a/cli/src/commands/dispatch.ts
+++ b/cli/src/commands/dispatch.ts
@@ -11,7 +11,7 @@ import { resolveApiKey, resolveFormat, resolveTimeout, loadConfig, saveConfig, C
 import { formatOutput } from "../lib/output.js";
 import type { Format } from "../lib/output.js";
 import { AuthError, RateLimitError, ServerError } from "../lib/errors.js";
-import { shouldTriggerCompounding, triggerCompounding } from "../lib/compounding.js";
+import { launchBackgroundCompounding, shouldTriggerCompounding } from "../lib/compounding.js";
 import { parseInput } from "./parse-input.js";
 import { getAgentService } from "../tui/services/agent-service.js";
 import { runInit, detectPlatforms, getDetected } from "./init.js";
@@ -1408,8 +1408,9 @@ async function executeScan(args: string[], ctx: CommandContext): Promise<Command
     });
 
     // Trigger compounding intelligence after successful ingestion
-    if (shouldTriggerCompounding(result.scanned, dryRun)) {
-      triggerCompounding(client).catch(() => {});
+    const apiKey = ctx.apiKey ?? resolveApiKey();
+    if (apiKey && shouldTriggerCompounding(result.scanned, dryRun)) {
+      launchBackgroundCompounding(apiKey);
     }
 
     return ok({ scanned: result.scanned, skipped: result.skipped, errors: result.errors }, ctx);

--- a/cli/src/commands/dispatch.ts
+++ b/cli/src/commands/dispatch.ts
@@ -11,6 +11,7 @@ import { resolveApiKey, resolveFormat, resolveTimeout, loadConfig, saveConfig, C
 import { formatOutput } from "../lib/output.js";
 import type { Format } from "../lib/output.js";
 import { AuthError, RateLimitError, ServerError } from "../lib/errors.js";
+import { shouldTriggerCompounding, triggerCompounding } from "../lib/compounding.js";
 import { parseInput } from "./parse-input.js";
 import { getAgentService } from "../tui/services/agent-service.js";
 import { runInit, detectPlatforms, getDetected } from "./init.js";
@@ -58,17 +59,6 @@ function fmt(data: unknown, ctx: CommandContext): string {
 
 function ok(data: unknown, ctx: CommandContext, extra?: Partial<CommandResult>): CommandResult {
   return { output: fmt(data, ctx), data, exitCode: 0, ...extra };
-}
-
-/**
- * Trigger compounding intelligence jobs (pattern detection, playbook synthesis)
- * after content ingestion. Runs in the background — errors are non-fatal.
- */
-async function triggerCompounding(client: NexClient): Promise<void> {
-  const jobs = ["consolidation", "pattern_detection", "playbook_synthesis"];
-  await Promise.allSettled(
-    jobs.map((job) => client.post("/v1/compounding/trigger", { job_type: job, dry_run: false }, 10_000)),
-  );
 }
 
 function fail(error: string, exitCode = 1): CommandResult {
@@ -1418,7 +1408,7 @@ async function executeScan(args: string[], ctx: CommandContext): Promise<Command
     });
 
     // Trigger compounding intelligence after successful ingestion
-    if (!dryRun && result.scanned > 0) {
+    if (shouldTriggerCompounding(result.scanned, dryRun)) {
       triggerCompounding(client).catch(() => {});
     }
 

--- a/cli/src/commands/scan.ts
+++ b/cli/src/commands/scan.ts
@@ -7,7 +7,7 @@ import { resolveApiKey, resolveFormat, resolveTimeout } from "../lib/config.js";
 import { NexClient } from "../lib/client.js";
 import { printOutput, printError } from "../lib/output.js";
 import { scanFiles, loadScanConfig, isScanEnabled } from "../lib/file-scanner.js";
-import { shouldTriggerCompounding, triggerCompounding } from "../lib/compounding.js";
+import { launchBackgroundCompounding, shouldTriggerCompounding } from "../lib/compounding.js";
 import type { Format } from "../lib/output.js";
 import { spinner as createSpinner, table, style, sym, isTTY, exitHint } from "../lib/tui.js";
 
@@ -116,8 +116,8 @@ program
           return client.post("/v1/context/text", { content, context });
         });
 
-        if (shouldTriggerCompounding(result.scanned, opts.dryRun)) {
-          triggerCompounding(client).catch(() => {});
+        if (apiKey && shouldTriggerCompounding(result.scanned, opts.dryRun)) {
+          launchBackgroundCompounding(apiKey);
         }
 
         if (spin) {

--- a/cli/src/commands/scan.ts
+++ b/cli/src/commands/scan.ts
@@ -7,6 +7,7 @@ import { resolveApiKey, resolveFormat, resolveTimeout } from "../lib/config.js";
 import { NexClient } from "../lib/client.js";
 import { printOutput, printError } from "../lib/output.js";
 import { scanFiles, loadScanConfig, isScanEnabled } from "../lib/file-scanner.js";
+import { shouldTriggerCompounding, triggerCompounding } from "../lib/compounding.js";
 import type { Format } from "../lib/output.js";
 import { spinner as createSpinner, table, style, sym, isTTY, exitHint } from "../lib/tui.js";
 
@@ -114,6 +115,10 @@ program
         const result = await scanFiles(dir, scanOpts, async (content, context) => {
           return client.post("/v1/context/text", { content, context });
         });
+
+        if (shouldTriggerCompounding(result.scanned, opts.dryRun)) {
+          triggerCompounding(client).catch(() => {});
+        }
 
         if (spin) {
           spin.succeed("Scan complete");

--- a/cli/src/commands/setup.ts
+++ b/cli/src/commands/setup.ts
@@ -48,7 +48,7 @@ import {
 } from "../lib/installers.js";
 import { writeDefaultProjectConfig } from "../lib/project-config.js";
 import { scanFiles, loadScanConfig, isScanEnabled } from "../lib/file-scanner.js";
-import { shouldTriggerCompounding, triggerCompounding } from "../lib/compounding.js";
+import { launchBackgroundCompounding, shouldTriggerCompounding } from "../lib/compounding.js";
 
 function getClient(): { client: NexClient; format: Format } {
   const opts = program.opts();
@@ -459,7 +459,7 @@ async function runSetup(opts: {
         spin?.update(`Scanning files (${current}/${total}): ${name}  ${exitHint}`);
       });
       if (shouldTriggerCompounding(scanResult.scanned)) {
-        triggerCompounding(client).catch(() => {});
+        launchBackgroundCompounding(apiKey);
       }
       if (scanResult.scanned > 0) {
         spin?.succeed(`${scanResult.scanned} files ingested, ${scanResult.skipped} skipped, ${scanResult.errors} errors`);

--- a/cli/src/commands/setup.ts
+++ b/cli/src/commands/setup.ts
@@ -48,6 +48,7 @@ import {
 } from "../lib/installers.js";
 import { writeDefaultProjectConfig } from "../lib/project-config.js";
 import { scanFiles, loadScanConfig, isScanEnabled } from "../lib/file-scanner.js";
+import { shouldTriggerCompounding, triggerCompounding } from "../lib/compounding.js";
 
 function getClient(): { client: NexClient; format: Format } {
   const opts = program.opts();
@@ -457,6 +458,9 @@ async function runSetup(opts: {
         const name = filePath.replace(process.cwd() + "/", "");
         spin?.update(`Scanning files (${current}/${total}): ${name}  ${exitHint}`);
       });
+      if (shouldTriggerCompounding(scanResult.scanned)) {
+        triggerCompounding(client).catch(() => {});
+      }
       if (scanResult.scanned > 0) {
         spin?.succeed(`${scanResult.scanned} files ingested, ${scanResult.skipped} skipped, ${scanResult.errors} errors`);
         results.push(`File scan: ${scanResult.scanned} files ingested, ${scanResult.skipped} skipped, ${scanResult.errors} errors`);

--- a/cli/src/lib/compounding-worker.ts
+++ b/cli/src/lib/compounding-worker.ts
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+
+import { NexClient } from "./client.js";
+import { triggerCompounding, COMPOUNDING_BACKGROUND_TIMEOUT_MS } from "./compounding.js";
+
+/**
+ * Run compounding triggers in a detached process so the parent CLI command can
+ * exit immediately even when the backend keeps the HTTP response open.
+ */
+async function main(): Promise<void> {
+  const apiKey = process.env.NEX_API_KEY;
+  if (!apiKey) {
+    return;
+  }
+
+  const rawTimeout = Number.parseInt(process.env.NEX_COMPOUNDING_TIMEOUT_MS ?? "", 10);
+  const timeoutMs = Number.isFinite(rawTimeout) && rawTimeout > 0
+    ? rawTimeout
+    : COMPOUNDING_BACKGROUND_TIMEOUT_MS;
+
+  const client = new NexClient(apiKey, timeoutMs);
+  await triggerCompounding(client);
+}
+
+main().then(() => process.exit(0)).catch(() => process.exit(0));

--- a/cli/src/lib/compounding.ts
+++ b/cli/src/lib/compounding.ts
@@ -1,10 +1,23 @@
+import { spawn } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import type { NexClient } from "./client.js";
+import { BASE_URL } from "./config.js";
 
 type CompoundingClient = Pick<NexClient, "post">;
 
 export const COMPOUNDING_JOBS = ["consolidation", "pattern_detection", "playbook_synthesis"] as const;
 export const COMPOUNDING_TRIGGER_TIMEOUT_MS = 10_000;
+export const COMPOUNDING_BACKGROUND_TIMEOUT_MS = 120_000;
 
+const WORKER_PATH = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "compounding-worker.js",
+);
+
+/**
+ * Returns whether a scan result should kick off compounding jobs.
+ */
 export function shouldTriggerCompounding(scanned: number, dryRun = false): boolean {
   return !dryRun && scanned > 0;
 }
@@ -19,4 +32,27 @@ export async function triggerCompounding(client: CompoundingClient): Promise<voi
       client.post("/v1/compounding/trigger", { job_type: job, dry_run: false }, COMPOUNDING_TRIGGER_TIMEOUT_MS),
     ),
   );
+}
+
+/**
+ * Launch compounding triggers in a detached worker so the caller does not wait
+ * on a backend response that may hang for valid job types.
+ */
+export function launchBackgroundCompounding(apiKey: string): void {
+  try {
+    const baseUrl = typeof BASE_URL === "string" ? BASE_URL : "https://app.nex.ai";
+    const child = spawn(process.execPath, [WORKER_PATH], {
+      detached: true,
+      env: {
+        ...process.env,
+        NEX_API_KEY: apiKey,
+        NEX_DEV_URL: baseUrl,
+        NEX_COMPOUNDING_TIMEOUT_MS: String(COMPOUNDING_BACKGROUND_TIMEOUT_MS),
+      },
+      stdio: "ignore" as const,
+    });
+    child.unref();
+  } catch {
+    // Ignore background trigger failures so scans remain non-fatal.
+  }
 }

--- a/cli/src/lib/compounding.ts
+++ b/cli/src/lib/compounding.ts
@@ -1,0 +1,22 @@
+import type { NexClient } from "./client.js";
+
+type CompoundingClient = Pick<NexClient, "post">;
+
+export const COMPOUNDING_JOBS = ["consolidation", "pattern_detection", "playbook_synthesis"] as const;
+export const COMPOUNDING_TRIGGER_TIMEOUT_MS = 10_000;
+
+export function shouldTriggerCompounding(scanned: number, dryRun = false): boolean {
+  return !dryRun && scanned > 0;
+}
+
+/**
+ * Trigger compounding intelligence jobs after content ingestion.
+ * Runs in the background — errors are non-fatal to the scan flow.
+ */
+export async function triggerCompounding(client: CompoundingClient): Promise<void> {
+  await Promise.allSettled(
+    COMPOUNDING_JOBS.map((job) =>
+      client.post("/v1/compounding/trigger", { job_type: job, dry_run: false }, COMPOUNDING_TRIGGER_TIMEOUT_MS),
+    ),
+  );
+}

--- a/cli/tests/lib/compounding.test.ts
+++ b/cli/tests/lib/compounding.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, mock } from "bun:test";
+import { COMPOUNDING_JOBS, COMPOUNDING_TRIGGER_TIMEOUT_MS, shouldTriggerCompounding, triggerCompounding } from "../../src/lib/compounding.ts";
+
+describe("shouldTriggerCompounding", () => {
+  it("triggers only when files were scanned and the run is not dry-run", () => {
+    expect(shouldTriggerCompounding(1)).toBe(true);
+    expect(shouldTriggerCompounding(0)).toBe(false);
+    expect(shouldTriggerCompounding(3, true)).toBe(false);
+  });
+});
+
+describe("triggerCompounding", () => {
+  it("posts all compounding jobs to the trigger endpoint", async () => {
+    const post = mock(async () => ({}));
+
+    await triggerCompounding({ post });
+
+    expect(post).toHaveBeenCalledTimes(COMPOUNDING_JOBS.length);
+    expect(post.mock.calls).toEqual(
+      COMPOUNDING_JOBS.map((job) => [
+        "/v1/compounding/trigger",
+        { job_type: job, dry_run: false },
+        COMPOUNDING_TRIGGER_TIMEOUT_MS,
+      ]),
+    );
+  });
+
+  it("attempts every job even if one request fails", async () => {
+    const post = mock(async (_path: string, body?: { job_type?: string }) => {
+      if (body?.job_type === "pattern_detection") {
+        throw new Error("boom");
+      }
+      return {};
+    });
+
+    await expect(triggerCompounding({ post })).resolves.toBeUndefined();
+    expect(post).toHaveBeenCalledTimes(COMPOUNDING_JOBS.length);
+  });
+});


### PR DESCRIPTION
## Summary
- move the compounding trigger into a shared helper
- invoke it from the real `nex scan` and `nex setup` flows, not just the legacy dispatcher path
- add unit coverage for trigger conditions and posted jobs

## Verification
- bun test cli/tests/lib/compounding.test.ts
- cd cli && bunx tsc --noEmit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic background compounding now launches after successful file scans when an API key is available and files were actually scanned; skipped in dry-run. The background launch is detached/non-blocking and won’t cause the scan command to fail if compounding errors occur.

* **Tests**
  * Added tests validating the compounding trigger gating (scan count and dry-run) and resilient behavior when individual compounding jobs fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->