### PR TITLE
docs: rewrite README for post-migration repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Pre-written agent instructions that teach each platform how to use Nex tools. Co
 |----------|------|-------------|
 | Cursor | `cursor-rules.md` | `.cursor/rules/` |
 | Windsurf | `windsurf-rules.md` | `.windsurf/rules/` |
-| VS Code | `vscode-instructions.md` | `.github/instructions/` |
+| GitHub Copilot | `vscode-instructions.md` | `.github/instructions/` |
 | Zed | `zed-rules.md` | `.zed/rules/` |
 | Aider | `aider-conventions.md` | `.aider/conventions/` |
 | Cline | `cline-rules.md` | `.cline/rules/` |
@@ -203,7 +203,7 @@ Do not stop after partial setup. Only pause if you need my email for registratio
 
 ### Repo structure
 
-```
+```text
 src/                    # Bootstrapper binary source (compiled via Bun)
 bin/                    # Thin Node.js shims that delegate to nex-cli (npm fallback)
 install.sh              # curl-pipe installer for the standalone binary

--- a/README.md
+++ b/README.md
@@ -11,30 +11,15 @@ Supports Claude Code, OpenClaw, Cursor, Windsurf, Codex, Aider, Continue, Zed, a
 
 Talk to the team, share feedback, and connect with other developers building AI agents with Nex.
 
