### PR TITLE
[codex] claude: use preflight before direct agent tools

### DIFF
--- a/claude-code-plugin/src/auto-recall-worker.ts
+++ b/claude-code-plugin/src/auto-recall-worker.ts
@@ -4,9 +4,7 @@ import { loadConfig } from "./config.js";
 import { formatNexContext } from "./context-format.js";
 import { NexClient } from "./nex-client.js";
 import { RecallCache } from "./recall-cache.js";
-import { SessionStore } from "./session-store.js";
 
-const sessions = new SessionStore();
 const recallCache = new RecallCache();
 
 interface WorkerInput {
@@ -60,22 +58,16 @@ async function main(): Promise<void> {
 
     const cfg = loadConfig();
     const client = new NexClient(cfg.apiKey, cfg.baseUrl);
-    const nexSessionId = sessions.get(sessionKey);
-    const result = await client.ask(prompt, nexSessionId, BACKGROUND_RECALL_TIMEOUT_MS);
+    const result = await client.prepareAgentTurnContext(prompt, sessionKey, BACKGROUND_RECALL_TIMEOUT_MS);
 
-    if (!result.answer) {
+    if (!result.prepared_context) {
       recallCache.clearPending(sessionKey, promptHash);
       return;
     }
 
-    if (result.session_id) {
-      sessions.set(sessionKey, result.session_id);
-    }
-
     const context = formatNexContext({
-      answer: result.answer,
+      answer: result.prepared_context,
       entityCount: result.entity_references?.length ?? 0,
-      sessionId: result.session_id,
     });
 
     if (!recallCache.hasPending(sessionKey, promptHash, PENDING_CACHE_TTL_MS)) {

--- a/claude-code-plugin/src/auto-recall.ts
+++ b/claude-code-plugin/src/auto-recall.ts
@@ -89,9 +89,9 @@ function launchBackgroundRecall(
 
 /**
  * Check if this is the first prompt for this session.
- * A session with no stored Nex session ID is considered "first prompt"
- * (SessionStart may have already set one, but that's fine — it means
- * baseline context was loaded, and first user prompt still gets recall).
+ * This uses the session-start Ask flow as a lightweight marker that baseline
+ * context has already been loaded for the Claude session. If no marker exists,
+ * we bias toward treating the turn as a first prompt so recall stays helpful.
  */
 function isFirstPrompt(sessionKey: string | undefined): boolean {
   if (!sessionKey) return true;
@@ -154,10 +154,8 @@ async function main(): Promise<void> {
 
     const client = new NexClient(cfg.apiKey, cfg.baseUrl);
 
-    // Resolve session ID for multi-turn continuity
     const sessionKey = input.session_id;
     const promptHash = hashPrompt(prompt);
-    const nexSessionId = sessionKey ? sessions.get(sessionKey) : undefined;
     const cachedReady = sessionKey
       ? recallCache.getInjectable(sessionKey, READY_CACHE_TTL_MS)
       : undefined;
@@ -175,17 +173,12 @@ async function main(): Promise<void> {
 
     if (!hasPendingCurrent) {
       try {
-        const result = await client.ask(prompt, nexSessionId, FAST_RECALL_BUDGET_MS);
+        const result = await client.prepareAgentTurnContext(prompt, sessionKey, FAST_RECALL_BUDGET_MS);
 
-        if (result.answer) {
-          if (result.session_id && sessionKey) {
-            sessions.set(sessionKey, result.session_id);
-          }
-
+        if (result.prepared_context) {
           const context = formatNexContext({
-            answer: result.answer,
+            answer: result.prepared_context,
             entityCount: result.entity_references?.length ?? 0,
-            sessionId: result.session_id,
           });
 
           if (sessionKey) {

--- a/claude-code-plugin/src/auto-session-start.ts
+++ b/claude-code-plugin/src/auto-session-start.ts
@@ -31,6 +31,13 @@ interface HookInput {
 }
 
 const SESSION_START_QUERY = "Summarize the key active context, recent interactions, and important updates for this user.";
+const SESSION_START_TIMEOUT_MS = readTimeoutEnv("NEX_SESSION_START_TIMEOUT_MS", 90_000);
+
+function readTimeoutEnv(name: string, fallbackMs: number): number {
+  const raw = process.env[name];
+  const parsed = Number.parseInt(raw ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallbackMs;
+}
 
 async function main(): Promise<void> {
   try {
@@ -146,8 +153,12 @@ async function main(): Promise<void> {
       }
     }
 
+    // Claude's session_id is not a Nex ask session_id on first contact.
+    // Reuse the mapped Nex session only when we have already established one.
+    const nexSessionId = input.session_id ? sessions.get(input.session_id) : undefined;
+
     // --- Nex context query ---
-    const result = await client.ask(SESSION_START_QUERY, undefined, 10_000);
+    const result = await client.ask(SESSION_START_QUERY, nexSessionId, SESSION_START_TIMEOUT_MS);
 
     if (!result.answer && contextParts.length === 0) {
       process.stdout.write("{}");

--- a/claude-code-plugin/src/context-files.ts
+++ b/claude-code-plugin/src/context-files.ts
@@ -18,7 +18,9 @@ import type { RateLimiter } from "./rate-limiter.js";
 import { readManifest, writeManifest, isChanged, markIngested } from "./file-manifest.js";
 
 const CLAUDE_DIR = join(homedir(), ".claude");
-const INGEST_TIMEOUT_MS = 10_000;
+const INGEST_TIMEOUT_MS = readTimeoutEnv("NEX_CONTEXT_FILES_TIMEOUT_MS", 10_000);
+const TOTAL_BUDGET_MS = readTimeoutEnv("NEX_CONTEXT_FILES_TOTAL_BUDGET_MS", 12_000);
+const CONTEXT_FILES_ENABLED = (process.env.NEX_CONTEXT_FILES_ENABLED ?? "true").toLowerCase() !== "false";
 const MAX_FILE_SIZE = 100_000;
 
 export interface ContextFilesResult {
@@ -26,6 +28,16 @@ export interface ContextFilesResult {
   skipped: number;
   errors: number;
   files: string[]; // context tags of ingested files
+}
+
+function readTimeoutEnv(name: string, fallbackMs: number): number {
+  const raw = process.env[name];
+  const parsed = Number.parseInt(raw ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallbackMs;
+}
+
+function isAbortError(err: unknown): boolean {
+  return err instanceof Error && err.name === "AbortError";
 }
 
 /**
@@ -43,16 +55,16 @@ function collectContextFiles(cwd: string): Array<{ path: string; contextTag: str
   const files: Array<{ path: string; contextTag: string }> = [];
   const key = projectKey(cwd);
 
-  // 1. Global CLAUDE.md
-  const globalClaude = join(CLAUDE_DIR, "CLAUDE.md");
-  if (existsSync(globalClaude)) {
-    files.push({ path: globalClaude, contextTag: "claude-md:global" });
-  }
-
-  // 2. Project CLAUDE.md
+  // 1. Project CLAUDE.md
   const projectClaude = join(cwd, "CLAUDE.md");
   if (existsSync(projectClaude)) {
     files.push({ path: projectClaude, contextTag: "claude-md:project" });
+  }
+
+  // 2. Global CLAUDE.md
+  const globalClaude = join(CLAUDE_DIR, "CLAUDE.md");
+  if (existsSync(globalClaude)) {
+    files.push({ path: globalClaude, contextTag: "claude-md:global" });
   }
 
   // 3. Memory files: ~/.claude/projects/{key}/memory/*.md
@@ -84,12 +96,23 @@ export async function ingestContextFiles(
   cwd: string
 ): Promise<ContextFilesResult> {
   const result: ContextFilesResult = { ingested: 0, skipped: 0, errors: 0, files: [] };
+  if (!CONTEXT_FILES_ENABLED) {
+    return result;
+  }
   const manifest = readManifest();
   const candidates = collectContextFiles(cwd);
   let dirty = false;
+  const startedAt = Date.now();
 
-  for (const { path, contextTag } of candidates) {
+  for (let i = 0; i < candidates.length; i++) {
+    const { path, contextTag } = candidates[i];
     try {
+      const remainingBudgetMs = TOTAL_BUDGET_MS - (Date.now() - startedAt);
+      if (remainingBudgetMs <= 0) {
+        result.skipped += candidates.length - i;
+        break;
+      }
+
       const stat = statSync(path);
       if (!isChanged(path, stat, manifest)) {
         result.skipped++;
@@ -107,12 +130,17 @@ export async function ingestContextFiles(
         content = content.slice(0, MAX_FILE_SIZE) + "\n[...truncated]";
       }
 
-      await client.ingest(content, contextTag, INGEST_TIMEOUT_MS);
+      await client.ingest(content, contextTag, Math.min(INGEST_TIMEOUT_MS, remainingBudgetMs));
       markIngested(path, stat, contextTag, manifest);
       result.ingested++;
       result.files.push(contextTag);
       dirty = true;
     } catch (err) {
+      if (isAbortError(err)) {
+        // Optional preload only: stop here and let SessionStart continue with Ask.
+        result.skipped += candidates.length - i;
+        break;
+      }
       process.stderr.write(
         `[nex-context-files] Failed to ingest ${contextTag}: ${err instanceof Error ? err.message : String(err)}\n`
       );

--- a/claude-code-plugin/src/nex-client.ts
+++ b/claude-code-plugin/src/nex-client.ts
@@ -58,6 +58,11 @@ export interface AskResponse {
   entity_references?: EntityReference[];
 }
 
+export interface AgentTurnContextResponse {
+  prepared_context: string;
+  entity_references?: EntityReference[];
+}
+
 // --- Client ---
 
 export class NexClient {
@@ -172,5 +177,16 @@ export class NexClient {
     const body: Record<string, unknown> = { query };
     if (sessionId) body.session_id = sessionId;
     return this.request<AskResponse>("POST", "/v1/context/ask", body, timeoutMs);
+  }
+
+  /** Prepare turn-level context once before the outer agent starts tool selection. */
+  async prepareAgentTurnContext(
+    prompt: string,
+    threadId?: string,
+    timeoutMs?: number,
+  ): Promise<AgentTurnContextResponse> {
+    const body: Record<string, unknown> = { prompt };
+    if (threadId) body.thread_id = threadId;
+    return this.request<AgentTurnContextResponse>("POST", "/v1/agent/prepare_turn_context", body, timeoutMs);
   }
 }


### PR DESCRIPTION
Part of nex-crm/core#848.

## What changed
- updates Claude recall/session flows to run turn preflight before direct tool usage
- keeps session-start synthesis on Ask where that path is still intentional
- bounds the optional context-file preload during `SessionStart`, prioritizes the project `CLAUDE.md`, and quiets timeout abort noise

## Why
- Claude is an agent-owned caller for the post-start tool path and should stop routing that path back through Ask
- session start should stay reliable even when optional context-file ingestion is slow

## Validation
- `npm test`
- `npm --prefix claude-code-plugin run build`
- covered by the live acceptance run linked from nex-crm/core#848
