### PR TITLE
ci: auto-create version pin PR when nex-cli releases

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -193,14 +193,16 @@ jobs:
             dist/nex-cli-* dist/checksums.txt
 
       - name: Create version pin PR
-        if: steps.check.outputs.exists == 'false' && success()
+        if: success()
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
 
           # Update NEX_CLI_VERSION in src/nex.ts
+          grep -qE '^const NEX_CLI_VERSION = ".*";' src/nex.ts || { echo "Could not locate NEX_CLI_VERSION declaration"; exit 1; }
           sed -i "s|^const NEX_CLI_VERSION = \".*\";.*|const NEX_CLI_VERSION = \"${VERSION}\";|" src/nex.ts
+          grep -q "^const NEX_CLI_VERSION = \"${VERSION}\";" src/nex.ts || { echo "Failed to pin NEX_CLI_VERSION to ${VERSION}"; exit 1; }
 
           if git diff --quiet src/nex.ts; then
             echo "Already pinned to ${VERSION}, skipping PR"

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   release:
@@ -190,6 +191,42 @@ jobs:
           curl -fsSL https://raw.githubusercontent.com/nex-crm/nex-as-a-skill/main/install.sh | sh
           \`\`\`" \
             dist/nex-cli-* dist/checksums.txt
+
+      - name: Create version pin PR
+        if: steps.check.outputs.exists == 'false' && success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # Update NEX_CLI_VERSION in src/nex.ts
+          sed -i "s|^const NEX_CLI_VERSION = \".*\";.*|const NEX_CLI_VERSION = \"${VERSION}\";|" src/nex.ts
+
+          if git diff --quiet src/nex.ts; then
+            echo "Already pinned to ${VERSION}, skipping PR"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          BRANCH="chore/pin-nex-cli"
+          git checkout -b "$BRANCH"
+          git add src/nex.ts
+          git commit -m "chore: pin nex-cli to ${VERSION}"
+          git push origin "$BRANCH" --force
+
+          existing=$(gh pr list --head "$BRANCH" --json number -q '.[0].number // empty' 2>/dev/null || true)
+          if [ -z "$existing" ]; then
+            gh pr create \
+              --title "chore: pin nex-cli to ${VERSION}" \
+              --body "Auto-generated from nex-cli release ${VERSION}. Merge to update the pinned CLI version."
+          else
+            gh pr edit "$existing" \
+              --title "chore: pin nex-cli to ${VERSION}" \
+              --body "Auto-generated from nex-cli release ${VERSION}. Merge to update the pinned CLI version."
+            echo "Updated existing PR #${existing}"
+          fi
 
       - name: Skip if already released
         if: steps.check.outputs.exists == 'true'

--- a/src/nex.ts
+++ b/src/nex.ts
@@ -7,7 +7,7 @@ import { arch, homedir, platform } from "node:os";
 import { basename, join } from "node:path";
 
 const VERSION = "0.2.0";
-const NEX_CLI_VERSION = "latest"; // TODO: pin to specific version once nex-cli has releases
+const NEX_CLI_VERSION = "v0.1.3";
 
 const args = process.argv.slice(2);
 


### PR DESCRIPTION
## Summary
- Adds a "Create version pin PR" step to `release-binary.yml` that runs after mirroring a nex-cli release
- Pins `NEX_CLI_VERSION` in `src/nex.ts` to the released version (removes stale `// TODO` — nex-cli has had releases since v0.1.0)
- Uses a single `chore/pin-nex-cli` branch, force-pushed each time so only one PR exists at a time
- If a PR already exists, updates its title/body to reflect the new version

## How it works
1. nex-cli releases `v0.1.4` → dispatches to nex-as-a-skill
2. `release-binary.yml` mirrors binaries (existing) → creates/updates PR `chore: pin nex-cli to v0.1.4` (new)
3. Merging that PR updates the compiled wrapper binary's auto-install target

## Test plan
- [ ] Merge this PR, then trigger `release-binary.yml` manually with `workflow_dispatch` (version: `v0.1.3`) to verify the PR step runs and creates a `chore/pin-nex-cli` PR
- [ ] Verify the created PR correctly updates `NEX_CLI_VERSION` in `src/nex.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CLI installation now downloads from a specific pinned release version instead of the latest stream.
  * Release workflow now automatically creates or updates a version-pin pull request when a new release is published.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->