### PR TITLE
[codex] rules: steer agents to preflight plus direct tools

### DIFF
--- a/platform-rules/aider-conventions.md
+++ b/platform-rules/aider-conventions.md
@@ -1,20 +1,33 @@
+# --- Nex Context & Memory ---
+
 # Nex — Organizational Context & Memory
 
-Nex provides your AI agent with real-time organizational knowledge — contacts, deals, meetings, emails, notes, insights, patterns, and playbooks — via MCP tools. Context is proactively injected into your conversation, so relevant knowledge surfaces automatically even when you don't ask for it.
+Nex provides your AI agent with real-time organizational knowledge — contacts, deals, meetings, emails, notes, insights, patterns, playbooks, and executable skills — via MCP tools. Context is proactively injected into your conversation, so relevant knowledge surfaces automatically even when you don't ask for it.
 
 ## MCP Tools Available
 
-### `nex_ask` — AI-powered context query (recommended)
-Use for natural language questions about organizational context.
-Examples: "what's the latest on the Acme deal?", "when did I last talk to Sarah?"
+### `search_knowledge` — Broad context retrieval
+Use for broad, fuzzy, or topic-based workspace questions.
+Examples: "what's the latest on the Acme deal?", "any updates on hiring?"
 
-### `nex_remember` — Store information
+### `get_entity_brief` / `get_entity_profile` — Grounded entity context
+Use when you know which person, company, or deal you need and want the latest grounded brief.
+
+### `search_entities` — Entity lookup and disambiguation
+Use when you need to find or disambiguate a person/company by email, name, or domain before pulling a brief.
+
+### `get_tasks` — Task and action-item lookup
+Use for to-dos, open action items, and task status questions.
+
+### `save_facts` / `nex_remember` — Store information
 Save notes, observations, meeting summaries, or any text to the knowledge base.
 Examples: "remember that John prefers email over Slack", store meeting notes
 
-### `nex_search` — Fuzzy record lookup
-Search CRM records (people, companies, deals) by name or keyword.
-Use when looking up a specific named entity rather than asking a question.
+### `external_search` — Web enrichment
+Use when internal context is insufficient and you need grounded external information about a company, person, or market.
+
+### `query_context` / `nex_ask` — Open-ended fallback
+Use only when the task does not map cleanly to a direct primitive above and you need a synthesized answer to an open-ended context question.
 
 ### `nex_list_integrations` — Check connected data sources
 Shows which integrations (Gmail, Slack, Calendar, CRM) are connected and active.
@@ -38,18 +51,28 @@ Nex automatically surfaces relevant context from the user's knowledge graph on e
 - **Entity insights** — facts about people, companies, and deals mentioned or relevant to the task
 - **Knowledge insights** — patterns, lessons learned, and domain knowledge from past work
 - **Playbook rules** — proven approaches and best practices from the user's experience
+- **Agent skills** — executable workflows with specific tools, steps, and decision points
 
 Leverage this context to provide more informed, personalized responses. If the context mentions a relevant pattern or past decision, incorporate it naturally without explicitly referencing the context block.
 
 ## When to Use Nex Tools Directly
 
-Use `nex_ask` proactively when:
+Use the direct tools proactively when:
 - The user mentions a person, company, or project — look up their context
 - The task involves a domain the knowledge graph may have insights on
 - You need organizational context to make a better recommendation
 
-Use `nex_remember` when:
+Suggested selection:
+- `search_entities` to resolve the right record
+- `get_entity_brief` when the target entity is known
+- `search_knowledge` for broad topic or timeline questions
+- `get_tasks` for to-dos and action items
+- `save_facts` when the user shares durable new information
+- `external_search` only when internal context is insufficient
+- `query_context` / `nex_ask` only as a fallback for open-ended synthesis
+
+Use `save_facts` / `nex_remember` when:
 - The user shares a decision, preference, or important fact worth persisting
 - A conversation reveals new knowledge that future sessions should have access to
 
-Always try `nex_ask` first for general queries. Use `nex_search` when you need to find a specific record by name.
+# --- End Nex ---

--- a/platform-rules/cline-rules.md
+++ b/platform-rules/cline-rules.md
@@ -1,20 +1,33 @@
+# --- Nex Context & Memory ---
+
 # Nex — Organizational Context & Memory
 
-Nex provides your AI agent with real-time organizational knowledge — contacts, deals, meetings, emails, notes, insights, patterns, and playbooks — via MCP tools. Context is proactively injected into your conversation, so relevant knowledge surfaces automatically even when you don't ask for it.
+Nex provides your AI agent with real-time organizational knowledge — contacts, deals, meetings, emails, notes, insights, patterns, playbooks, and executable skills — via MCP tools. Context is proactively injected into your conversation, so relevant knowledge surfaces automatically even when you don't ask for it.
 
 ## MCP Tools Available
 
