### PR TITLE
ci: add sync-release workflow for nex-cli releases

### DIFF
--- a/.github/workflows/sync-release.yml
+++ b/.github/workflows/sync-release.yml
@@ -1,0 +1,181 @@
+name: Sync nex-cli Release
+
+on:
+  repository_dispatch:
+    types: [nex-cli-release]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version tag (e.g. v0.1.3). Defaults to latest nex-cli release."
+        required: false
+
+concurrency:
+  group: sync-release
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  mirror-release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      created: ${{ steps.create.outputs.created }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve version
+        id: version
+        env:
+          GH_TOKEN: ${{ secrets.CLI_REPO_TOKEN }}
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            VERSION="${{ inputs.version }}"
+          elif [ -n "${{ github.event.client_payload.version }}" ]; then
+            VERSION="${{ github.event.client_payload.version }}"
+          else
+            VERSION=$(gh release view --repo nex-crm/nex-cli --json tagName -q .tagName)
+          fi
+          # Normalize: ensure v prefix
+          VERSION="${VERSION#v}"
+          VERSION="v${VERSION}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "### Sync Release" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Target version:** \`$VERSION\`" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Check if release already exists
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Release already exists, skipping." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download binaries from nex-cli
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.CLI_REPO_TOKEN }}
+        run: |
+          mkdir -p dist
+          VERSION="${{ steps.version.outputs.version }}"
+          for target in darwin-arm64 darwin-x64 linux-arm64 linux-x64; do
+            echo "Downloading nex-cli-${target}..."
+            gh release download "$VERSION" \
+              --repo nex-crm/nex-cli \
+              --pattern "nex-cli-${target}" \
+              --dir dist
+          done
+          ls -lh dist/
+
+      - name: Verify binary
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          BINARY="dist/nex-cli-linux-x64"
+          chmod +x "$BINARY"
+          VERSION_OUT=$("$BINARY" --version)
+          echo "Binary reports version: $VERSION_OUT"
+          echo "$VERSION_OUT" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$' \
+            || { echo "FAIL: version output is not semver"; exit 1; }
+
+      - name: Generate checksums
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          cd dist
+          sha256sum nex-cli-* > checksums.txt
+          cat checksums.txt
+
+      # Use CLI_REPO_TOKEN (PAT) so the release:published event triggers
+      # homebrew-update.yml. GITHUB_TOKEN would suppress downstream workflows.
+      - name: Create release
+        id: create
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.CLI_REPO_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          gh release create "$VERSION" \
+            --repo nex-crm/nex-as-a-skill \
+            --title "$VERSION" \
+            --notes "nex-cli ${VERSION} binaries.
+
+          Install:
+          \`\`\`
+          curl -fsSL https://raw.githubusercontent.com/nex-crm/nex-cli/main/install.sh | sh
+          \`\`\`
+
+          Or via Homebrew:
+          \`\`\`
+          brew install nex-crm/tap/nex
+          \`\`\`" \
+            dist/nex-cli-* dist/checksums.txt
+          echo "created=true" >> "$GITHUB_OUTPUT"
+          echo "**Release created**" >> "$GITHUB_STEP_SUMMARY"
+
+  publish-npm:
+    needs: mirror-release
+    if: needs.mirror-release.outputs.created == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ secrets.CLI_REPO_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - name: Validate shims
+        run: node --check bin/nex.js && node --check bin/nex-mcp.js
+
+      - name: Bump version and publish
+        id: npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          PUBLISHED=$(npm view @nex-ai/nex version 2>/dev/null || echo "0.0.0")
+          LOCAL=$(node -e "console.log(require('./package.json').version)")
+
+          NEEDS_BUMP=$(node -e "
+            const [lM,lm,lp] = '$LOCAL'.split('.').map(Number);
+            const [pM,pm,pp] = '$PUBLISHED'.split('.').map(Number);
+            const localNum = lM*1000000 + lm*1000 + lp;
+            const pubNum = pM*1000000 + pm*1000 + pp;
+            console.log(localNum <= pubNum ? 'true' : 'false');
+          ")
+
+          if [ "$NEEDS_BUMP" = "true" ]; then
+            npm version "$PUBLISHED" --no-git-tag-version --allow-same-version
+            npm version patch --no-git-tag-version
+          fi
+
+          NEW_VERSION=$(node -e "console.log(require('./package.json').version)")
+          echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+
+          if npm view "@nex-ai/nex@$NEW_VERSION" version 2>/dev/null; then
+            echo "Version $NEW_VERSION already on npm, skipping."
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          else
+            npm publish --access public
+            echo "published=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit version bump
+        if: steps.npm.outputs.published == 'true'
+        env:
+          NPM_VERSION: ${{ steps.npm.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add package.json
+          git diff --staged --quiet && exit 0
+          git commit -m "chore: bump to v${NPM_VERSION} [skip ci]"
+          git push

--- a/.github/workflows/sync-release.yml
+++ b/.github/workflows/sync-release.yml
@@ -106,7 +106,7 @@ jobs:
 
           Install:
           \`\`\`
-          curl -fsSL https://raw.githubusercontent.com/nex-crm/nex-cli/main/install.sh | sh
+          curl -fsSL https://raw.githubusercontent.com/nex-crm/nex-as-a-skill/main/install.sh | sh
           \`\`\`
 
           Or via Homebrew:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Talk to the team, share feedback, and connect with other developers building AI 
 
 ```bash
 # Option A: install the nex-cli binary (no Node.js required)
