### PR TITLE
feat(agents): add /nex:agents sync and review docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,36 @@ Read a skill by slug from `.nex/skills/` first, with API fallback if it is not c
 ### `sync_skills` — Sync skills locally
 Download all skills to `.nex/skills/` as markdown files. Local agents read these directly without API calls.
 
+### `list_agents` — List agents
+List workspace agents and their current status, version, and domain.
+
+### `get_agent_by_slug` — View an agent
+Fetch an agent definition by slug. Use this before activating, updating, or running a specific agent.
+
+### `compile_agents` — Refresh compiled agents
+Re-run agent compilation from the latest workspace skills. Existing compiled agents are updated in place when their generated definition changes.
+
+### `generate_agent` — Create an agent from a prompt
+Create a new agent from a natural-language request, built-in template, or explicit spec.
+
+### `update_agent` — Improve an agent
+Patch an existing agent definition, then refresh the local Claude agent file if it is cached locally.
+
+### `download_agent` — Render an agent for a platform
+Generate the platform-specific agent artifact without changing the agent's status. Use `claude-code` for local markdown sync.
+
+### `read_agent` — Read a synced agent locally
+Read an agent by slug from `.claude/agents/` first, with API fallback if it is not cached locally.
+
+### `sync_agents` — Sync agents locally
+Download all non-archived agents to `.claude/agents/` as markdown files so local Claude sessions stay aligned with the backend definitions.
+
+### `activate_agent` — Activate an agent
+Mark an agent active. When Claude output is requested, also refresh the local `.claude/agents/` file.
+
+### `run_agent` — Trigger an agent run
+Create a new run for an agent and inspect the resulting findings with `get_agent_runs` and `get_agent_findings`.
+
 ## Proactive Context
 
 Nex automatically surfaces relevant context from the user's knowledge graph on every prompt — not just questions. When you see a `<nex-context>` block, use it naturally to inform your response:

--- a/claude-code-plugin/commands/nex:agents.md
+++ b/claude-code-plugin/commands/nex:agents.md
@@ -1,0 +1,66 @@
+---
+description: List, view, compile, generate, update, sync, activate, run, and review agents
+---
+Handle agent requests based on $ARGUMENTS:
+
+**No arguments → list all agents:**
+Use the `list_agents` MCP tool. Display results as a table:
+| Name | Slug | Domain | Status | Version | Updated |
+
+**Agent slug → show agent details:**
+Use `get_agent_by_slug` with the slug. Display the full agent details including name, domain, goal, spec, status, and version.
+
+**"sync" → sync all agents to local .claude/agents/ folder:**
+Use `sync_agents`. Downloads all non-archived agents as Claude Code markdown files. Structure:
+```text
+.claude/agents/
+  crm-hygiene.md
+  sales-pipeline-strategist.md
+  customer-retention.md
+```
+
+**"read <slug>" → read a synced agent locally:**
+Use `read_agent` with the slug. Reads locally first (zero API cost), falls back to the API-rendered Claude markdown.
+
+**"generate <description>" → create a new agent from a prompt:**
+The user describes what they want the agent to do. You should:
+1. Read workspace context using `query_context` and any relevant record tools
+2. Determine whether this should be a prompt-generated agent, a built-in template, or a manual spec
+3. Call `generate_agent`
+4. Show the created agent to the user
+
+Example: `/nex:agents generate A customer retention agent that watches stale renewal deals and drafts recovery actions`
+
+**"compile" → compile or refresh compiled agents:**
+Use `compile_agents`. This updates existing compiled agents in place when their generated definition changes.
+
+**"update <slug>" → improve an existing agent:**
+First use `get_agent_by_slug` with the slug to find the agent ID and current definition. Then call `update_agent` with any changed `name`, `domain`, `goal`, or `spec`. Show the updated agent to the user.
+
+**"activate <slug>" → activate an agent:**
+1. Find the agent with `get_agent_by_slug`
+2. Call `activate_agent` with the agent ID
+3. Confirm activation and note that the Claude markdown was refreshed locally when Claude output was requested
+
+**"run <slug>" → trigger an agent run:**
+1. Find the agent with `get_agent_by_slug`
+2. Call `run_agent` with the agent ID
+3. Display the run ID and initial status
+4. Poll `get_agent_runs` until the run completes
+5. When complete, show the summary and findings count
+
+**"runs <slug>" → show run history:**
+1. Find the agent with `get_agent_by_slug`
+2. Call `get_agent_runs` with the agent ID
+3. Display results as a table:
+| Run ID | Status | Trigger | Started | Completed | Findings |
+
+**"findings <slug>" → show pending findings for review:**
+1. Find the agent with `get_agent_by_slug`
+2. Call `get_agent_findings` with `status=pending`
+3. Display each finding with title, severity, confidence, description, evidence, and recommended action
+4. For each finding, ask the user: **Approve** or **Reject**?
+5. Call `approve_finding` or `reject_finding` based on the user's choice
+
+**"findings <slug> all" → show all findings:**
+Same as above but without the pending-only filter. Do not prompt for approve/reject on already-finalized findings.