-### `nex_ask` — AI-powered context query (recommended)
-Use for natural language questions about organizational context.
-Examples: "what's the latest on the Acme deal?", "when did I last talk to Sarah?"
+### `search_knowledge` — Broad context retrieval
+Use for broad, fuzzy, or topic-based workspace questions.
+Examples: "what's the latest on the Acme deal?", "any updates on hiring?"
 
-### `nex_remember` — Store information
+### `get_entity_brief` / `get_entity_profile` — Grounded entity context
+Use when you know which person, company, or deal you need and want the latest grounded brief.
+
+### `search_entities` — Entity lookup and disambiguation
+Use when you need to find or disambiguate a person/company by email, name, or domain before pulling a brief.
+
+### `get_tasks` — Task and action-item lookup
+Use for to-dos, open action items, and task status questions.
+
+### `save_facts` / `nex_remember` — Store information
 Save notes, observations, meeting summaries, or any text to the knowledge base.
 Examples: "remember that John prefers email over Slack", store meeting notes
 
-### `nex_search` — Fuzzy record lookup
-Search CRM records (people, companies, deals) by name or keyword.
-Use when looking up a specific named entity rather than asking a question.
+### `external_search` — Web enrichment
+Use when internal context is insufficient and you need grounded external information about a company, person, or market.
+
+### `query_context` / `nex_ask` — Open-ended fallback
+Use only when the task does not map cleanly to a direct primitive above and you need a synthesized answer to an open-ended context question.
 
 ### `nex_list_integrations` — Check connected data sources
 Shows which integrations (Gmail, Slack, Calendar, CRM) are connected and active.
@@ -38,18 +51,28 @@ Nex automatically surfaces relevant context from the user's knowledge graph on e
 - **Entity insights** — facts about people, companies, and deals mentioned or relevant to the task
 - **Knowledge insights** — patterns, lessons learned, and domain knowledge from past work
 - **Playbook rules** — proven approaches and best practices from the user's experience
+- **Agent skills** — executable workflows with specific tools, steps, and decision points
 
 Leverage this context to provide more informed, personalized responses. If the context mentions a relevant pattern or past decision, incorporate it naturally without explicitly referencing the context block.
 
 ## When to Use Nex Tools Directly
 
-Use `nex_ask` proactively when:
+Use the direct tools proactively when:
 - The user mentions a person, company, or project — look up their context
 - The task involves a domain the knowledge graph may have insights on
 - You need organizational context to make a better recommendation
 
-Use `nex_remember` when:
+Suggested selection:
+- `search_entities` to resolve the right record
+- `get_entity_brief` when the target entity is known
+- `search_knowledge` for broad topic or timeline questions
+- `get_tasks` for to-dos and action items
+- `save_facts` when the user shares durable new information
+- `external_search` only when internal context is insufficient
+- `query_context` / `nex_ask` only as a fallback for open-ended synthesis
+
+Use `save_facts` / `nex_remember` when:
 - The user shares a decision, preference, or important fact worth persisting
 - A conversation reveals new knowledge that future sessions should have access to
 
-Always try `nex_ask` first for general queries. Use `nex_search` when you need to find a specific record by name.
+# --- End Nex ---

--- a/platform-rules/codex-agents.md
+++ b/platform-rules/codex-agents.md
@@ -2,21 +2,32 @@
 
 # Nex — Organizational Context & Memory
 
-Nex provides your AI agent with real-time organizational knowledge — contacts, deals, meetings, emails, notes, insights, patterns, and playbooks — via MCP tools. Context is proactively injected into your conversation, so relevant knowledge surfaces automatically even when you don't ask for it.
+Nex provides your AI agent with real-time organizational knowledge — contacts, deals, meetings, emails, notes, insights, patterns, playbooks, and executable skills — via MCP tools. Context is proactively injected into your conversation, so relevant knowledge surfaces automatically even when you don't ask for it.
 
 ## MCP Tools Available
 
-### `nex_ask` — AI-powered context query (recommended)
-Use for natural language questions about organizational context.
-Examples: "what's the latest on the Acme deal?", "when did I last talk to Sarah?"
+### `search_knowledge` — Broad context retrieval
+Use for broad, fuzzy, or topic-based workspace questions.
+Examples: "what's the latest on the Acme deal?", "any updates on hiring?"
 
-### `nex_remember` — Store information
+### `get_entity_brief` / `get_entity_profile` — Grounded entity context
+Use when you know which person, company, or deal you need and want the latest grounded brief.
+
+### `search_entities` — Entity lookup and disambiguation
+Use when you need to find or disambiguate a person/company by email, name, or domain before pulling a brief.
+
+### `get_tasks` — Task and action-item lookup
+Use for to-dos, open action items, and task status questions.
+
+### `save_facts` / `nex_remember` — Store information
 Save notes, observations, meeting summaries, or any text to the knowledge base.
 Examples: "remember that John prefers email over Slack", store meeting notes
 
