### PR TITLE
[codex] docs: describe preflight plus direct tool flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ Get the full skill content by slug name. Shows trigger condition, action steps, 
 Re-synthesize skills from the latest playbook rules. Runs automatically after playbook compilation on cron.
 
 ### `generate_skill` — Create a skill from a prompt
-Create a new skill from scratch. Read workspace context first with direct tools such as `search_knowledge`, `search_entities`, `get_entity_brief`, `lookup_record`, and `get_tasks`, then generate the full skill markdown and store it. Use when the user asks to create a new workflow or automation.
+Create a new skill from scratch. Read workspace context first with direct tools such as `search_knowledge`, `search_entities`, `get_entity_brief`, and `get_tasks`, then generate the full skill markdown and store it. Use when the user asks to create a new workflow or automation.
 
 ### `update_skill` — Improve a skill
 Patch or replace a skill's content. Use when the user corrects an approach during execution — the skill improves for next time.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,21 +20,34 @@ Setup: `bun install && bunx lefthook install`
 
 # Nex — Organizational Context & Memory
 
-Nex provides your AI agent with real-time organizational knowledge — contacts, deals, meetings, emails, notes, insights, patterns, and playbooks — via MCP tools. Context is proactively injected into your conversation, so relevant knowledge surfaces automatically even when you don't ask for it.
+Nex provides your AI agent with real-time organizational knowledge — contacts, deals, meetings, emails, notes, insights, patterns, playbooks, and executable skills — via MCP tools. Context is proactively injected into your conversation, so relevant knowledge surfaces automatically even when you don't ask for it.
 
 ## MCP Tools Available
 
-### `nex_ask` — AI-powered context query (recommended)
-Use for natural language questions about organizational context.
-Examples: "what's the latest on the Acme deal?", "when did I last talk to Sarah?"
+### `search_knowledge` — Broad context retrieval
+Use for broad, fuzzy, or topic-based workspace questions.
+Examples: "what's the latest on the Acme deal?", "any updates on hiring?"
 
-### `nex_remember` — Store information
+### `get_entity_brief` / `get_entity_profile` — Grounded entity context
+Use when you know which person, company, or deal you need and want the latest grounded brief.
+Examples: "brief me on Sarah", "show Acme's latest profile"
+
+### `search_entities` — Entity lookup and disambiguation
+Use when you need to find or disambiguate a person/company by email, name, or domain before pulling a brief.
+Examples: "find sarah@acme.com", "which Acme is this?"
+
+### `get_tasks` — Task and action-item lookup
+Use for to-dos, open action items, and task status questions.
+
+### `save_facts` / `nex_remember` — Store information
 Save notes, observations, meeting summaries, or any text to the knowledge base.
 Examples: "remember that John prefers email over Slack", store meeting notes
 
-### `nex_search` — Fuzzy record lookup
-Search CRM records (people, companies, deals) by name or keyword.
-Use when looking up a specific named entity rather than asking a question.
+### `external_search` — Web enrichment
+Use when internal context is insufficient and you need grounded external information about a company, person, or market.
+
+### `query_context` / `nex_ask` — Open-ended fallback
+Use only when the task does not map cleanly to a direct primitive above and you need a synthesized answer to an open-ended context question.
 
 ### `nex_list_integrations` — Check connected data sources
 Shows which integrations (Gmail, Slack, Calendar, CRM) are connected and active.
@@ -51,6 +64,24 @@ Change notification frequency or toggle notification types. Example: set polling
 ### `nex_create_notification_rule` — Create custom notification rules
 Set up AI-powered notification rules in natural language. Example: "notify me when deal value changes by more than 10%".
 