--- a/plugin-commands/nex:agents.md
+++ b/plugin-commands/nex:agents.md
@@ -1,0 +1,66 @@
+---
+description: List, view, compile, generate, update, sync, activate, run, and review agents
+---
+Handle agent requests based on $ARGUMENTS:
+
+**No arguments → list all agents:**
+Use the `list_agents` MCP tool. Display results as a table:
+| Name | Slug | Domain | Status | Version | Updated |
+
+**Agent slug → show agent details:**
+Use `get_agent_by_slug` with the slug. Display the full agent details including name, domain, goal, spec, status, and version.
+
+**"sync" → sync all agents to local .claude/agents/ folder:**
+Use `sync_agents`. Downloads all non-archived agents as Claude Code markdown files. Structure:
+```text
+.claude/agents/
+  crm-hygiene.md
+  sales-pipeline-strategist.md
+  customer-retention.md
+```
+
+**"read <slug>" → read a synced agent locally:**
+Use `read_agent` with the slug. Reads locally first (zero API cost), falls back to the API-rendered Claude markdown.
+
+**"generate <description>" → create a new agent from a prompt:**
+The user describes what they want the agent to do. You should:
+1. Read workspace context using `query_context` and any relevant record tools
+2. Determine whether this should be a prompt-generated agent, a built-in template, or a manual spec
+3. Call `generate_agent`
+4. Show the created agent to the user
+
+Example: `/nex:agents generate A customer retention agent that watches stale renewal deals and drafts recovery actions`
+
+**"compile" → compile or refresh compiled agents:**
+Use `compile_agents`. This updates existing compiled agents in place when their generated definition changes.
+
+**"update <slug>" → improve an existing agent:**
+First use `get_agent_by_slug` with the slug to find the agent ID and current definition. Then call `update_agent` with any changed `name`, `domain`, `goal`, or `spec`. Show the updated agent to the user.
+
+**"activate <slug>" → activate an agent:**
+1. Find the agent with `get_agent_by_slug`
+2. Call `activate_agent` with the agent ID
+3. Confirm activation and note that the Claude markdown was refreshed locally when Claude output was requested
+
+**"run <slug>" → trigger an agent run:**
+1. Find the agent with `get_agent_by_slug`
+2. Call `run_agent` with the agent ID
+3. Display the run ID and initial status
+4. Poll `get_agent_runs` until the run completes
+5. When complete, show the summary and findings count
+
+**"runs <slug>" → show run history:**
+1. Find the agent with `get_agent_by_slug`
+2. Call `get_agent_runs` with the agent ID
+3. Display results as a table:
+| Run ID | Status | Trigger | Started | Completed | Findings |
+
+**"findings <slug>" → show pending findings for review:**
+1. Find the agent with `get_agent_by_slug`
+2. Call `get_agent_findings` with `status=pending`
+3. Display each finding with title, severity, confidence, description, evidence, and recommended action
+4. For each finding, ask the user: **Approve** or **Reject**?
+5. Call `approve_finding` or `reject_finding` based on the user's choice
+
+**"findings <slug> all" → show all findings:**
+Same as above but without the pending-only filter. Do not prompt for approve/reject on already-finalized findings.


### PR DESCRIPTION
## Summary

Companion to nex-crm/core#876 for issue nex-crm/core#857.

Adds `/nex:agents` command docs and agent-tool guidance so the local sync workflow is discoverable alongside the existing skill command flow.

## What Changed

- add `plugin-commands/nex:agents.md`
- add `claude-code-plugin/commands/nex:agents.md`
- document the new agent MCP tools in `AGENTS.md`

## Validation

- `npm test`

Refs nex-crm/core#857