-### `nex_search` — Fuzzy record lookup
-Search CRM records (people, companies, deals) by name or keyword.
-Use when looking up a specific named entity rather than asking a question.
+### `external_search` — Web enrichment
+Use when internal context is insufficient and you need grounded external information about a company, person, or market.
+
+### `query_context` / `nex_ask` — Open-ended fallback
+Use only when the task does not map cleanly to a direct primitive above and you need a synthesized answer to an open-ended context question.
 
 ### `nex_list_integrations` — Check connected data sources
 Shows which integrations (Gmail, Slack, Calendar, CRM) are connected and active.
@@ -40,20 +51,28 @@ Nex automatically surfaces relevant context from the user's knowledge graph on e
 - **Entity insights** — facts about people, companies, and deals mentioned or relevant to the task
 - **Knowledge insights** — patterns, lessons learned, and domain knowledge from past work
 - **Playbook rules** — proven approaches and best practices from the user's experience
+- **Agent skills** — executable workflows with specific tools, steps, and decision points
 
 Leverage this context to provide more informed, personalized responses. If the context mentions a relevant pattern or past decision, incorporate it naturally without explicitly referencing the context block.
 
 ## When to Use Nex Tools Directly
 
-Use `nex_ask` proactively when:
+Use the direct tools proactively when:
 - The user mentions a person, company, or project — look up their context
 - The task involves a domain the knowledge graph may have insights on
 - You need organizational context to make a better recommendation
 
-Use `nex_remember` when:
+Suggested selection:
+- `search_entities` to resolve the right record
+- `get_entity_brief` when the target entity is known
+- `search_knowledge` for broad topic or timeline questions
+- `get_tasks` for to-dos and action items
+- `save_facts` when the user shares durable new information
+- `external_search` only when internal context is insufficient
+- `query_context` / `nex_ask` only as a fallback for open-ended synthesis
+
+Use `save_facts` / `nex_remember` when:
 - The user shares a decision, preference, or important fact worth persisting
 - A conversation reveals new knowledge that future sessions should have access to
-
-Always try `nex_ask` first for general queries. Use `nex_search` when you need to find a specific record by name.
 
 # --- End Nex ---

--- a/platform-rules/continue-rules.md
+++ b/platform-rules/continue-rules.md
@@ -1,20 +1,33 @@
+# --- Nex Context & Memory ---
+
 # Nex — Organizational Context & Memory
 
-Nex provides your AI agent with real-time organizational knowledge — contacts, deals, meetings, emails, notes, insights, patterns, and playbooks — via MCP tools. Context is proactively injected into your conversation, so relevant knowledge surfaces automatically even when you don't ask for it.
+Nex provides your AI agent with real-time organizational knowledge — contacts, deals, meetings, emails, notes, insights, patterns, playbooks, and executable skills — via MCP tools. Context is proactively injected into your conversation, so relevant knowledge surfaces automatically even when you don't ask for it.
 
 ## MCP Tools Available
 
-### `nex_ask` — AI-powered context query (recommended)
-Use for natural language questions about organizational context.
-Examples: "what's the latest on the Acme deal?", "when did I last talk to Sarah?"
+### `search_knowledge` — Broad context retrieval
+Use for broad, fuzzy, or topic-based workspace questions.
+Examples: "what's the latest on the Acme deal?", "any updates on hiring?"
 
-### `nex_remember` — Store information
+### `get_entity_brief` / `get_entity_profile` — Grounded entity context
+Use when you know which person, company, or deal you need and want the latest grounded brief.
+
+### `search_entities` — Entity lookup and disambiguation
+Use when you need to find or disambiguate a person/company by email, name, or domain before pulling a brief.
+
+### `get_tasks` — Task and action-item lookup
+Use for to-dos, open action items, and task status questions.
+
+### `save_facts` / `nex_remember` — Store information
 Save notes, observations, meeting summaries, or any text to the knowledge base.
 Examples: "remember that John prefers email over Slack", store meeting notes
 
-### `nex_search` — Fuzzy record lookup
-Search CRM records (people, companies, deals) by name or keyword.
-Use when looking up a specific named entity rather than asking a question.
+### `external_search` — Web enrichment
+Use when internal context is insufficient and you need grounded external information about a company, person, or market.
+
+### `query_context` / `nex_ask` — Open-ended fallback
+Use only when the task does not map cleanly to a direct primitive above and you need a synthesized answer to an open-ended context question.
 
 ### `nex_list_integrations` — Check connected data sources
 Shows which integrations (Gmail, Slack, Calendar, CRM) are connected and active.
@@ -38,18 +51,28 @@ Nex automatically surfaces relevant context from the user's knowledge graph on e
 - **Entity insights** — facts about people, companies, and deals mentioned or relevant to the task
 - **Knowledge insights** — patterns, lessons learned, and domain knowledge from past work
 - **Playbook rules** — proven approaches and best practices from the user's experience
+- **Agent skills** — executable workflows with specific tools, steps, and decision points
 
 Leverage this context to provide more informed, personalized responses. If the context mentions a relevant pattern or past decision, incorporate it naturally without explicitly referencing the context block.
 
 ## When to Use Nex Tools Directly
 
