### PR TITLE
parity(07): platform rules secondary

### DIFF
--- a/docs/cli-parity-pr-seeds/07-platform-rules-secondary.md
+++ b/docs/cli-parity-pr-seeds/07-platform-rules-secondary.md
@@ -1,0 +1,13 @@
+# Parity PR 07 Seed
+
+Canonical issue: #87
+Planning PR: #88
+Branch: `feat/nex-as-a-skill-parity-07-platform-rules-secondary`
+
+This is a scaffold draft PR cut from `main`. The placeholder file in this branch exists only to reserve the branch name and PR number.
+
+Intended scope:
+- update the remaining editor and agent rule bundles
+
+Plan doc:
+- `docs/cli-parity-prs/07-platform-rules-secondary.md` in PR #88


### PR DESCRIPTION
## Summary
- branch: `feat/nex-as-a-skill-parity-07-platform-rules-secondary`
- review target: <450 changed lines
- current branch content: seed placeholder commit only; implementation will replace it on this same branch

## Product Outcome
Bring the remaining editor and agent rule bundles to the same standard without overloading PR 06.

## Technical Scope
- `platform-rules/aider-conventions.md`
- `platform-rules/cline-rules.md`
- `platform-rules/continue-rules.md`
- `platform-rules/zed-rules.md`
- `platform-rules/opencode-agents.md`
- `platform-rules/kilocode-rules.md`

## Current Branch State
- This draft branch currently contains only a seed placeholder commit to reserve the PR number and dependency position.

## What This PR Is Intended To Ship
- secondary rule bundle parity
- platform-specific wording instead of generic filler
- shared conceptual model carried over from PRs 04 and 05

## What Is Intentionally Not Included
- core editor bundles
- platform plugin assets

## Dependencies
Upstream PRs:
- #92 parity(04): plugin commands memory
- #93 parity(05): plugin commands ops

Downstream PRs:
- #97 parity(09): platform plugins workflows

## Validation
- secondary rule bundles are internally consistent and match the current package surface

Refs #87 and #88