-## What's in this repo
-
-This repo is the **public integration layer** for Nex. It contains the npm package, platform plugins, agent instructions, and slash commands. The heavy lifting happens in the [`nex-cli`](https://github.com/nex-crm/nex-cli) binary, which is installed separately.
-
-```
-bin/                    # Thin Node.js shims that delegate to nex-cli
-claude-code-plugin/     # Claude Code hooks (auto-recall, auto-capture, slash commands)
-openclaw-plugin/        # OpenClaw plugin (15+ tools, auto-recall, auto-capture)
-plugin-commands/        # Slash command definitions (.md files)
-platform-rules/         # Agent instructions for 10 platforms (Cursor, Windsurf, Zed, etc.)
-platform-plugins/       # Editor integrations (Continue, OpenCode, KiloCode, Windsurf workflows)
-scripts/                # Bash API wrappers for shell-only agents
-server.json             # MCP Registry manifest
-```
-
 ## Quick Start
 
-### Install the CLI
+### Install
 
 ```bash
 # Option A: install the nex-cli binary directly
 curl -fsSL https://raw.githubusercontent.com/nex-crm/nex-cli/main/install.sh | sh
 
-# Option B: install the npm shim (delegates to nex-cli)
+# Option B: install via npm (or bun/pnpm)
 npm install -g @nex-ai/nex
 ```
 
@@ -55,48 +40,100 @@ nex ask "who is Maria Rodriguez?"
 nex remember "Met with Maria, CTO of TechFlow. European expansion Q3, $2M budget."
 ```
 
-## Copy-Paste Bootstrap Prompt
+## Skills & Platform Rules
 
-Drop this into any terminal-capable AI agent to bootstrap Nex end to end:
+The core of this repo is a set of skills, slash commands, and agent instructions that teach any AI platform how to use Nex.
 
-```text
-Install and fully bootstrap Nex in this project from start to finish.
+### Slash Commands (`plugin-commands/`)
 
-1. If the `nex` CLI is missing, install it globally with `npm install -g @nex-ai/nex`.
-2. If Nex is not authenticated yet, ask me for the email address I want to use for registration, then continue. If Nex is already authenticated, reuse the existing account and key.
-3. Run `nex setup` and complete the full install flow for every detected AI coding platform in this environment.
-4. After setup, inspect integrations and connect the first available unconnected integration. Prefer this order when multiple choices are available: gmail, google-calendar, slack, salesforce, hubspot, attio, outlook, outlook-calendar. If OAuth is required, open the browser flow and wait for it to complete.
-5. Run a fresh file scan for the current directory so the workspace is up to date.
-6. After the scan finishes, trigger Nex compounding jobs by calling the authenticated `POST https://app.nex.ai/api/developers/v1/compounding/trigger` endpoint for these job types: `consolidation`, `pattern_detection`, and `playbook_synthesis`. Use the active Nex API key from the current environment or the config written by Nex setup.
-7. Fetch the last 24 hours of insights with the insights endpoint or `nex insight list --last 24h`, then give me a clean digest with sections for Highlights, Risks, Opportunities, Open Loops, and Recommended Next Actions.
-8. Finish by showing me:
-   - what Nex installed
-   - which integration was connected
-   - how many files were scanned and ingested
-   - whether the compounding/playbooks trigger succeeded
-   - the formatted 24-hour insight digest
+Drop these `.md` files into your agent's commands directory to get Nex slash commands:
 
-Do not stop after partial setup. Only pause if you need my email for registration or if an OAuth flow requires my interaction.
-```
+| Command | What it does |
+|---------|-------------|
+| `/nex:recall <query>` | Search your knowledge base |
+| `/nex:remember <text>` | Store information for later recall |
+| `/nex:entities <query>` | Find people, companies, topics |
+| `/nex:scan <dir>` | Scan project files into Nex |
+| `/nex:integrate <provider>` | Connect an OAuth integration |
+| `/nex:register <email>` | One-time account registration |
+| `/nex:notify` | Check recent notifications |
 
-## Platform Setup
+For Claude Code: `cp plugin-commands/*.md ~/.claude/commands/`
 
-### Claude Code
+### Platform Rules (`platform-rules/`)
 
-The fastest path is `nex setup` — it auto-configures hooks, MCP, and slash commands.
+Pre-written agent instructions that teach each platform how to use Nex tools. Copy the relevant file into your editor's config:
 
-For manual setup, see [`claude-code-plugin/README.md`](claude-code-plugin/README.md). In short:
+| Platform | File | Destination |
+|----------|------|-------------|
+| Cursor | `cursor-rules.md` | `.cursor/rules/` |
+| Windsurf | `windsurf-rules.md` | `.windsurf/rules/` |
+| VS Code | `vscode-instructions.md` | `.github/instructions/` |
+| Zed | `zed-rules.md` | `.zed/rules/` |
+| Aider | `aider-conventions.md` | `.aider/conventions/` |
+| Cline | `cline-rules.md` | `.cline/rules/` |
+| Continue | `continue-rules.md` | `.continue/rules/` |
+| KiloCode | `kilocode-rules.md` | `.kilocode/rules/` |
+| Codex | `codex-agents.md` | `.codex/agents/` |
+| OpenCode | `opencode-agents.md` | `.opencode/agents/` |
+
+### Platform Plugins (`platform-plugins/`)
+
+Deeper integrations for editors that support plugin APIs:
+
+- **Continue** (`continue-provider.ts`) — Nex as a context provider for autocomplete
+- **OpenCode** (`opencode-plugin.ts`) — Session lifecycle hooks for context preservation
+- **KiloCode** (`kilocode-modes.yaml`) — Nex memory mode definitions
+- **Windsurf** (`windsurf-workflows/`) — Native workflow definitions for ask, remember, search, notify
+
+## Plugins
+
+### Claude Code Plugin
+
+Full auto-recall and auto-capture via Claude Code hooks. Queries Nex before each prompt and captures conversation facts after each response.
 
 ```bash
 cd claude-code-plugin && bun install && bun run build
 ```
 
-Then add hooks to `~/.claude/settings.json` (see [`settings.json`](claude-code-plugin/settings.json) for the template) and copy slash commands:
+Then add hooks to `~/.claude/settings.json` (see [`settings.json`](claude-code-plugin/settings.json) for the template) and register the MCP server:
 
 ```bash
 cp claude-code-plugin/commands/*.md ~/.claude/commands/
 claude mcp add nex -- nex-mcp
 ```
+
+The fastest path is just `nex setup` — it does all of this automatically.
+
+See [`claude-code-plugin/README.md`](claude-code-plugin/README.md) for details.
+
+### OpenClaw Plugin
+
+15+ tools, auto-recall, and auto-capture for OpenClaw agents.
+
+```bash
+cp -r openclaw-plugin /path/to/openclaw/plugins/nex
+cd /path/to/openclaw/plugins/nex && bun install && bun run build
+```
+
+Add to `openclaw.json`:
+
+```json
+{
+  "plugins": {
+    "load": { "paths": ["/path/to/plugins/nex"] },
+    "slots": { "memory": "nex" },
+    "entries": {
+      "nex": {
+        "enabled": true,
+        "config": { "apiKey": "sk-your_key_here" }
+      }
+    }
+  }
+}
+```
+
+See [`openclaw-plugin/README.md`](openclaw-plugin/README.md) for details.
 
 ### MCP Server (Claude Desktop, Cursor, Windsurf)
 
@@ -125,68 +162,54 @@ Or without a global install:
 }
 ```
 
-### OpenClaw
-
-```bash
-cp -r openclaw-plugin /path/to/openclaw/plugins/nex
-cd /path/to/openclaw/plugins/nex && bun install && bun run build
-```
-
-Add to `openclaw.json`:
-
-```json
-{
-  "plugins": {
-    "load": { "paths": ["/path/to/plugins/nex"] },
-    "slots": { "memory": "nex" },
-    "entries": {
-      "nex": {
-        "enabled": true,
-        "config": { "apiKey": "sk-your_key_here" }
-      }
-    }
-  }
-}
-```
-
-See [`openclaw-plugin/README.md`](openclaw-plugin/README.md) for details.
-
-### Other Platforms
-
-Copy the relevant rule file from [`platform-rules/`](platform-rules/) into your editor's config:
-
-| Platform | File | Destination |
-|----------|------|-------------|
-| Cursor | `cursor-rules.md` | `.cursor/rules/` |
-| Windsurf | `windsurf-rules.md` | `.windsurf/rules/` |
-| VS Code | `vscode-instructions.md` | `.github/instructions/` |
-| Zed | `zed-rules.md` | `.zed/rules/` |
-| Aider | `aider-conventions.md` | `.aider/conventions/` |
-| Cline | `cline-rules.md` | `.cline/rules/` |
-| Continue | `continue-rules.md` | `.continue/rules/` |
-| KiloCode | `kilocode-rules.md` | `.kilocode/rules/` |
-| Codex | `codex-agents.md` | `.codex/agents/` |
-| OpenCode | `opencode-agents.md` | `.opencode/agents/` |
-
 ### Shell-only Agents (no Node.js)
 
+Bash scripts for agents that can only run shell commands. Requires `curl` and `jq`.
+
 ```bash
-# Register
 bash scripts/nex-openclaw-register.sh your@email.com "Your Name"
-
-# Query
 printf '{"query":"who is Maria?"}' | bash scripts/nex-api.sh POST /v1/context/ask
-
-# Ingest
-printf '{"content":"Meeting notes..."}' | bash scripts/nex-api.sh POST /v1/context/text
-
-# Scan files
 bash scripts/nex-scan-files.sh --dir . --max-files 10
 ```
 
-Requires `curl` and `jq`.
+## Copy-Paste Bootstrap Prompt
+
+Drop this into any terminal-capable AI agent to bootstrap Nex end to end:
+
+```text
+Install and fully bootstrap Nex in this project from start to finish.
+
+1. If the `nex` CLI is missing, install it globally with `npm install -g @nex-ai/nex`.
+2. If Nex is not authenticated yet, ask me for the email address I want to use for registration, then continue. If Nex is already authenticated, reuse the existing account and key.
+3. Run `nex setup` and complete the full install flow for every detected AI coding platform in this environment.
+4. After setup, inspect integrations and connect the first available unconnected integration. Prefer this order when multiple choices are available: gmail, google-calendar, slack, salesforce, hubspot, attio, outlook, outlook-calendar. If OAuth is required, open the browser flow and wait for it to complete.
+5. Run a fresh file scan for the current directory so the workspace is up to date.
+6. After the scan finishes, trigger Nex compounding jobs by calling the authenticated `POST https://app.nex.ai/api/developers/v1/compounding/trigger` endpoint for these job types: `consolidation`, `pattern_detection`, and `playbook_synthesis`. Use the active Nex API key from the current environment or the config written by Nex setup.
+7. Fetch the last 24 hours of insights with the insights endpoint or `nex insight list --last 24h`, then give me a clean digest with sections for Highlights, Risks, Opportunities, Open Loops, and Recommended Next Actions.
+8. Finish by showing me:
+   - what Nex installed
+   - which integration was connected
+   - how many files were scanned and ingested
+   - whether the compounding/playbooks trigger succeeded
+   - the formatted 24-hour insight digest
+
+Do not stop after partial setup. Only pause if you need my email for registration or if an OAuth flow requires my interaction.
+```
 
 ## Development
+
+### Repo structure
+
+```
+bin/                    # Thin Node.js shims that delegate to nex-cli
+claude-code-plugin/     # Claude Code hooks (auto-recall, auto-capture)
+openclaw-plugin/        # OpenClaw plugin (15+ tools, auto-recall, auto-capture)
+plugin-commands/        # Slash command definitions (.md files)
+platform-rules/         # Agent instructions for 10 platforms
+platform-plugins/       # Editor integrations (Continue, OpenCode, KiloCode, Windsurf)
+scripts/                # Bash API wrappers for shell-only agents
+server.json             # MCP Registry manifest
+```
 
 ### Build and test
 
@@ -203,11 +226,7 @@ cd openclaw-plugin && bun install && bun run build && bun test
 
 ### How the npm package works
 
-The `@nex-ai/nex` npm package is a thin shim. `bin/nex.js` and `bin/nex-mcp.js` look for the `nex-cli` binary on your PATH (or `~/.local/bin/nex-cli`) and forward all arguments. If it's not found, they print install instructions:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/nex-crm/nex-cli/main/install.sh | sh
-```
+The `@nex-ai/nex` npm package is a thin shim. `bin/nex.js` and `bin/nex-mcp.js` look for the `nex-cli` binary on your PATH (or `~/.local/bin/nex-cli`) and forward all arguments. If it's not found, they print install instructions.
 
 ### CI/CD
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,13 @@ Talk to the team, share feedback, and connect with other developers building AI 
 ### Install
 
 ```bash
-# Option A: install the nex-cli binary directly
+# Option A: standalone binary (no Node.js required, auto-installs nex-cli)
+curl -fsSL https://raw.githubusercontent.com/nex-crm/nex-as-a-skill/main/install.sh | sh
+
+# Option B: install the nex-cli binary directly
 curl -fsSL https://raw.githubusercontent.com/nex-crm/nex-cli/main/install.sh | sh
 
-# Option B: install via npm (or bun/pnpm)
+# Option C: install via npm (or bun/pnpm)
 npm install -g @nex-ai/nex
 ```
 
@@ -200,8 +203,10 @@ Do not stop after partial setup. Only pause if you need my email for registratio
 
 ### Repo structure
 
-```text
-bin/                    # Thin Node.js shims that delegate to nex-cli
+```
+src/                    # Bootstrapper binary source (compiled via Bun)
+bin/                    # Thin Node.js shims that delegate to nex-cli (npm fallback)
+install.sh              # curl-pipe installer for the standalone binary
 claude-code-plugin/     # Claude Code hooks (auto-recall, auto-capture)
 openclaw-plugin/        # OpenClaw plugin (15+ tools, auto-recall, auto-capture)
 plugin-commands/        # Slash command definitions (.md files)
@@ -214,6 +219,10 @@ server.json             # MCP Registry manifest
 ### Build and test
 
 ```bash
+# Standalone binary (compiles via Bun)
+bun run build:binary            # native platform
+bun run build:all               # all 4 targets (darwin/linux × arm64/x64)
+
 # Shims (syntax check only)
 npm test
 
@@ -224,14 +233,17 @@ cd claude-code-plugin && bun install && bun run build && bun test
 cd openclaw-plugin && bun install && bun run build && bun test
 ```
 
-### How the npm package works
+### How it works
 
-The `@nex-ai/nex` npm package is a thin shim. `bin/nex.js` and `bin/nex-mcp.js` look for the `nex-cli` binary on your PATH (or `~/.local/bin/nex-cli`) and forward all arguments. If it's not found, they print install instructions.
+**Standalone binary** (`src/nex.ts`): Compiled via `bun build --compile`. Finds `nex-cli` on PATH or common locations and delegates all commands. If `nex-cli` isn't installed, auto-downloads it on first run. Detects `nex-mcp` symlink invocation to transparently prepend `mcp` to args.
+
+**npm package** (`bin/nex.js`): Thin Node.js shim with the same delegation logic, for `npx @nex-ai/nex` and MCP Registry compatibility.
 
 ### CI/CD
 
-- **CI** (`ci.yml`): Validates shims, builds + tests both plugins on every PR
-- **Publish** (`publish-cli.yml`): Auto-publishes to npm on push to main (when `bin/`, `plugin-commands/`, `platform-rules/`, `platform-plugins/`, or `package.json` change)
+- **CI** (`ci.yml`): Validates shims, builds + tests both plugins, builds + smoke tests the binary on every PR
+- **Release** (`release.yml`): Cross-compiles 4 binary targets on `v*` tags, creates GitHub Release with checksums
+- **Publish** (`publish-cli.yml`): Auto-publishes to npm on push to main
 - **MCP Registry** (`publish-mcp.yml`): Publishes `server.json` to the MCP Registry on version tags
 
 ## Environment Variables
@@ -248,23 +260,26 @@ The `@nex-ai/nex` npm package is a thin shim. `bin/nex.js` and `bin/nex-mcp.js` 
 ## Architecture
 
 ```mermaid
-flowchart TD
-    API["Nex Context Graph\n(app.nex.ai API)"]
-
+graph TD
+    API["Nex Context Graph<br/><i>app.nex.ai API</i>"]
     CLI["nex-cli binary"]
-    MCP["MCP Server\n(nex-mcp)"]
+
+    API --- CLI
+
+    NEX["nex binary / npm shim"]
+    MCP["MCP Server<br/><i>nex-mcp</i>"]
     OC["OpenClaw Plugin"]
     CC["Claude Code Plugin"]
 
-    API --- CLI
-    API --- MCP
-    API --- OC
-    API --- CC
+    CLI --- NEX
+    CLI --- MCP
+    CLI --- OC
+    CLI --- CC
 
-    CLI --> T1["Any terminal\n+ this npm package"]
-    MCP --> T2["Claude Desktop\nCursor, Windsurf\nChatGPT"]
-    OC --> T3["OpenClaw agents"]
-    CC --> T4["Claude Code"]
+    NEX -.- T1["Any terminal"]
+    MCP -.- T2["Claude Desktop · Cursor<br/>Windsurf · ChatGPT"]
+    OC -.- T3["OpenClaw agents"]
+    CC -.- T4["Claude Code"]
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,61 +1,44 @@
-# Nex: Compounding Intelligence for AI agents
+# Nex: Compounding Intelligence for AI Agents
 
 [![npm version](https://img.shields.io/npm/v/@nex-ai/nex)](https://www.npmjs.com/package/@nex-ai/nex)
 [![Discord](https://img.shields.io/badge/Discord-Join%20Community-5865F2?logo=discord&logoColor=white)](https://discord.gg/gjSySC3PzV)
 
-Turn all your AI agent conversations into a unified knowledge graph. Supports Claude Code, Codex, OpenClaw, Cursor, OpenCode, etc. Adds additional context from Email, Meetings, Slack, HubSpot, Salesforce.
+Nex turns AI agent conversations into a unified knowledge graph. Tell something to one agent, recall it from any other. Context follows you across tools — no copy-pasting, no re-explaining.
 
-Tell something to OpenClaw. Ask about it in Claude Code. Reference it from Cursor. Context follows you across tools — no copy-pasting, no re-explaining, no lost context.
+Supports Claude Code, OpenClaw, Cursor, Windsurf, Codex, Aider, Continue, Zed, and more. Adds context from Email, Meetings, Slack, HubSpot, Salesforce.
 
-<a href="https://discord.gg/gjSySC3PzV"><img src="https://img.shields.io/badge/Join%20our%20Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Join our Discord" /></a>
+## What's in this repo
 
-Talk to the team, share feedback, and connect with other developers building AI agents with Nex.
-
-## How It Works
+This repo is the **public integration layer** for Nex. It contains the npm package, platform plugins, agent instructions, and slash commands. The heavy lifting happens in the [`nex-cli`](https://github.com/nex-crm/nex-cli) binary, which is installed separately.
 
 ```
-You → OpenClaw: "Maria Rodriguez, CTO of TechFlow, wants to expand to Europe in Q3. Budget is $2M."
-
-You → Claude Code: "What do you know about Maria Rodriguez?"
-Claude Code: "Maria Rodriguez is the CTO of TechFlow. They're planning European expansion
-              in Q3 with a $2M budget."
-
-You → Cursor: "Which companies are planning European expansion?"
-Cursor: "TechFlow — Maria Rodriguez (CTO) confirmed Q3 timeline, $2M budget."
+bin/                    # Thin Node.js shims that delegate to nex-cli
+claude-code-plugin/     # Claude Code hooks (auto-recall, auto-capture, slash commands)
+openclaw-plugin/        # OpenClaw plugin (15+ tools, auto-recall, auto-capture)
+plugin-commands/        # Slash command definitions (.md files)
+platform-rules/         # Agent instructions for 10 platforms (Cursor, Windsurf, Zed, etc.)
+platform-plugins/       # Editor integrations (Continue, OpenCode, KiloCode, Windsurf workflows)
+scripts/                # Bash API wrappers for shell-only agents
+server.json             # MCP Registry manifest
 ```
 
-One fact entered once. Available everywhere, instantly.
-
-## Integration Options
-
-| | CLI + MCP Server | OpenClaw Plugin | Claude Code Plugin | Scripts |
-|---|---|---|---|---|
-| **Platforms** | Any terminal, Claude Desktop, ChatGPT, Cursor, Windsurf | OpenClaw | Claude Code CLI | OpenClaw (script-based) |
-| **Auto-recall** | Via `nex recall` / MCP tool calls | Yes (smart filter) | Yes (smart filter) | No (manual) |
-| **Auto-capture** | Via `nex capture` | Yes | Yes | No (manual) |
-| **Notifications** | Daily digest + proactive alerts (Channels API) | No | No | No |
-| **Commands** | 50+ CLI commands, 50+ MCP tools, `nex mcp` | 4 tools + 4 commands | 5 slash commands + MCP | bash scripts |
-| **Setup** | `nex setup` | Copy plugin | `nex setup` | Set `NEX_API_KEY` |
-
-## Quick Start (Recommended)
+## Quick Start
 
 ```bash
-# Install and run setup — handles everything in one step
 npm install -g @nex-ai/nex
 nex setup
 ```
 
-`nex setup` registers your API key, auto-detects your AI platforms (Claude Code, Cursor, Windsurf, etc.), installs hooks, scans project files, and creates config. One command, fully configured.
+`nex setup` registers your API key, detects your AI platforms, installs hooks, scans project files, and writes config. After setup:
 
 ```bash
-# Now use it from any agent
 nex ask "who is Maria Rodriguez?"
 nex remember "Met with Maria, CTO of TechFlow. European expansion Q3, $2M budget."
 ```
 
-## Copy-Paste Prompt For Any AI Agent
+## Copy-Paste Bootstrap Prompt
 
-Drop this prompt into any terminal-capable AI agent when you want it to bootstrap Nex for you end to end:
+Drop this into any terminal-capable AI agent to bootstrap Nex end to end:
 
 ```text
 Install and fully bootstrap Nex in this project from start to finish.
@@ -77,51 +60,26 @@ Install and fully bootstrap Nex in this project from start to finish.
 Do not stop after partial setup. Only pause if you need my email for registration or if an OAuth flow requires my interaction.
 ```
 
-This works best in agents that can run shell commands and open OAuth URLs.
+## Platform Setup
 
----
+### Claude Code
 
-<details>
-<summary>Manual setup per platform (if you prefer step-by-step)</summary>
+The fastest path is `nex setup` — it auto-configures hooks, MCP, and slash commands.
 
-### CLI (any terminal, any AI agent)
-
-```bash
-npx @nex-ai/nex register --email you@company.com
-```
-
-That's it. Now use it:
+For manual setup, see [`claude-code-plugin/README.md`](claude-code-plugin/README.md). In short:
 
 ```bash
-# Ask your knowledge graph
-nex ask "who is Maria Rodriguez?"
-
-# Ingest information
-nex remember "Met with Maria Rodriguez, CTO of TechFlow. European expansion Q3, $2M budget."
-
-# Or pipe from stdin
-cat meeting-notes.txt | nex remember
-
-# Search CRM records
-nex search "TechFlow"
-
-# CRUD operations
-nex record list person --limit 10
-nex task create --title "Follow up with Maria" --priority high
-nex insight list --last 24h
-
-# Build auto-recall hooks for any agent
-nex recall "what do I know about TechFlow?"  # Returns <nex-context> XML block
-
-# Build auto-capture hooks
-nex capture "Agent conversation text..."  # Rate-limited, filtered
+cd claude-code-plugin && bun install && bun run build
 ```
 
-Install globally: `npm install -g @nex-ai/nex`
+Then add hooks to `~/.claude/settings.json` (see [`settings.json`](claude-code-plugin/settings.json) for the template) and copy slash commands:
+
+```bash
+cp claude-code-plugin/commands/*.md ~/.claude/commands/
+claude mcp add nex -- nex-mcp
+```
 
 ### MCP Server (Claude Desktop, Cursor, Windsurf)
-
-The MCP server is bundled inside `@nex-ai/nex`. No separate package needed.
 
 ```json
 {
@@ -148,72 +106,7 @@ Or without a global install:
 }
 ```
 
-No API key? The server starts in registration mode — call the `register` tool with your email.
-
-### Proactive Notifications (Claude Code Channels)
-
-The MCP server includes a built-in notification channel that pushes context updates directly into your Claude Code session — without you having to ask. This uses the [Claude SDK Channels API](https://code.claude.com/docs/en/channels-reference).
-
-**What you get:**
-
-| Notification | What it does | Frequency |
-|---|---|---|
-| **Daily digest** | Summarizes all context collected in the last 24 hours: deal updates, new relationships, upcoming events, actionable items | Once per day (on first session start after 24h) |
-| **Proactive alerts** | Pushes new insights as they're discovered — deal changes, relationship shifts, risks, opportunities | Every 15 minutes (configurable) |
-
-**How to enable:**
-
-1. Install Nex globally (if not already):
-   ```bash
-   npm install -g @nex-ai/nex
-   ```
-
-2. Add the MCP server to your project (`.mcp.json`):
-   ```json
-   {
-     "mcpServers": {
-       "nex": {
-         "command": "nex-mcp",
-         "env": {}
-       }
-     }
-   }
-   ```
-
-3. Start Claude Code with channels enabled:
-   ```bash
-   claude --dangerously-load-development-channels server:nex
-   ```
-
-4. That's it. Notifications arrive as `<channel>` events in your session:
-   ```
-   ← nex: [technical_stack] MCP server utilizes experimental channel capability...
-   ← nex: [deal_update | high] Meridian counter-offer moved to 12% equity split...
-   ```
-
-**Configuration:**
-
-| Environment variable | Default | Description |
-|---|---|---|
-| `NEX_NOTIFY_INTERVAL_MINUTES` | `15` | How often to poll for new insights |
-
-Set it in your `.mcp.json`:
-```json
-{
-  "mcpServers": {
-    "nex": {
-      "command": "nex-mcp",
-      "env": { "NEX_NOTIFY_INTERVAL_MINUTES": "5" }
-    }
-  }
-}
-```
-
-**State persistence:** Digest and notification timestamps are stored in `~/.nex/channel-state.json`. Delete this file to force a fresh digest on next session start.
-
-**Requirements:** Claude Code v2.1.80+, claude.ai login (API keys not supported for Channels), `--dangerously-load-development-channels` flag during research preview.
-
-### OpenClaw Plugin (auto-recall + auto-capture)
+### OpenClaw
 
 ```bash
 cp -r openclaw-plugin /path/to/openclaw/plugins/nex
@@ -230,9 +123,7 @@ Add to `openclaw.json`:
     "entries": {
       "nex": {
         "enabled": true,
-        "config": {
-          "apiKey": "sk-your_key_here"
-        }
+        "config": { "apiKey": "sk-your_key_here" }
       }
     }
   }
@@ -241,104 +132,69 @@ Add to `openclaw.json`:
 
 See [`openclaw-plugin/README.md`](openclaw-plugin/README.md) for details.
 
-### Claude Code Plugin (auto-recall + auto-capture)
+### Other Platforms
+
+Copy the relevant rule file from [`platform-rules/`](platform-rules/) into your editor's config:
+
+| Platform | File | Destination |
+|----------|------|-------------|
+| Cursor | `cursor-rules.md` | `.cursor/rules/` |
+| Windsurf | `windsurf-rules.md` | `.windsurf/rules/` |
+| VS Code | `vscode-instructions.md` | `.github/instructions/` |
+| Zed | `zed-rules.md` | `.zed/rules/` |
+| Aider | `aider-conventions.md` | `.aider/conventions/` |
+| Cline | `cline-rules.md` | `.cline/rules/` |
+| Continue | `continue-rules.md` | `.continue/rules/` |
+| KiloCode | `kilocode-rules.md` | `.kilocode/rules/` |
+| Codex | `codex-agents.md` | `.codex/agents/` |
+| OpenCode | `opencode-agents.md` | `.opencode/agents/` |
+
+### Shell-only Agents (no Node.js)
 
 ```bash
-cd claude-code-plugin && bun install && bun run build
-```
-
-Add hooks to `~/.claude/settings.json`:
-
-```json
-{
-  "hooks": {
-    "UserPromptSubmit": [{
-      "matcher": "",
-      "hooks": [{
-        "type": "command",
-        "command": "NEX_API_KEY=sk-your_key node /path/to/claude-code-plugin/dist/auto-recall.js",
-        "timeout": 10000
-      }]
-    }],
-    "Stop": [{
-      "matcher": "",
-      "hooks": [{
-        "type": "command",
-        "command": "NEX_API_KEY=sk-your_key node /path/to/claude-code-plugin/dist/auto-capture.js",
-        "timeout": 5000,
-        "async": true
-      }]
-    }]
-  }
-}
-```
-
-Slash commands and MCP server:
-
-```bash
-cp claude-code-plugin/commands/*.md ~/.claude/commands/    # /nex:recall, /nex:remember, /nex:scan, /nex:entities
-claude mcp add nex -- nex-mcp                               # Full toolset
-```
-
-See [`claude-code-plugin/README.md`](claude-code-plugin/README.md) for details.
-
-### Scripts (OpenClaw script-based)
-
-For OpenClaw agents without the plugin, bash scripts provide direct API access:
-
-```bash
-# Register and get API key
+# Register
 bash scripts/nex-openclaw-register.sh your@email.com "Your Name"
 
-# Query context
+# Query
 printf '{"query":"who is Maria?"}' | bash scripts/nex-api.sh POST /v1/context/ask
 
-# Ingest text
+# Ingest
 printf '{"content":"Meeting notes..."}' | bash scripts/nex-api.sh POST /v1/context/text
 
-# Scan project files
+# Scan files
 bash scripts/nex-scan-files.sh --dir . --max-files 10
 ```
 
-See the [scripts directory](scripts/) for details.
+Requires `curl` and `jq`.
 
-</details>
+## Development
 
-## Shared Config
+### Build and test
 
-All surfaces share configuration for cross-tool compatibility:
+```bash
+# Shims (syntax check only)
+npm test
 
-| File | Purpose | Shared by |
-|------|---------|-----------|
-| `~/.nex-mcp.json` | API key + workspace info | All surfaces |
-| `~/.nex/file-scan-manifest.json` | File change tracking | All surfaces |
-| `~/.nex/rate-limiter.json` | Rate limit timestamps | OC, MCP, CC |
-| `~/.nex/recall-state.json` | Recall debounce state | CC |
+# Claude Code plugin
+cd claude-code-plugin && bun install && bun run build && bun test
 
-Register once via any surface → all other surfaces pick up the key automatically.
-
-## Architecture
-
+# OpenClaw plugin
+cd openclaw-plugin && bun install && bun run build && bun test
 ```
-                    ┌─────────────────────┐
-                    │   Nex Context Graph  │
-                    │  (people, companies, │
-                    │  insights, tasks...) │
-                    └──────────┬──────────┘
-                               │
-      ┌────────────────────────┼────────────────────────┐
-      │              │                   │              │
-  ┌───▼────┐  ┌─────▼───────┐  ┌───────▼──────┐  ┌───▼──────────┐
-  │  CLI   │  │  MCP Server │  │  OpenClaw    │  │  Claude Code │
-  │  50+   │  │  50+ tools  │  │  Plugin     │  │  Plugin      │
-  │  cmds  │  │  + scan     │  │  + recall   │  │  + recall    │
-  └───┬────┘  └─────┬───────┘  └──────┬──────┘  └──────┬───────┘
-      │             │                 │                 │
-  Any agent    Claude Desktop    OpenClaw agents   Claude Code
-  Aider        ChatGPT          Clawgent          Any project
-  Codex        Cursor            WhatsApp
-  Custom       Windsurf
+
+### How the npm package works
+
+The `@nex-ai/nex` npm package is a thin shim. `bin/nex.js` and `bin/nex-mcp.js` look for the `nex-cli` binary on your PATH (or `~/.local/bin/nex-cli`) and forward all arguments. If it's not found, they print install instructions:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/nex-crm/nex-cli/main/install.sh | sh
 ```
+
+### CI/CD
+
+- **CI** (`ci.yml`): Validates shims, builds + tests both plugins on every PR
+- **Publish** (`publish-cli.yml`): Auto-publishes to npm on push to main (when `bin/`, `plugin-commands/`, `platform-rules/`, `platform-plugins/`, or `package.json` change)
+- **MCP Registry** (`publish-mcp.yml`): Publishes `server.json` to the MCP Registry on version tags
 
 ## Environment Variables
 
@@ -347,18 +203,29 @@ Register once via any surface → all other surfaces pick up the key automatical
 | `NEX_API_KEY` | Yes (or register) | — |
 | `NEX_DEV_URL` | No (dev only) | `https://app.nex.ai` |
 | `NEX_SCAN_ENABLED` | No | `true` |
-| `NEX_SCAN_EXTENSIONS` | No | `.md,.txt,.rtf,.html,.htm,.csv,.tsv,.json,.yaml,.yml,.toml,.xml,.js,.ts,.jsx,.tsx,.py,.rb,.go,.rs,.java,.sh,.bash,.zsh,.fish,.org,.rst,.adoc,.tex,.log,.env,.ini,.cfg,.conf,.properties` |
 | `NEX_SCAN_MAX_FILES` | No | `5` |
 | `NEX_SCAN_DEPTH` | No | `20` |
-| `NEX_SCAN_MAX_FILE_SIZE` | No | `100000` (bytes) |
-| `NEX_SCAN_IGNORE_DIRS` | No | `node_modules,.git,dist,build,.next,__pycache__,vendor,.venv,.claude,coverage,.turbo,.cache` |
 | `NEX_NOTIFY_INTERVAL_MINUTES` | No | `15` |
 
-## Testing
+## Architecture
 
-- **Shims**: `npm test` (syntax validation of bin/ shims)
-- **OpenClaw plugin**: `cd openclaw-plugin && npx vitest run`
-- **Claude Code plugin**: `cd claude-code-plugin && bun test`
+```
+                    ┌─────────────────────┐
+                    │   Nex Context Graph  │
+                    │  (app.nex.ai API)    │
+                    └──────────┬──────────┘
+                               │
+      ┌────────────────────────┼────────────────────────┐
+      │              │                   │              │
+  ┌───▼────┐  ┌─────▼───────┐  ┌───────▼──────┐  ┌───▼──────────┐
+  │nex-cli │  │  MCP Server │  │  OpenClaw    │  │  Claude Code │
+  │ binary │  │  (nex-mcp)  │  │  Plugin     │  │  Plugin      │
+  └───┬────┘  └─────┬───────┘  └──────┬──────┘  └──────┬───────┘
+      │             │                 │                 │
+  Any terminal  Claude Desktop   OpenClaw agents   Claude Code
+  + this npm    Cursor, Windsurf
+    package     ChatGPT
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ bash scripts/nex-scan-files.sh --dir . --max-files 10
 
 ## Copy-Paste Bootstrap Prompt
 
-Drop this into any terminal-capable AI agent to bootstrap Nex end to end:
+Drop this into any terminal-capable AI agent to bootstrap Nex end-to-end:
 
 ```text
 Install and fully bootstrap Nex in this project from start to finish.
@@ -200,7 +200,7 @@ Do not stop after partial setup. Only pause if you need my email for registratio
 
 ### Repo structure
 
-```
+```text
 bin/                    # Thin Node.js shims that delegate to nex-cli
 claude-code-plugin/     # Claude Code hooks (auto-recall, auto-capture)
 openclaw-plugin/        # OpenClaw plugin (15+ tools, auto-recall, auto-capture)
@@ -247,22 +247,24 @@ The `@nex-ai/nex` npm package is a thin shim. `bin/nex.js` and `bin/nex-mcp.js` 
 
 ## Architecture
 
-```
-                    ┌─────────────────────┐
-                    │   Nex Context Graph  │
-                    │  (app.nex.ai API)    │
-                    └──────────┬──────────┘
-                               │
-      ┌────────────────────────┼────────────────────────┐
-      │              │                   │              │
-  ┌───▼────┐  ┌─────▼───────┐  ┌───────▼──────┐  ┌───▼──────────┐
-  │nex-cli │  │  MCP Server │  │  OpenClaw    │  │  Claude Code │
-  │ binary │  │  (nex-mcp)  │  │  Plugin     │  │  Plugin      │
-  └───┬────┘  └─────┬───────┘  └──────┬──────┘  └──────┬───────┘
-      │             │                 │                 │
-  Any terminal  Claude Desktop   OpenClaw agents   Claude Code
-  + this npm    Cursor, Windsurf
-    package     ChatGPT
+```mermaid
+flowchart TD
+    API["Nex Context Graph\n(app.nex.ai API)"]
+
+    CLI["nex-cli binary"]
+    MCP["MCP Server\n(nex-mcp)"]
+    OC["OpenClaw Plugin"]
+    CC["Claude Code Plugin"]
+
+    API --- CLI
+    API --- MCP
+    API --- OC
+    API --- CC
+
+    CLI --> T1["Any terminal\n+ this npm package"]
+    MCP --> T2["Claude Desktop\nCursor, Windsurf\nChatGPT"]
+    OC --> T3["OpenClaw agents"]
+    CC --> T4["Claude Code"]
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Nex turns AI agent conversations into a unified knowledge graph. Tell something 
 
 Supports Claude Code, OpenClaw, Cursor, Windsurf, Codex, Aider, Continue, Zed, and more. Adds context from Email, Meetings, Slack, HubSpot, Salesforce.
 
+<a href="https://discord.gg/gjSySC3PzV"><img src="https://img.shields.io/badge/Join%20our%20Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Join our Discord" /></a>
+
+Talk to the team, share feedback, and connect with other developers building AI agents with Nex.
+
 ## What's in this repo
 
 This repo is the **public integration layer** for Nex. It contains the npm package, platform plugins, agent instructions, and slash commands. The heavy lifting happens in the [`nex-cli`](https://github.com/nex-crm/nex-cli) binary, which is installed separately.
@@ -24,12 +28,27 @@ server.json             # MCP Registry manifest
 
 ## Quick Start
 
+### Install the CLI
+
 ```bash
+# Option A: install the nex-cli binary directly
+curl -fsSL https://raw.githubusercontent.com/nex-crm/nex-cli/main/install.sh | sh
+
+# Option B: install the npm shim (delegates to nex-cli)
 npm install -g @nex-ai/nex
+```
+
+### Sign up and configure
+
+```bash
+# Create an account (or log in if you already have one)
+nex register --email you@company.com
+
+# Auto-detect your AI platforms and install hooks, MCP, slash commands
 nex setup
 ```
 
-`nex setup` registers your API key, detects your AI platforms, installs hooks, scans project files, and writes config. After setup:
+`nex setup` detects your platforms (Claude Code, Cursor, Windsurf, etc.), installs hooks, scans project files, and writes config. After setup:
 
 ```bash
 nex ask "who is Maria Rodriguez?"


### PR DESCRIPTION
## Summary
- Rewrite README to reflect the actual repo structure after the 45K-line CLI removal in #70
- Add "What's in this repo" section with directory layout
- Restructure platform setup as a flat reference instead of nested details/summary
- Add platform-rules table mapping rule files to editor config destinations
- Add Development section covering build, test, CI/CD, and how the npm shims work
- Remove stale content: verbose CLI command list, Channels API docs, Shared Config section, long env vars table
- Update architecture diagram to show nex-cli binary instead of "50+ cmds"

## Test plan
- [ ] Verify all internal links resolve (claude-code-plugin/README.md, openclaw-plugin/README.md, platform-rules/, scripts/)
- [ ] Confirm no references to deleted files (cli/, SKILL.md, DEVELOPMENT.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworked README into a repo overview, concise Quick Start CLI flow, and new "Skills & Platform Rules" section.
  * Added shell-only agent guidance and simplified plugin/platform instructions.
  * Removed the long copy-paste prompt, detailed per-platform manual setup, and several obsolete environment-variable entries.
  * Updated development, build/test commands, architecture description, and CI/CD/MCP references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->