-Use `nex_ask` proactively when:
+Use the direct tools proactively when:
 - The user mentions a person, company, or project — look up their context
 - The task involves a domain the knowledge graph may have insights on
 - You need organizational context to make a better recommendation
 
-Use `nex_remember` when:
+Suggested selection:
+- `search_entities` to resolve the right record
+- `get_entity_brief` when the target entity is known
+- `search_knowledge` for broad topic or timeline questions
+- `get_tasks` for to-dos and action items
+- `save_facts` when the user shares durable new information
+- `external_search` only when internal context is insufficient
+- `query_context` / `nex_ask` only as a fallback for open-ended synthesis
+
+Use `save_facts` / `nex_remember` when:
 - The user shares a decision, preference, or important fact worth persisting
 - A conversation reveals new knowledge that future sessions should have access to
 
-Always try `nex_ask` first for general queries. Use `nex_search` when you need to find a specific record by name.
+# --- End Nex ---

--- a/platform-rules/cursor-rules.md
+++ b/platform-rules/cursor-rules.md
@@ -1,20 +1,33 @@
+# --- Nex Context & Memory ---
+
 # Nex — Organizational Context & Memory
 
-Nex provides your AI agent with real-time organizational knowledge — contacts, deals, meetings, emails, notes, insights, patterns, and playbooks — via MCP tools. Context is proactively injected into your conversation, so relevant knowledge surfaces automatically even when you don't ask for it.
+Nex provides your AI agent with real-time organizational knowledge — contacts, deals, meetings, emails, notes, insights, patterns, playbooks, and executable skills — via MCP tools. Context is proactively injected into your conversation, so relevant knowledge surfaces automatically even when you don't ask for it.
 
 ## MCP Tools Available
 
-### `nex_ask` — AI-powered context query (recommended)
-Use for natural language questions about organizational context.
-Examples: "what's the latest on the Acme deal?", "when did I last talk to Sarah?"
+### `search_knowledge` — Broad context retrieval
+Use for broad, fuzzy, or topic-based workspace questions.
+Examples: "what's the latest on the Acme deal?", "any updates on hiring?"
 
-### `nex_remember` — Store information
+### `get_entity_brief` / `get_entity_profile` — Grounded entity context
+Use when you know which person, company, or deal you need and want the latest grounded brief.
+
+### `search_entities` — Entity lookup and disambiguation
+Use when you need to find or disambiguate a person/company by email, name, or domain before pulling a brief.
+
+### `get_tasks` — Task and action-item lookup
+Use for to-dos, open action items, and task status questions.
+
+### `save_facts` / `nex_remember` — Store information
 Save notes, observations, meeting summaries, or any text to the knowledge base.
 Examples: "remember that John prefers email over Slack", store meeting notes
 
-### `nex_search` — Fuzzy record lookup
-Search CRM records (people, companies, deals) by name or keyword.
-Use when looking up a specific named entity rather than asking a question.
+### `external_search` — Web enrichment
+Use when internal context is insufficient and you need grounded external information about a company, person, or market.
+
+### `query_context` / `nex_ask` — Open-ended fallback
+Use only when the task does not map cleanly to a direct primitive above and you need a synthesized answer to an open-ended context question.
 
 ### `nex_list_integrations` — Check connected data sources
 Shows which integrations (Gmail, Slack, Calendar, CRM) are connected and active.
@@ -38,18 +51,28 @@ Nex automatically surfaces relevant context from the user's knowledge graph on e
 - **Entity insights** — facts about people, companies, and deals mentioned or relevant to the task
 - **Knowledge insights** — patterns, lessons learned, and domain knowledge from past work
 - **Playbook rules** — proven approaches and best practices from the user's experience
+- **Agent skills** — executable workflows with specific tools, steps, and decision points
 
 Leverage this context to provide more informed, personalized responses. If the context mentions a relevant pattern or past decision, incorporate it naturally without explicitly referencing the context block.
 
 ## When to Use Nex Tools Directly
 
-Use `nex_ask` proactively when:
+Use the direct tools proactively when:
 - The user mentions a person, company, or project — look up their context
 - The task involves a domain the knowledge graph may have insights on
 - You need organizational context to make a better recommendation
 
-Use `nex_remember` when:
+Suggested selection:
+- `search_entities` to resolve the right record
+- `get_entity_brief` when the target entity is known
+- `search_knowledge` for broad topic or timeline questions
+- `get_tasks` for to-dos and action items
+- `save_facts` when the user shares durable new information
+- `external_search` only when internal context is insufficient
+- `query_context` / `nex_ask` only as a fallback for open-ended synthesis
+
+Use `save_facts` / `nex_remember` when:
 - The user shares a decision, preference, or important fact worth persisting
 - A conversation reveals new knowledge that future sessions should have access to
 
-Always try `nex_ask` first for general queries. Use `nex_search` when you need to find a specific record by name.
+# --- End Nex ---

--- a/platform-rules/kilocode-rules.md
+++ b/platform-rules/kilocode-rules.md
@@ -1,20 +1,33 @@
+# --- Nex Context & Memory ---
+
 # Nex — Organizational Context & Memory
 