+### `list_skills` — List agent skills
+List executable skills synthesized from playbook rules. Skills are grounded to workspace tools, team, and CRM schema.
+
+### `get_skill_by_slug` — View a skill
+Get the full skill content by slug name. Shows trigger condition, action steps, required integrations, and Composio actions.
+
+### `compile_skills` — Trigger skill compilation
+Re-synthesize skills from the latest playbook rules. Runs automatically after playbook compilation on cron.
+
+### `generate_skill` — Create a skill from a prompt
+Create a new skill from scratch. Read workspace context first with direct tools such as `search_knowledge`, `search_entities`, `get_entity_brief`, `lookup_record`, and `get_tasks`, then generate the full skill markdown and store it. Use when the user asks to create a new workflow or automation.
+
+### `update_skill` — Improve a skill
+Patch or replace a skill's content. Use when the user corrects an approach during execution — the skill improves for next time.
+
+### `sync_skills` — Sync skills locally
+Download all skills to `.nex/skills/` as markdown files. Local agents read these directly without API calls.
+
 ## Proactive Context
 
 Nex automatically surfaces relevant context from the user's knowledge graph on every prompt — not just questions. When you see a `<nex-context>` block, use it naturally to inform your response:
@@ -58,20 +89,30 @@ Nex automatically surfaces relevant context from the user's knowledge graph on e
 - **Entity insights** — facts about people, companies, and deals mentioned or relevant to the task
 - **Knowledge insights** — patterns, lessons learned, and domain knowledge from past work
 - **Playbook rules** — proven approaches and best practices from the user's experience
+- **Agent skills** — executable workflows the agent can follow, with specific tools, steps, and decision points
 
 Leverage this context to provide more informed, personalized responses. If the context mentions a relevant pattern or past decision, incorporate it naturally without explicitly referencing the context block.
 
 ## When to Use Nex Tools Directly
 
-Use `nex_ask` proactively when:
+Use the direct tools proactively when:
 - The user mentions a person, company, or project — look up their context
 - The task involves a domain the knowledge graph may have insights on
 - You need organizational context to make a better recommendation
 
-Use `nex_remember` when:
+If you control an agent turn loop, call `prepare_turn_context` once at the start of the turn before selecting direct tools. Do not call it before every tool invocation. Keep `query_context` / `nex_ask` for open-ended synthesis or non-agent flows that do not own tool selection.
+
+Suggested selection:
+- `search_entities` to resolve the right record
+- `get_entity_brief` when the target entity is known
+- `search_knowledge` for broad topic or timeline questions
+- `get_tasks` for to-dos and action items
+- `save_facts` when the user shares durable new information
+- `external_search` only when internal context is insufficient
+- `query_context` / `nex_ask` only as a fallback for open-ended synthesis
+
+Use `save_facts` / `nex_remember` when:
 - The user shares a decision, preference, or important fact worth persisting
 - A conversation reveals new knowledge that future sessions should have access to
-
-Always try `nex_ask` first for general queries. Use `nex_search` when you need to find a specific record by name.
 
 # --- End Nex ---

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Talk to the team, share feedback, and connect with other developers building AI 
 curl -fsSL https://raw.githubusercontent.com/nex-crm/nex-as-a-skill/main/install.sh | sh
 
 # Option B: install the nex-cli binary directly
-curl -fsSL https://raw.githubusercontent.com/nex-crm/nex-as-a-skill/main/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/nex-crm/nex-cli/main/install.sh | sh
 
 # Option C: install via npm (or bun/pnpm)
 npm install -g @nex-ai/nex
@@ -47,6 +47,16 @@ nex remember "Met with Maria, CTO of TechFlow. European expansion Q3, $2M budget
 
 The core of this repo is a set of skills, slash commands, and agent instructions that teach any AI platform how to use Nex.
 
+### Agent-owned vs synthesis paths
+
+For agent-owned tool loops, the intended flow is:
+
+1. Call `prepare_turn_context` once at the start of the turn
+2. Let the outer agent choose direct tools such as `search_knowledge`, `search_entities`, `get_entity_brief`, or `get_tasks`
+3. Use `query_context` / Ask only as an explicit fallback for open-ended synthesis
+
+Non-agent provider flows such as startup summaries, digest generation, or editor context providers still use Ask because those paths need Nex to do the synthesis itself rather than expose raw tool primitives.
+
 ### Slash Commands (`plugin-commands/`)
 
 Drop these `.md` files into your agent's commands directory to get Nex slash commands:
@@ -55,7 +65,7 @@ Drop these `.md` files into your agent's commands directory to get Nex slash com
 |---------|-------------|
 | `/nex:recall <query>` | Search your knowledge base |
 | `/nex:remember <text>` | Store information for later recall |
-| `/nex:entities <query>` | Find people, companies, topics |
+| `/nex:entities <query>` | Look up entities by email, name, or domain |
 | `/nex:scan <dir>` | Scan project files into Nex |
 | `/nex:integrate <provider>` | Connect an OAuth integration |
 | `/nex:register <email>` | One-time account registration |
@@ -85,7 +95,7 @@ Pre-written agent instructions that teach each platform how to use Nex tools. Co
 Deeper integrations for editors that support plugin APIs:
 
 - **Continue** (`continue-provider.ts`) — Nex as a context provider for autocomplete
-- **OpenCode** (`opencode-plugin.ts`) — Session lifecycle hooks for context preservation
+- **OpenCode** (`opencode-plugin.ts`) — Session lifecycle hooks for context preservation and startup synthesis
 - **KiloCode** (`kilocode-modes.yaml`) — Nex memory mode definitions
 - **Windsurf** (`windsurf-workflows/`) — Native workflow definitions for ask, remember, search, notify
 
@@ -165,32 +175,13 @@ Or without a global install:
 }
 ```
 
-### Remote MCP Server (no install required)
-
-Connect directly to the hosted Nex MCP server. No local installation needed — works with any MCP client that supports Streamable HTTP transport.
-
-```json
-{
-  "mcpServers": {
-    "nex": {
-      "url": "https://mcp.nex.ai/mcp",
-      "headers": {
-        "Authorization": "Bearer sk-your_key_here"
-      }
-    }
-  }
-}
-```
-
-Get an API key at [app.nex.ai/settings/developers](https://app.nex.ai/settings/developers).
-
 ### Shell-only Agents (no Node.js)
 
 Bash scripts for agents that can only run shell commands. Requires `curl` and `jq`.
 
 ```bash
 bash scripts/nex-openclaw-register.sh your@email.com "Your Name"
