### PR TITLE
feat: add /nex:playbooks slash command

### DIFF
--- a/claude-code-plugin/commands/nex:briefs.md
+++ b/claude-code-plugin/commands/nex:briefs.md
@@ -1,0 +1,38 @@
+---
+description: List, view, compile, and sync entity briefs and workspace playbooks
+---
+Handle brief/playbook requests based on $ARGUMENTS:
+
+**No arguments → list all briefs:**
+Use the `list_briefs` MCP tool. Display results as a table:
+| Title | Type | Updated |
+Show scope_type 1 as "Entity Brief" and scope_type 2 as "Workspace Playbook".
+
+**Entity name → find and show brief:**
+First use `search_entities` to find the entity. Then use `get_entity_brief` with the context_id. Display the full markdown content.
+
+**"workspace" or "playbooks" → list workspace playbooks only:**
+Use `list_briefs` with scope_type=2.
+
+**Playbook slug → show workspace playbook:**
+Use `get_workspace_playbook` with the slug. Display the full markdown.
+
+**"sync" → sync all briefs to local .nex/briefs/ folder:**
+Use `sync_briefs`. Downloads all entity briefs, workspace playbooks, and private playbooks as .md files for fast local access. Structure:
+```
+.nex/briefs/entities/   — person-brief-lenny-rachitsky.md
+.nex/briefs/workspace/  — early-b2b-growth.md
+.nex/briefs/private/    — my-writing-style.md
+```
+
+**"compile <entity>" → trigger compilation:**
+Search for the entity, then use `compile_brief` with the context_id. Add `--private` for a private brief.
+
+**"download <id>" → download as markdown:**
+Use `download_brief` with the ID. Display the raw markdown.
+
+**"history <id>" → show version history:**
+Use `get_brief_history` with the ID. Display events with diff summaries.
+
+**"read <name>" → read from local .nex/ folder:**
+Use `read_brief` with a search term. Reads locally first (zero API cost), falls back to API.

--- a/claude-code-plugin/commands/nex:playbooks.md
+++ b/claude-code-plugin/commands/nex:playbooks.md
@@ -4,21 +4,21 @@ description: List, view, compile, and sync entity playbooks and workspace playbo
 Handle playbook requests based on $ARGUMENTS:
 
 **No arguments → list all playbooks:**
-Use the `list_briefs` MCP tool. Display results as a table:
+Use the `list_playbooks` MCP tool. Display results as a table:
 | Title | Type | Updated |
 Show scope_type 1 as "Entity Playbook" and scope_type 2 as "Workspace Playbook".
 
 **Entity name → find and show playbook:**
-First use `search_entities` to find the entity. Then use `get_entity_brief` with the context_id. Display the full markdown content.
+First use `search_entities` to find the entity. Then use `get_entity_playbook` with the context_id. Display the full markdown content.
 
 **"workspace" or "playbooks" → list workspace playbooks only:**
-Use `list_briefs` with scope_type=2.
+Use `list_playbooks` with scope_type=2.
 
 **Playbook slug → show workspace playbook:**
 Use `get_workspace_playbook` with the slug. Display the full markdown.
 
 **"sync" → sync all playbooks to local .nex/playbooks/ folder:**
-Use `sync_briefs`. Downloads all entity playbooks, workspace playbooks, and private playbooks as .md files for fast local access. Structure:
+Use `sync_playbooks`. Downloads all entity playbooks, workspace playbooks, and private playbooks as .md files for fast local access. Structure:
 ```
 .nex/playbooks/entities/   — person-playbook-lenny-rachitsky.md
 .nex/playbooks/workspace/  — early-b2b-growth.md
@@ -26,13 +26,13 @@ Use `sync_briefs`. Downloads all entity playbooks, workspace playbooks, and priv
 ```
 
 **"compile <entity>" → trigger compilation:**
-Search for the entity, then use `compile_brief` with the context_id. Add `--private` for a private playbook.
+Search for the entity, then use `compile_playbook` with the context_id. Add `--private` for a private playbook.
 
 **"download <id>" → download as markdown:**