-Nex provides your AI agent with real-time organizational knowledge — contacts, deals, meetings, emails, notes, insights, patterns, and playbooks — via MCP tools. Context is proactively injected into your conversation, so relevant knowledge surfaces automatically even when you don't ask for it.
+Nex provides your AI agent with real-time organizational knowledge — contacts, deals, meetings, emails, notes, insights, patterns, playbooks, and executable skills — via MCP tools. Context is proactively injected into your conversation, so relevant knowledge surfaces automatically even when you don't ask for it.
 
 ## MCP Tools Available
 
-### `nex_ask` — AI-powered context query (recommended)
-Use for natural language questions about organizational context.
-Examples: "what's the latest on the Acme deal?", "when did I last talk to Sarah?"
+### `search_knowledge` — Broad context retrieval
+Use for broad, fuzzy, or topic-based workspace questions.
+Examples: "what's the latest on the Acme deal?", "any updates on hiring?"
 
-### `nex_remember` — Store information
+### `get_entity_brief` / `get_entity_profile` — Grounded entity context
+Use when you know which person, company, or deal you need and want the latest grounded brief.
+
+### `search_entities` — Entity lookup and disambiguation
+Use when you need to find or disambiguate a person/company by email, name, or domain before pulling a brief.
+
+### `get_tasks` — Task and action-item lookup
+Use for to-dos, open action items, and task status questions.
+
+### `save_facts` / `nex_remember` — Store information
 Save notes, observations, meeting summaries, or any text to the knowledge base.
 Examples: "remember that John prefers email over Slack", store meeting notes
 
-### `nex_search` — Fuzzy record lookup
-Search CRM records (people, companies, deals) by name or keyword.
-Use when looking up a specific named entity rather than asking a question.
+### `external_search` — Web enrichment
+Use when internal context is insufficient and you need grounded external information about a company, person, or market.
+
+### `query_context` / `nex_ask` — Open-ended fallback
+Use only when the task does not map cleanly to a direct primitive above and you need a synthesized answer to an open-ended context question.
 
 ### `nex_list_integrations` — Check connected data sources
 Shows which integrations (Gmail, Slack, Calendar, CRM) are connected and active.
@@ -38,18 +51,28 @@ Nex automatically surfaces relevant context from the user's knowledge graph on e
 - **Entity insights** — facts about people, companies, and deals mentioned or relevant to the task
 - **Knowledge insights** — patterns, lessons learned, and domain knowledge from past work
 - **Playbook rules** — proven approaches and best practices from the user's experience
+- **Agent skills** — executable workflows with specific tools, steps, and decision points
 
 Leverage this context to provide more informed, personalized responses. If the context mentions a relevant pattern or past decision, incorporate it naturally without explicitly referencing the context block.
 
 ## When to Use Nex Tools Directly
 
-Use `nex_ask` proactively when:
+Use the direct tools proactively when:
 - The user mentions a person, company, or project — look up their context
 - The task involves a domain the knowledge graph may have insights on
 - You need organizational context to make a better recommendation
 
-Use `nex_remember` when:
+Suggested selection:
+- `search_entities` to resolve the right record
+- `get_entity_brief` when the target entity is known
+- `search_knowledge` for broad topic or timeline questions
+- `get_tasks` for to-dos and action items
+- `save_facts` when the user shares durable new information
+- `external_search` only when internal context is insufficient
+- `query_context` / `nex_ask` only as a fallback for open-ended synthesis
+
+Use `save_facts` / `nex_remember` when:
 - The user shares a decision, preference, or important fact worth persisting
 - A conversation reveals new knowledge that future sessions should have access to
 
-Always try `nex_ask` first for general queries. Use `nex_search` when you need to find a specific record by name.
+# --- End Nex ---

--- a/platform-rules/opencode-agents.md
+++ b/platform-rules/opencode-agents.md
@@ -1,20 +1,33 @@
+# --- Nex Context & Memory ---
+
 # Nex — Organizational Context & Memory
 
-Nex provides your AI agent with real-time organizational knowledge — contacts, deals, meetings, emails, notes, insights, patterns, and playbooks — via MCP tools. Context is proactively injected into your conversation, so relevant knowledge surfaces automatically even when you don't ask for it.
+Nex provides your AI agent with real-time organizational knowledge — contacts, deals, meetings, emails, notes, insights, patterns, playbooks, and executable skills — via MCP tools. Context is proactively injected into your conversation, so relevant knowledge surfaces automatically even when you don't ask for it.
 
 ## MCP Tools Available
 
-### `nex_ask` — AI-powered context query (recommended)
-Use for natural language questions about organizational context.
-Examples: "what's the latest on the Acme deal?", "when did I last talk to Sarah?"
+### `search_knowledge` — Broad context retrieval
+Use for broad, fuzzy, or topic-based workspace questions.
+Examples: "what's the latest on the Acme deal?", "any updates on hiring?"
 