-printf '{"query":"who is Maria?"}' | bash scripts/nex-api.sh POST /v1/context/ask
+printf '{"arguments":{"query":"who is Maria?"}}' | bash scripts/nex-api.sh POST /v1/agent/tools/search_knowledge/execute
 bash scripts/nex-scan-files.sh --dir . --max-files 10
 ```
 

--- a/claude-code-plugin/README.md
+++ b/claude-code-plugin/README.md
@@ -111,14 +111,18 @@ Then use:
 3. Injects as system context so the agent "already knows" relevant business context from the first message
 4. On any error: returns `{}`, logs to stderr (graceful degradation)
 
+This stays on Ask intentionally because it is a synthesis path, not an outer-agent tool loop.
+
 ### Auto-Recall (UserPromptSubmit Hook)
 
 1. Reads the user's prompt from stdin (`{ "prompt": "...", "session_id": "..." }`)
 2. Runs prompt through `recall-filter.ts` and skips only low-signal input such as short messages, slash commands, explicit `!` opt-out prompts, and bare shell commands
-3. If recall is needed, tries a short synchronous `/ask` request so relevant context can land on the same user turn
-4. If the sync budget is missed, falls back to a background `/ask` request and caches the result for the next eligible prompt
+3. If recall is needed, calls the agent preflight endpoint so Nex runs turn-level prep and pre-search once before Claude starts selecting direct tools
+4. If the synchronous budget is missed, the background recall worker retries the same preflight request and caches the result for the next eligible prompt
 5. Returns `{ "additionalContext": "<nex-context>...</nex-context>" }` when recall is ready to inject into the conversation
 6. On any error: returns `{}`, logs to stderr (graceful degradation)
+
+This is the agent-owned path: preflight once per turn, then Claude uses direct tools itself instead of routing through a nested Ask agent.
 
 ### Auto-Capture (Stop Hook)
 
@@ -136,7 +140,7 @@ claude-code-plugin/
 │   ├── auto-session-start.ts  # SessionStart hook — baseline context load
 │   ├── auto-recall.ts         # UserPromptSubmit hook — fast recall + cache fallback
 │   ├── auto-capture.ts        # Stop hook — conversation capture
-│   ├── auto-recall-worker.ts  # Background recall worker for slow Ask calls
+│   ├── auto-recall-worker.ts  # Background recall worker for slow preflight calls
 │   ├── recall-filter.ts       # Smart prompt classifier
 │   ├── nex-client.ts          # HTTP client for Nex API
 │   ├── config.ts              # Environment variable config

--- a/claude-code-plugin/commands/nex:entities.md
+++ b/claude-code-plugin/commands/nex:entities.md
@@ -1,12 +1,13 @@
 ---
-description: Search for entities (people, companies, topics) in Nex knowledge base
+description: Look up entities in Nex by email, name, or domain
 ---
-Search for entities matching: $ARGUMENTS
-If no query provided, respond: "Usage: /nex:entities <search query>"
+Look up entities matching: $ARGUMENTS
+If no query provided, respond: "Usage: /nex:entities <email|name|domain>"
 
-Use the `mcp__nex__query_context` tool with the query.
-From the response, extract the `entity_references` array.
-If no entities found, respond: "No matching entities found."
+Use the direct entity lookup tools instead of `query_context`:
+1. Call `mcp__nex__search_entities` with the query if that tool name is available. Otherwise call `search_entities`.
+2. If there are no matches, respond: "No matching entities found."
+3. If the result is ambiguous and you need richer detail for a specific match, follow up with `get_entity_brief` or `get_entity_profile`.
 
 Format each entity as a bullet list:
 ```

--- a/claude-code-plugin/commands/nex:recall.md
+++ b/claude-code-plugin/commands/nex:recall.md
@@ -2,4 +2,4 @@
 description: Recall relevant memories from Nex knowledge base
 ---
 Search the nex knowledge base for: $ARGUMENTS
-Use the mcp__nex__context_ask tool to query and return formatted results with sources.
+Use the direct `mcp__nex__search_knowledge` tool if available. If not, fall back to `mcp__nex__context_ask`.

--- a/platform-plugins/opencode-plugin.ts
+++ b/platform-plugins/opencode-plugin.ts
@@ -5,8 +5,11 @@
  * OpenCode's bun runtime resolves imports at load time.
  *
  * Provides:
- * - Session lifecycle hooks (context loading on session create)
+ * - Session lifecycle hooks (Ask-based context loading on session create)
  * - Context preservation during compaction
+ *
+ * OpenCode's startup synthesis stays on Ask because it is automatic
+ * context loading rather than a direct agent-invoked query.
  */
 
 import { readFileSync } from "node:fs";

--- a/platform-plugins/vscode-agent.md
+++ b/platform-plugins/vscode-agent.md
@@ -9,9 +9,13 @@ You are the Nex agent. You help users query their organizational knowledge, CRM 
 
 ## Available MCP Tools
 
-- **nex_ask** — Query the knowledge graph with natural language (people, companies, deals, meetings, emails)
-- **nex_remember** — Store information for future recall across all connected platforms
-- **nex_search** — Search CRM records by name (people, companies, deals)
+- **search_knowledge** — Broad workspace retrieval for fuzzy, topic-based questions
+- **get_entity_brief** / **get_entity_profile** — Grounded context for a known person, company, or deal
+- **search_entities** — Entity lookup and disambiguation by email, name, or domain
+- **get_tasks** — Task and action-item lookup
+- **save_facts** / **nex_remember** — Store durable information for future recall
+- **external_search** — Web enrichment when internal context is insufficient
+- **query_context** / **nex_ask** — Open-ended fallback for synthesized context answers
 - **nex_list_integrations** — Check connected data sources (Gmail, Slack, Salesforce, etc.)
 - **nex_connect_integration** — Connect a new data source via OAuth
 