-Use `download_brief` with the ID. Display the raw markdown.
+Use `download_playbook` with the ID. Display the raw markdown.
 
 **"history <id>" → show version history:**
-Use `get_brief_history` with the ID. Display events with diff summaries.
+Use `get_playbook_history` with the ID. Display events with diff summaries.
 
 **"read <name>" → read from local .nex/ folder:**
-Use `read_brief` with a search term. Reads locally first (zero API cost), falls back to API.
+Use `read_playbook` with a search term. Reads locally first (zero API cost), falls back to API.

--- a/claude-code-plugin/commands/nex:playbooks.md
+++ b/claude-code-plugin/commands/nex:playbooks.md
@@ -1,14 +1,14 @@
 ---
-description: List, view, compile, and sync entity briefs and workspace playbooks
+description: List, view, compile, and sync entity playbooks and workspace playbooks
 ---
-Handle brief/playbook requests based on $ARGUMENTS:
+Handle playbook requests based on $ARGUMENTS:
 
-**No arguments → list all briefs:**
+**No arguments → list all playbooks:**
 Use the `list_briefs` MCP tool. Display results as a table:
 | Title | Type | Updated |
-Show scope_type 1 as "Entity Brief" and scope_type 2 as "Workspace Playbook".
+Show scope_type 1 as "Entity Playbook" and scope_type 2 as "Workspace Playbook".
 
-**Entity name → find and show brief:**
+**Entity name → find and show playbook:**
 First use `search_entities` to find the entity. Then use `get_entity_brief` with the context_id. Display the full markdown content.
 
 **"workspace" or "playbooks" → list workspace playbooks only:**
@@ -17,16 +17,16 @@ Use `list_briefs` with scope_type=2.
 **Playbook slug → show workspace playbook:**
 Use `get_workspace_playbook` with the slug. Display the full markdown.
 
-**"sync" → sync all briefs to local .nex/briefs/ folder:**
-Use `sync_briefs`. Downloads all entity briefs, workspace playbooks, and private playbooks as .md files for fast local access. Structure:
+**"sync" → sync all playbooks to local .nex/playbooks/ folder:**
+Use `sync_briefs`. Downloads all entity playbooks, workspace playbooks, and private playbooks as .md files for fast local access. Structure:
 ```
-.nex/briefs/entities/   — person-brief-lenny-rachitsky.md
-.nex/briefs/workspace/  — early-b2b-growth.md
-.nex/briefs/private/    — my-writing-style.md
+.nex/playbooks/entities/   — person-playbook-lenny-rachitsky.md
+.nex/playbooks/workspace/  — early-b2b-growth.md
+.nex/playbooks/private/    — my-writing-style.md
 ```
 
 **"compile <entity>" → trigger compilation:**
-Search for the entity, then use `compile_brief` with the context_id. Add `--private` for a private brief.
+Search for the entity, then use `compile_brief` with the context_id. Add `--private` for a private playbook.
 
 **"download <id>" → download as markdown:**
 Use `download_brief` with the ID. Display the raw markdown.


### PR DESCRIPTION
## Summary

Adds `/nex:briefs` slash command for entity briefs and workspace playbooks in Claude Code.

### Commands
- `/nex:briefs` — list all briefs
- `/nex:briefs <entity name>` — view entity brief
- `/nex:briefs workspace` — list workspace playbooks
- `/nex:briefs sync` — download all to local `.nex/briefs/` folder
- `/nex:briefs compile <entity>` — trigger compilation
- `/nex:briefs download <id>` — download as markdown
- `/nex:briefs history <id>` — version history
- `/nex:briefs read <name>` — local-first read with API fallback

### Local Sync Structure
```
.nex/briefs/
  entities/   — person-brief-lenny-rachitsky.md
  workspace/  — early-b2b-growth.md
  private/    — my-writing-style.md
```

### Depends on
- nex-crm/core#794 (backend API)
- MCP tools in @nex-ai/nex npm package (list_briefs, get_brief, compile_brief, sync_briefs, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added command documentation for playbook operations, including listing, resolving entity and workspace playbooks, local synchronization, compilation, downloading, and viewing playbook history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->