-### `nex_remember` — Store information
+### `get_entity_brief` / `get_entity_profile` — Grounded entity context
+Use when you know which person, company, or deal you need and want the latest grounded brief.
+
+### `search_entities` — Entity lookup and disambiguation
+Use when you need to find or disambiguate a person/company by email, name, or domain before pulling a brief.
+
+### `get_tasks` — Task and action-item lookup
+Use for to-dos, open action items, and task status questions.
+
+### `save_facts` / `nex_remember` — Store information
 Save notes, observations, meeting summaries, or any text to the knowledge base.
 Examples: "remember that John prefers email over Slack", store meeting notes
 
-### `nex_search` — Fuzzy record lookup
-Search CRM records (people, companies, deals) by name or keyword.
-Use when looking up a specific named entity rather than asking a question.
+### `external_search` — Web enrichment
+Use when internal context is insufficient and you need grounded external information about a company, person, or market.
+
+### `query_context` / `nex_ask` — Open-ended fallback
+Use only when the task does not map cleanly to a direct primitive above and you need a synthesized answer to an open-ended context question.
 
 ### `nex_list_integrations` — Check connected data sources
 Shows which integrations (Gmail, Slack, Calendar, CRM) are connected and active.
@@ -38,18 +51,28 @@ Nex automatically surfaces relevant context from the user's knowledge graph on e
 - **Entity insights** — facts about people, companies, and deals mentioned or relevant to the task
 - **Knowledge insights** — patterns, lessons learned, and domain knowledge from past work
 - **Playbook rules** — proven approaches and best practices from the user's experience
+- **Agent skills** — executable workflows with specific tools, steps, and decision points
 
 Leverage this context to provide more informed, personalized responses. If the context mentions a relevant pattern or past decision, incorporate it naturally without explicitly referencing the context block.
 
 ## When to Use Nex Tools Directly
 
-Use `nex_ask` proactively when:
+Use the direct tools proactively when:
 - The user mentions a person, company, or project — look up their context
 - The task involves a domain the knowledge graph may have insights on
 - You need organizational context to make a better recommendation
 
-Use `nex_remember` when:
+Suggested selection:
+- `search_entities` to resolve the right record
+- `get_entity_brief` when the target entity is known
+- `search_knowledge` for broad topic or timeline questions
+- `get_tasks` for to-dos and action items
+- `save_facts` when the user shares durable new information
+- `external_search` only when internal context is insufficient
+- `query_context` / `nex_ask` only as a fallback for open-ended synthesis
+
+Use `save_facts` / `nex_remember` when:
 - The user shares a decision, preference, or important fact worth persisting
 - A conversation reveals new knowledge that future sessions should have access to
 
-Always try `nex_ask` first for general queries. Use `nex_search` when you need to find a specific record by name.
+# --- End Nex ---

--- a/platform-rules/vscode-instructions.md
+++ b/platform-rules/vscode-instructions.md
@@ -1,20 +1,33 @@
+# --- Nex Context & Memory ---
+
 # Nex — Organizational Context & Memory
 
-Nex provides your AI agent with real-time organizational knowledge — contacts, deals, meetings, emails, notes, insights, patterns, and playbooks — via MCP tools. Context is proactively injected into your conversation, so relevant knowledge surfaces automatically even when you don't ask for it.
+Nex provides your AI agent with real-time organizational knowledge — contacts, deals, meetings, emails, notes, insights, patterns, playbooks, and executable skills — via MCP tools. Context is proactively injected into your conversation, so relevant knowledge surfaces automatically even when you don't ask for it.
 
 ## MCP Tools Available
 
-### `nex_ask` — AI-powered context query (recommended)
-Use for natural language questions about organizational context.
-Examples: "what's the latest on the Acme deal?", "when did I last talk to Sarah?"
+### `search_knowledge` — Broad context retrieval
+Use for broad, fuzzy, or topic-based workspace questions.
+Examples: "what's the latest on the Acme deal?", "any updates on hiring?"
 
-### `nex_remember` — Store information
+### `get_entity_brief` / `get_entity_profile` — Grounded entity context
+Use when you know which person, company, or deal you need and want the latest grounded brief.
+
+### `search_entities` — Entity lookup and disambiguation
+Use when you need to find or disambiguate a person/company by email, name, or domain before pulling a brief.
+
+### `get_tasks` — Task and action-item lookup
+Use for to-dos, open action items, and task status questions.
+
+### `save_facts` / `nex_remember` — Store information
 Save notes, observations, meeting summaries, or any text to the knowledge base.
 Examples: "remember that John prefers email over Slack", store meeting notes
 
-### `nex_search` — Fuzzy record lookup
-Search CRM records (people, companies, deals) by name or keyword.
-Use when looking up a specific named entity rather than asking a question.
+### `external_search` — Web enrichment
+Use when internal context is insufficient and you need grounded external information about a company, person, or market.
+
+### `query_context` / `nex_ask` — Open-ended fallback
+Use only when the task does not map cleanly to a direct primitive above and you need a synthesized answer to an open-ended context question.
 
 ### `nex_list_integrations` — Check connected data sources
 Shows which integrations (Gmail, Slack, Calendar, CRM) are connected and active.