-curl -fsSL https://raw.githubusercontent.com/nex-crm/nex-cli/main/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/nex-crm/nex-as-a-skill/main/install.sh | sh
 
 # Option B: install via npm (or bun/pnpm) — thin shim that delegates to nex-cli
 npm install -g @nex-ai/nex
@@ -249,7 +249,7 @@ cd openclaw-plugin && bun install && bun run build && bun test
 
 The `nex-cli` binary is built and released from [nex-crm/nex-cli](https://github.com/nex-crm/nex-cli). Install it with:
 ```bash
-curl -fsSL https://raw.githubusercontent.com/nex-crm/nex-cli/main/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/nex-crm/nex-as-a-skill/main/install.sh | sh
 ```
 
 ### CI/CD

--- a/bin/nex-mcp.js
+++ b/bin/nex-mcp.js
@@ -43,7 +43,7 @@ console.error(`
   nex-cli binary not found.
 
   Install it with:
-    curl -fsSL https://raw.githubusercontent.com/nex-crm/nex-cli/main/install.sh | sh
+    curl -fsSL https://raw.githubusercontent.com/nex-crm/nex-as-a-skill/main/install.sh | sh
 
   Then run your command again.
 `);

--- a/bin/nex.js
+++ b/bin/nex.js
@@ -3,7 +3,7 @@
 /**
  * Thin shim for @nex-ai/nex — delegates all commands to the nex-cli binary.
  *
- * Install the binary: curl -fsSL https://raw.githubusercontent.com/nex-crm/nex-cli/main/install.sh | sh
+ * Install the binary: curl -fsSL https://raw.githubusercontent.com/nex-crm/nex-as-a-skill/main/install.sh | sh
  */
 
 import { execFileSync } from "node:child_process";
@@ -46,7 +46,7 @@ console.error(`
   nex-cli binary not found.
 
   Install it with:
-    curl -fsSL https://raw.githubusercontent.com/nex-crm/nex-cli/main/install.sh | sh
+    curl -fsSL https://raw.githubusercontent.com/nex-crm/nex-as-a-skill/main/install.sh | sh
 
   Then run your command again.
 `);

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,102 @@
+#!/bin/sh
+set -e
+
+REPO="nex-crm/nex-as-a-skill"
+INSTALL_DIR="/usr/local/bin"
+FALLBACK_DIR="${HOME}/.local/bin"
+
+# Detect OS and architecture
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+case "$ARCH" in
+    x86_64)  ARCH="x64" ;;
+    aarch64) ARCH="arm64" ;;
+    arm64)   ARCH="arm64" ;;
+    *)       echo "Unsupported architecture: $ARCH"; exit 1 ;;
+esac
+
+case "$OS" in
+    darwin|linux) ;;
+    *)            echo "Unsupported OS: $OS"; exit 1 ;;
+esac
+
+BINARY="nex-cli-${OS}-${ARCH}"
+BASE_URL="https://github.com/${REPO}/releases/latest/download"
+echo "Downloading ${BINARY}..."
+
+TMP=$(mktemp)
+trap 'rm -f "$TMP" "$TMP.checksums"' EXIT
+
+curl -fsSL "${BASE_URL}/${BINARY}" -o "$TMP" || {
+    echo ""
+    echo "Download failed. No release found at:"
+    echo "  ${BASE_URL}/${BINARY}"
+    echo ""
+    echo "Check https://github.com/${REPO}/releases for available versions."
+    exit 1
+}
+
+# Verify checksum
+curl -fsSL "${BASE_URL}/checksums.txt" -o "$TMP.checksums" 2>/dev/null || true
+if [ -f "$TMP.checksums" ] && [ -s "$TMP.checksums" ]; then
+    EXPECTED=$(grep "$BINARY" "$TMP.checksums" | awk '{print $1}')
+    if [ -n "$EXPECTED" ]; then
+        if command -v sha256sum > /dev/null 2>&1; then
+            ACTUAL=$(sha256sum "$TMP" | awk '{print $1}')
+        elif command -v shasum > /dev/null 2>&1; then
+            ACTUAL=$(shasum -a 256 "$TMP" | awk '{print $1}')
+        else
+            ACTUAL="$EXPECTED"
+        fi
+        if [ "$ACTUAL" != "$EXPECTED" ]; then
+            echo "Checksum mismatch! Expected ${EXPECTED}, got ${ACTUAL}"
+            exit 1
+        fi
+        echo "Checksum verified."
+    fi
+fi
+
+chmod +x "$TMP"
+
+# Verify binary runs
+VERSION_OUT=$("$TMP" --version 2>/dev/null) || {
+    echo "Downloaded binary failed to execute. This may be a platform mismatch."
+    echo "Expected: ${OS}-${ARCH}"
+    exit 1
+}
+echo "Version: ${VERSION_OUT}"
+
+# Install binary
+do_install() {
+    dir="$1"
+    use_sudo="$2"
+    cmd=""
+    [ "$use_sudo" = "true" ] && cmd="sudo"
+    $cmd mkdir -p "$dir"
+    $cmd mv "$TMP" "${dir}/nex-cli"
+    TARGET_DIR="$dir"
+}
+
+if [ -w "$INSTALL_DIR" ]; then
+    do_install "$INSTALL_DIR" false
+elif [ "$(id -u)" = "0" ]; then
+    do_install "$INSTALL_DIR" false
+elif command -v sudo > /dev/null 2>&1; then
+    echo "Installing to ${INSTALL_DIR} (requires sudo)..."
+    do_install "$INSTALL_DIR" true
+else
+    do_install "$FALLBACK_DIR" false
+fi
+
+echo "nex-cli installed to ${TARGET_DIR}/nex-cli"
+
+# Check PATH
+case ":$PATH:" in
+    *":${TARGET_DIR}:"*) ;;
+    *) echo ""; echo "Add to your PATH:  export PATH=\"${TARGET_DIR}:\$PATH\"" ;;
+esac
+
+echo ""
+echo "Get started:"
+echo "  nex-cli --cmd \"setup you@company.com\""


### PR DESCRIPTION
## Summary
- Adds `sync-release.yml` that catches `repository_dispatch: nex-cli-release` from nex-cli
- **Mirrors binaries** into a public GitHub release on nex-as-a-skill (enables self-update + public distribution)
- **Triggers Homebrew** formula update via `release:published` event (uses PAT to avoid GITHUB_TOKEN event suppression)
- **Publishes to npm** with patch version bump + `[skip ci]` commit to prevent double-publish

### End-to-end flow
```
nex-cli release v0.1.4
  → dispatches nex-cli-release
  → sync-release.yml
      → mirror-release: download binaries, create public release
          → homebrew-update.yml fires automatically
      → publish-npm: bump + publish @nex-ai/nex
```

Replaces the deleted `release-binary.yml` (removed by #86) with a cleaner design that doesn't build/test binaries (that's nex-cli's job).

## Test plan
- [ ] Merge, then trigger manually: Actions → "Sync nex-cli Release" → Run workflow (version: `v0.1.3`)
- [ ] Verify release created on nex-as-a-skill with 4 binaries + checksums
- [ ] Verify homebrew-update workflow triggered
- [ ] Verify npm package published

🤖 Generated with [Claude Code](https://claude.com/claude-code)