### PR TITLE
fix(ci): use github.token for release, inline Homebrew step

### DIFF
--- a/.github/workflows/sync-release.yml
+++ b/.github/workflows/sync-release.yml
@@ -90,17 +90,14 @@ jobs:
           sha256sum nex-cli-* > checksums.txt
           cat checksums.txt
 
-      # Use CLI_REPO_TOKEN (PAT) so the release:published event triggers
-      # homebrew-update.yml. GITHUB_TOKEN would suppress downstream workflows.
       - name: Create release
         id: create
         if: steps.check.outputs.exists == 'false'
         env:
-          GH_TOKEN: ${{ secrets.CLI_REPO_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           gh release create "$VERSION" \
-            --repo nex-crm/nex-as-a-skill \
             --title "$VERSION" \
             --notes "nex-cli ${VERSION} binaries.
 
@@ -116,6 +113,16 @@ jobs:
             dist/nex-cli-* dist/checksums.txt
           echo "created=true" >> "$GITHUB_OUTPUT"
           echo "**Release created**" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Update Homebrew formula
+        if: steps.create.outputs.created == 'true'
+        continue-on-error: true
+        uses: dawidd6/action-homebrew-bump-formula@v4
+        with:
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          tap: nex-crm/tap
+          formula: nex
+          tag: ${{ steps.version.outputs.version }}
 
   publish-npm:
     needs: mirror-release


### PR DESCRIPTION
## Summary
- `CLI_REPO_TOKEN` returned 403 on release creation — it lacks write access to nex-as-a-skill releases
- Switch to `github.token` (has `contents: write` from the workflow permissions block)
- Inline the Homebrew formula bump directly in `sync-release.yml` since `GITHUB_TOKEN`-created events don't trigger downstream workflows

## Test plan
- [ ] Merge, re-run "Sync nex-cli Release" workflow with `v0.1.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release automation workflow with streamlined authentication.
  * Automated Homebrew formula updates for new releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->