@@ -38,18 +51,28 @@ Nex automatically surfaces relevant context from the user's knowledge graph on e
 - **Entity insights** — facts about people, companies, and deals mentioned or relevant to the task
 - **Knowledge insights** — patterns, lessons learned, and domain knowledge from past work
 - **Playbook rules** — proven approaches and best practices from the user's experience
+- **Agent skills** — executable workflows with specific tools, steps, and decision points
 
 Leverage this context to provide more informed, personalized responses. If the context mentions a relevant pattern or past decision, incorporate it naturally without explicitly referencing the context block.
 
 ## When to Use Nex Tools Directly
 
-Use `nex_ask` proactively when:
+Use the direct tools proactively when:
 - The user mentions a person, company, or project — look up their context
 - The task involves a domain the knowledge graph may have insights on
 - You need organizational context to make a better recommendation
 
-Use `nex_remember` when:
+Suggested selection:
+- `search_entities` to resolve the right record
+- `get_entity_brief` when the target entity is known
+- `search_knowledge` for broad topic or timeline questions
+- `get_tasks` for to-dos and action items
+- `save_facts` when the user shares durable new information
+- `external_search` only when internal context is insufficient
+- `query_context` / `nex_ask` only as a fallback for open-ended synthesis
+
+Use `save_facts` / `nex_remember` when:
 - The user shares a decision, preference, or important fact worth persisting
 - A conversation reveals new knowledge that future sessions should have access to
 
-Always try `nex_ask` first for general queries. Use `nex_search` when you need to find a specific record by name.
+# --- End Nex ---

--- a/platform-rules/windsurf-rules.md
+++ b/platform-rules/windsurf-rules.md
@@ -1,20 +1,33 @@
+# --- Nex Context & Memory ---
+
 # Nex — Organizational Context & Memory
 
-Nex provides your AI agent with real-time organizational knowledge — contacts, deals, meetings, emails, notes, insights, patterns, and playbooks — via MCP tools. Context is proactively injected into your conversation, so relevant knowledge surfaces automatically even when you don't ask for it.
+Nex provides your AI agent with real-time organizational knowledge — contacts, deals, meetings, emails, notes, insights, patterns, playbooks, and executable skills — via MCP tools. Context is proactively injected into your conversation, so relevant knowledge surfaces automatically even when you don't ask for it.
 
 ## MCP Tools Available
 
-### `nex_ask` — AI-powered context query (recommended)
-Use for natural language questions about organizational context.
-Examples: "what's the latest on the Acme deal?", "when did I last talk to Sarah?"
+### `search_knowledge` — Broad context retrieval
+Use for broad, fuzzy, or topic-based workspace questions.
+Examples: "what's the latest on the Acme deal?", "any updates on hiring?"
 
-### `nex_remember` — Store information
+### `get_entity_brief` / `get_entity_profile` — Grounded entity context
+Use when you know which person, company, or deal you need and want the latest grounded brief.
+
+### `search_entities` — Entity lookup and disambiguation
+Use when you need to find or disambiguate a person/company by email, name, or domain before pulling a brief.
+
+### `get_tasks` — Task and action-item lookup
+Use for to-dos, open action items, and task status questions.
+
+### `save_facts` / `nex_remember` — Store information
 Save notes, observations, meeting summaries, or any text to the knowledge base.
 Examples: "remember that John prefers email over Slack", store meeting notes
 
-### `nex_search` — Fuzzy record lookup
-Search CRM records (people, companies, deals) by name or keyword.
-Use when looking up a specific named entity rather than asking a question.
+### `external_search` — Web enrichment
+Use when internal context is insufficient and you need grounded external information about a company, person, or market.
+
+### `query_context` / `nex_ask` — Open-ended fallback
+Use only when the task does not map cleanly to a direct primitive above and you need a synthesized answer to an open-ended context question.
 
 ### `nex_list_integrations` — Check connected data sources
 Shows which integrations (Gmail, Slack, Calendar, CRM) are connected and active.
@@ -38,18 +51,28 @@ Nex automatically surfaces relevant context from the user's knowledge graph on e
 - **Entity insights** — facts about people, companies, and deals mentioned or relevant to the task
 - **Knowledge insights** — patterns, lessons learned, and domain knowledge from past work
 - **Playbook rules** — proven approaches and best practices from the user's experience
+- **Agent skills** — executable workflows with specific tools, steps, and decision points
 
 Leverage this context to provide more informed, personalized responses. If the context mentions a relevant pattern or past decision, incorporate it naturally without explicitly referencing the context block.
 
 ## When to Use Nex Tools Directly
 
-Use `nex_ask` proactively when:
+Use the direct tools proactively when:
 - The user mentions a person, company, or project — look up their context
 - The task involves a domain the knowledge graph may have insights on
 - You need organizational context to make a better recommendation
 