@@ -27,8 +31,12 @@ Use Nex tools when the user asks about:
 
 ## Guidelines
 
-- Always use `nex_ask` for natural language queries about organizational knowledge
-- Use `nex_search` when looking up specific CRM records by name
-- Use `nex_remember` to store meeting notes, decisions, or important context
+- Use `search_entities` to resolve the right record before requesting a brief
+- Use `get_entity_brief` / `get_entity_profile` when the target entity is known
+- Use `search_knowledge` for broad topic and timeline questions
+- Use `get_tasks` for action items and task status
+- Use `save_facts` / `nex_remember` to store meeting notes, decisions, or important context
+- Use `external_search` only when the answer is not grounded in Nex already
+- Use `query_context` / `nex_ask` only when the task does not map cleanly to a more direct primitive
 - Present results clearly with key entities highlighted
 - If no results are found, suggest the user connect relevant data sources

--- a/platform-plugins/windsurf-workflows/nex:ask.md
+++ b/platform-plugins/windsurf-workflows/nex:ask.md
@@ -3,7 +3,9 @@ name: nex:ask
 description: Ask Nex a question about organizational context, people, companies, deals, or meetings
 ---
 
-Use the Nex MCP tool `nex_ask` to answer the user's question about organizational context.
+Answer the user's question with direct Nex MCP tools first.
+Use `search_knowledge` for broad or fuzzy queries, `search_entities` to resolve people or companies, `get_entity_brief` / `get_entity_profile` for known entities, and `get_tasks` for action-item questions.
+Use `query_context` / `nex_ask` only if the question is genuinely open-ended and does not map cleanly to a direct primitive.
 
 If the user provides a query, pass it directly. If not, ask what they'd like to know about their organizational context, CRM records, meetings, or communications.
 

--- a/plugin-commands/nex:entities.md
+++ b/plugin-commands/nex:entities.md
@@ -1,12 +1,13 @@
 ---
-description: Search for entities (people, companies, topics) in Nex knowledge base
+description: Look up entities in Nex by email, name, or domain
 ---
-Search for entities matching: $ARGUMENTS
-If no query provided, respond: "Usage: /nex:entities <search query>"
+Look up entities matching: $ARGUMENTS
+If no query provided, respond: "Usage: /nex:entities <email|name|domain>"
 
-Use the `mcp__nex__query_context` tool with the query.
-From the response, extract the `entity_references` array.
-If no entities found, respond: "No matching entities found."
+Use the direct entity lookup tools instead of `query_context`:
+1. Call `mcp__nex__search_entities` with the query if the agent has that tool name available, otherwise call `search_entities`.
+2. If the result is empty, respond: "No matching entities found."
+3. If the result is ambiguous and you need richer detail for a specific match, follow up with `get_entity_brief` / `get_entity_profile`.
 
 Format each entity as a bullet list:
 ```

--- a/plugin-commands/nex:recall.md
+++ b/plugin-commands/nex:recall.md
@@ -2,4 +2,4 @@
 description: Recall relevant memories from Nex knowledge base
 ---
 Search the nex knowledge base for: $ARGUMENTS
-Use the mcp__nex__context_ask tool to query and return formatted results with sources.
+Use the direct `mcp__nex__search_knowledge` tool if available. If not, fall back to `mcp__nex__context_ask`.


### PR DESCRIPTION
Part of nex-crm/core#848.

## What changed
- updates top-level docs and command docs to describe the new boundary
- clarifies when callers should use preflight plus direct tools vs Ask

## Why
- the rollout changes the execution model and needs explicit guidance for consumers and future maintainers

## Validation
- `npm test`
