### PR TITLE
ci: add verify-release job to sync-release workflow

### DIFF
--- a/.github/workflows/sync-release.yml
+++ b/.github/workflows/sync-release.yml
@@ -124,6 +124,53 @@ jobs:
           formula: nex
           tag: ${{ steps.version.outputs.version }}
 
+  verify-release:
+    needs: mirror-release
+    if: needs.mirror-release.outputs.created == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Download from public URL (no auth)
+        env:
+          VERSION: ${{ needs.mirror-release.outputs.version }}
+        run: |
+          BASE_URL="https://github.com/nex-crm/nex-as-a-skill/releases/download/${VERSION}"
+          mkdir -p dist
+
+          echo "==> Downloading checksums"
+          curl -fsSL "${BASE_URL}/checksums.txt" -o dist/checksums.txt
+          cat dist/checksums.txt
+
+          echo "==> Downloading linux-x64 binary"
+          curl -fsSL "${BASE_URL}/nex-cli-linux-x64" -o dist/nex-cli
+          chmod +x dist/nex-cli
+
+      - name: Verify checksum
+        run: |
+          EXPECTED=$(grep "nex-cli-linux-x64" dist/checksums.txt | awk '{print $1}')
+          ACTUAL=$(sha256sum dist/nex-cli | awk '{print $1}')
+          if [ "$ACTUAL" != "$EXPECTED" ]; then
+            echo "FAIL: checksum mismatch — expected $EXPECTED, got $ACTUAL"
+            exit 1
+          fi
+          echo "PASS: checksum matches ($ACTUAL)"
+
+      - name: Verify binary runs
+        run: |
+          VERSION_OUT=$(dist/nex-cli --version)
+          echo "PASS: binary reports version $VERSION_OUT"
+          echo "$VERSION_OUT" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$' \
+            || { echo "FAIL: version output is not semver"; exit 1; }
+
+      - name: Verify install.sh works
+        run: |
+          curl -fsSL "https://raw.githubusercontent.com/nex-crm/nex-as-a-skill/main/install.sh" -o install.sh
+          # Run in a temp dir without sudo to test the fallback path
+          export HOME=$(mktemp -d)
+          sh install.sh
+          "$HOME/.local/bin/nex-cli" --version
+          echo "PASS: install.sh end-to-end"
+
   publish-npm:
     needs: mirror-release
     if: needs.mirror-release.outputs.created == 'true'


### PR DESCRIPTION
## Summary
Adds a `verify-release` job that runs after `mirror-release` to validate the public distribution path:
- Downloads binary via unauthenticated `curl` (simulates a public user)
- Verifies SHA256 checksum
- Verifies binary executes and reports semver
- Runs `install.sh` end-to-end (fallback install path, no sudo)

## Test plan
- [ ] Merge, then trigger "Sync nex-cli Release" manually — verify-release job should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release verification process with automated checksum validation, binary execution testing, and end-to-end installation script verification to ensure release quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->