-Use `nex_remember` when:
+Suggested selection:
+- `search_entities` to resolve the right record
+- `get_entity_brief` when the target entity is known
+- `search_knowledge` for broad topic or timeline questions
+- `get_tasks` for to-dos and action items
+- `save_facts` when the user shares durable new information
+- `external_search` only when internal context is insufficient
+- `query_context` / `nex_ask` only as a fallback for open-ended synthesis
+
+Use `save_facts` / `nex_remember` when:
 - The user shares a decision, preference, or important fact worth persisting
 - A conversation reveals new knowledge that future sessions should have access to
 
-Always try `nex_ask` first for general queries. Use `nex_search` when you need to find a specific record by name.
+# --- End Nex ---

--- a/platform-rules/zed-rules.md
+++ b/platform-rules/zed-rules.md
@@ -1,20 +1,33 @@
+# --- Nex Context & Memory ---
+
 # Nex — Organizational Context & Memory
 
-Nex provides your AI agent with real-time organizational knowledge — contacts, deals, meetings, emails, notes, insights, patterns, and playbooks — via MCP tools. Context is proactively injected into your conversation, so relevant knowledge surfaces automatically even when you don't ask for it.
+Nex provides your AI agent with real-time organizational knowledge — contacts, deals, meetings, emails, notes, insights, patterns, playbooks, and executable skills — via MCP tools. Context is proactively injected into your conversation, so relevant knowledge surfaces automatically even when you don't ask for it.
 
 ## MCP Tools Available
 
-### `nex_ask` — AI-powered context query (recommended)
-Use for natural language questions about organizational context.
-Examples: "what's the latest on the Acme deal?", "when did I last talk to Sarah?"
+### `search_knowledge` — Broad context retrieval
+Use for broad, fuzzy, or topic-based workspace questions.
+Examples: "what's the latest on the Acme deal?", "any updates on hiring?"
 
-### `nex_remember` — Store information
+### `get_entity_brief` / `get_entity_profile` — Grounded entity context
+Use when you know which person, company, or deal you need and want the latest grounded brief.
+
+### `search_entities` — Entity lookup and disambiguation
+Use when you need to find or disambiguate a person/company by email, name, or domain before pulling a brief.
+
+### `get_tasks` — Task and action-item lookup
+Use for to-dos, open action items, and task status questions.
+
+### `save_facts` / `nex_remember` — Store information
 Save notes, observations, meeting summaries, or any text to the knowledge base.
 Examples: "remember that John prefers email over Slack", store meeting notes
 
-### `nex_search` — Fuzzy record lookup
-Search CRM records (people, companies, deals) by name or keyword.
-Use when looking up a specific named entity rather than asking a question.
+### `external_search` — Web enrichment
+Use when internal context is insufficient and you need grounded external information about a company, person, or market.
+
+### `query_context` / `nex_ask` — Open-ended fallback
+Use only when the task does not map cleanly to a direct primitive above and you need a synthesized answer to an open-ended context question.
 
 ### `nex_list_integrations` — Check connected data sources
 Shows which integrations (Gmail, Slack, Calendar, CRM) are connected and active.
@@ -38,18 +51,28 @@ Nex automatically surfaces relevant context from the user's knowledge graph on e
 - **Entity insights** — facts about people, companies, and deals mentioned or relevant to the task
 - **Knowledge insights** — patterns, lessons learned, and domain knowledge from past work
 - **Playbook rules** — proven approaches and best practices from the user's experience
+- **Agent skills** — executable workflows with specific tools, steps, and decision points
 
 Leverage this context to provide more informed, personalized responses. If the context mentions a relevant pattern or past decision, incorporate it naturally without explicitly referencing the context block.
 
 ## When to Use Nex Tools Directly
 
-Use `nex_ask` proactively when:
+Use the direct tools proactively when:
 - The user mentions a person, company, or project — look up their context
 - The task involves a domain the knowledge graph may have insights on
 - You need organizational context to make a better recommendation
 
-Use `nex_remember` when:
+Suggested selection:
+- `search_entities` to resolve the right record
+- `get_entity_brief` when the target entity is known
+- `search_knowledge` for broad topic or timeline questions
+- `get_tasks` for to-dos and action items
+- `save_facts` when the user shares durable new information
+- `external_search` only when internal context is insufficient
+- `query_context` / `nex_ask` only as a fallback for open-ended synthesis
+
+Use `save_facts` / `nex_remember` when:
 - The user shares a decision, preference, or important fact worth persisting
 - A conversation reveals new knowledge that future sessions should have access to
 
-Always try `nex_ask` first for general queries. Use `nex_search` when you need to find a specific record by name.
+# --- End Nex ---


### PR DESCRIPTION
Part of nex-crm/core#848.

## What changed
- updates platform rule files to steer agents toward once-per-turn preflight followed by direct tools

## Why
- the platform prompts need to reflect the new preferred execution path so the rollout is actually adopted

## Validation
- `npm test`
