### PR TITLE
feat: 5-phase onboarding UX for template prompts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist/
 node_modules/
+.worktrees

--- a/plugin-commands/nex:template.md
+++ b/plugin-commands/nex:template.md
@@ -1,52 +1,130 @@
 ---
-description: List available Nex agent templates or run one. Handles install, integrations, data sync, agent activation, and findings.
+description: Set up a Nex agent from a template or custom prompt. Handles discovery, install, integrations, data sync, agent activation, narrative progress, and findings report.
 ---
 
 # /nex:template
 
-Set up a Nex agent from a pre-built template.
+Set up a Nex agent with guided onboarding.
 
-## Routing
+## Behavior
 
-Handle requests based on $ARGUMENTS:
+This command has two modes depending on context:
 
-**No arguments or "list" → list available templates:**
+### Mode 1: User has a specific template in mind
+
+If $ARGUMENTS contains a template slug or "run <slug>", skip discovery and run it:
+
 ```bash
-nex-cli template list
+nex-cli template run <slug> --machine --crm <provider>
 ```
-If `nex-cli` is not installed, install it first:
+
+### Mode 2: User needs discovery (default)
+
+If no specific template requested, run the full onboarding flow:
+
+**Step 1 — Discovery**
+
+Ask these questions one at a time. Wait for each answer.
+
+1. "What does your team sell and who do you sell to?"
+2. "What CRM do you use?" (HubSpot, Salesforce, Attio)
+3. "What's the most annoying part of your GTM workflow?"
+4. "If you could have an AI teammate audit one thing overnight, what would it be?"
+
+**Step 2 — Template matching**
+
+Install nex-cli if not present:
 ```bash
 curl -fsSL https://raw.githubusercontent.com/nex-crm/nex-cli/main/install.sh | sh
 ```
 
-**Template slug or "run <slug>" → run the template:**
+List available templates:
 ```bash
-nex-cli template run <slug> --machine
+nex-cli template list --json
 ```
-Use `--machine` when running from an AI agent (returns structured JSON for input prompts).
-Use `--crm <provider>` to skip the CRM selection prompt.
-Use `--force` to start fresh (clear previous state).
+
+Match the user's answers against template descriptions. Present the best match:
+
+> "Based on what you told me, **[Template Name]** looks like a great fit. It [one-line description].
+> Want to go with this, or should I build something custom for [their specific need]?"
+
+If user picks custom → use `/nex:agents` to build a custom agent from their description.
+If user picks template → continue to Step 3.
+
+**Step 3 — Setup with narrative**
+
+Run the template:
+```bash
+nex-cli template run <slug> --machine --crm <provider>
+```
+
+The `--machine` flag returns structured JSON. Parse it and narrate in plain English:
+
+| CLI step | What to tell the user |
+|----------|----------------------|
+| `auth_check` | "Checking your Nex account..." |
+| `fetch_template` | "Loading the [name] template..." |
+| `check_existing` | "Checking if you already have this agent..." |
+| `crm_selection` | (already answered in discovery) |
+| `connect_integrations` | "Connecting to your [CRM]..." |
+| `poll_readiness` | "Syncing your data... [N] records so far, [M] insights generated..." |
+| `activate_agent` | "Activating your [name] agent..." |
+| `trigger_run` | "Running the first audit now..." |
+| `get_findings` | (present as report — see Step 4) |
+| `write_readme` | (skip narrating this) |
+
+If `--machine` returns `need_input` (exit code 2), parse the JSON, ask the user the question in your own words, then re-run with the answer as a flag.
+
+**Step 4 — Findings report**
+
+Present findings as a formatted report, not raw JSON:
+
+```markdown
+## [Agent Name] — First Run Report
+
+**Summary:** Found X issues across Y records
+
+### [Finding Type] (N found)
+| Record | Details | Recommended Action |
+|--------|---------|-------------------|
+| ...    | ...     | ...               |
+
+---
+**Want me to fix any of these?** I can [action list] with your approval.
+```
+
+Group findings by type. Show specific record names. Always end with an offer to act.
+
+**Step 5 — Schedule and next steps**
+
+After presenting findings:
+
+> "This agent runs [schedule]. Next run: [next time].
+> Check findings anytime: `nex-cli agents findings <slug>`
+> Want to set up another agent? Just tell me what you need."
 
 ## Available templates
 
-| Slug | Name | Description |
-|------|------|-------------|
-| `crm-hygiene` | CRM Hygiene Agent | Audit CRM for duplicates, missing fields, stale records |
-| `closed-lost-reengagement` | Closed-Lost Re-engagement | Find closed-lost deals worth re-engaging, draft reconnection emails |
-| `meetings` | Meetings Agent | Pre-meeting briefs, post-meeting action items, follow-up emails |
+| Slug | Name | Description | Default Schedule |
+|------|------|-------------|-----------------|
+| `crm-hygiene` | CRM Hygiene Agent | Audit CRM for duplicates, missing fields, stale records | Daily |
+| `closed-lost-reengagement` | Closed-Lost Re-engagement | Find closed-lost deals worth re-engaging | Weekly |
+| `meetings` | Meetings Agent | Pre-meeting briefs, post-meeting action items | Before each meeting |
 
-## What it does
+## Flags
 
-1. Checks authentication (creates account or logs in)
-2. Connects required integrations (CRM, email, calendar)
-3. Waits for initial data sync
-4. Activates a pre-built agent personalized to your data
-5. Runs the agent and shows findings
-6. For templates with actions (email, calendar): presents drafts for approval before sending
+| Flag | Effect |
+|------|--------|
+| `--machine` | Structured JSON output (always use from AI agents) |
+| `--crm <provider>` | Skip CRM selection prompt |
+| `--force` | Start fresh (clear previous state) |
+| `--dry-run` | Show what would happen without executing |
+| `--no-interactive` | Skip all prompts, use defaults |
 
 ## Check findings after setup
 
 ```bash
 nex-cli agents findings <slug>
 nex-cli agents runs <slug>
+nex-cli agents list
 ```

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,45 +1,118 @@
 # Nex Agent Templates
 
-Pre-built agent templates that users copy-paste into their AI agent for guided setup.
+Pre-built agent templates that users copy-paste into their AI agent for guided setup. Templates are the on-ramp, not the product. The product is: describe what you want, Nex builds the agent.
 
 ## How it works
 
 1. User copies a prompt from the Nex website
 2. Pastes it into any AI agent (Claude Code, ChatGPT, Cursor, etc.)
-3. AI agent installs `nex-cli` and runs the template
-4. CLI orchestrates everything: register → connect CRM → sync data → run agent → show findings
+3. AI agent asks a few questions to understand the business
+4. Discovers available templates via `nex-cli template list`
+5. Offers: use a matching template (fast) or build a custom agent from scratch
+6. Runs the template, narrates progress in real-time, presents findings as a report
+7. Shows the recurring schedule so the user knows their agent is working for them
+
+## Copy-Paste Prompt (Short)
+
+For website hero, Twitter, docs sidebar:
+
+---
+
+**Set up an AI agent for your GTM team with Nex.** Paste this into Claude Code, Cursor, or ChatGPT:
+
+> I want to set up AI agents for my business using Nex. Start by asking me a few questions about my team, then show me what agents are available and help me get one running.
+
+---
+
+## Copy-Paste Prompt (Full)
+
+For landing pages, blog posts, onboarding flows. Paste this entire block into any AI agent:
+
+---
+
+~~~
+I want to set up AI agents for my business using Nex. Here's how to help me:
+
+PHASE 1 — DISCOVERY (ask me, don't skip this)
+Ask me these questions one at a time. Wait for my answer before the next one.
+1. What does your team sell and who do you sell to?
+2. What CRM do you use? (HubSpot, Salesforce, Attio, or other)
+3. What's the most annoying part of your GTM workflow right now?
+4. If you could have an AI teammate audit one thing overnight, what would it be?
+
+PHASE 2 — MATCH
+Install nex-cli if not present:
+  curl -fsSL https://raw.githubusercontent.com/nex-crm/nex-cli/main/install.sh | sh
+Run: nex-cli template list
+Match my answers to the best template. If none fit, offer to build a custom agent.
+Ask me: "I found [template] — [what it does]. Want to use this, or should I
+build something custom for [my specific need]?"
+
+PHASE 3 — SETUP (narrate everything)
+Run: nex-cli template run <slug> --machine --crm <my-crm>
+While it runs, narrate what's happening like a teammate would:
+- "Connecting to your HubSpot..."
+- "Syncing your contacts and companies... 247 records so far..."
+- "Generating insights from your data..."
+- "Activating your CRM Hygiene agent..."
+- "Running the first audit now..."
+Don't dump raw CLI output. Translate every step into plain English.
+
+PHASE 4 — FINDINGS REPORT
+When findings come back, present them as a clear report:
+
+## 🔍 [Agent Name] — First Run Report
+
+**Summary:** Found X issues across Y records
+
+### Duplicates (N found)
+| Record | Duplicate of | Confidence |
+| ...    | ...          | ...        |
+
+### Missing Fields (N found)
+| Record | Missing | Impact |
+| ...    | ...     | ...    |
+
+### Stale Records (N found)
+| Record | Last Activity | Days Idle |
+| ...    | ...           | ...       |
+
+**Want me to fix any of these?** I can [merge duplicates / fill missing fields /
+archive stale records] with your approval before touching anything.
+
+PHASE 5 — SCHEDULE & NEXT STEPS
+After the first run, tell me:
+- "This agent runs daily. Next run: tomorrow at 9am."
+- "Check findings anytime: nex-cli agents findings <slug>"
+- "Want to set up another agent? I can show you what else is available."
+~~~
+
+---
 
 ## Available Templates
 
-| Template | Slug | Description |
-|----------|------|-------------|
-| CRM Hygiene | `crm-hygiene` | Daily duplicate detection, missing field audit, stale record cleanup |
+| Template | Slug | Description | Schedule |
+|----------|------|-------------|----------|
+| CRM Hygiene | `crm-hygiene` | Duplicate detection, missing field audit, stale record cleanup | Daily |
+| Closed-Lost Re-engagement | `closed-lost-reengagement` | Find closed-lost deals worth re-engaging based on signals | Weekly |
+| Meetings Agent | `meetings` | Pre-meeting briefs, post-meeting action items, follow-up emails | Before each meeting |
 
-## Copy-Paste Prompt
+## The Two Paths
 
-Copy this into any AI agent (Claude Code, ChatGPT, Cursor, etc.):
+**Path 1 — Template (fast):** User's intent matches a template. Run it. Agent is live in 5 minutes with real findings.
 
----
+**Path 2 — Custom (powerful):** No template fits. The AI agent uses `nex-cli` to connect integrations, compile playbooks, and generate a custom agent from the user's description. This is the real product.
 
-Audit my CRM for data quality issues with nex-cli. Install if needed: `curl -fsSL https://raw.githubusercontent.com/nex-crm/nex-cli/main/install.sh | sh` — then run `nex-cli template list` to see available templates and run the one that fits.
-
----
-
-That's it. The AI agent will:
-
-1. Install `nex-cli` if not present
-2. Run `nex-cli template list` to discover available templates
-3. Pick the right template based on your intent
-4. Run it via `nex-cli template run <slug>`, handle prompts, and present findings
-
-> **Note:** This prompt explicitly says `nex-cli` (not just "Nex") so the AI agent uses the template system instead of raw MCP data access. Long-term, `template list` and `template run` should be exposed as MCP tools and Claude Code skills so the agent routes there automatically.
+The copy-paste prompt handles both paths. The AI agent decides based on the discovery questions.
 
 ## Adding a New Template
 
-Create a YAML file in this directory following the schema in `crm-hygiene.yaml`. The template spec declares:
+Create a YAML file in this directory following the schema in `crm-hygiene.yaml`:
 
 - `integrations` — what to connect and which providers are supported
 - `readiness` — thresholds for when enough data has synced to proceed
 - `agent.slug` — which pre-built agent to activate
+- `discovery_hints` — keywords and questions that help AI agents match user intent to this template
+- `schedule` — default cron schedule and human-readable description
 
 Templates are fetched from the Nex API at runtime by the CLI. This directory is the canonical source for template definitions that get loaded into the server.

--- a/templates/crm-hygiene.yaml
+++ b/templates/crm-hygiene.yaml
@@ -1,10 +1,27 @@
 name: CRM Hygiene Agent
 slug: crm-hygiene
-version: 2
+version: 3
 description: |
   Daily CRM auditor. Finds duplicates, missing fields, stale records.
   Produces findings with evidence and recommended actions.
   Offers to fix issues directly in the CRM with user approval.
+
+# Discovery hints — help AI agents match user intent to this template
+discovery_hints:
+  keywords:
+    - duplicates
+    - data quality
+    - missing fields
+    - stale records
+    - CRM cleanup
+    - dirty data
+    - audit
+    - hygiene
+  questions:
+    - "My CRM is a mess"
+    - "We have duplicate contacts everywhere"
+    - "Nobody updates the CRM"
+    - "I don't trust our CRM data"
 
 integrations:
   - category: crm
@@ -55,6 +72,11 @@ agent:
   slug: crm-hygiene
   run_after_activation: true
 
+schedule:
+  cron: "0 9 * * *"
+  human: "Daily at 9am"
+  next_run_hint: "tomorrow at 9am"
+
 # After findings, the agent should OFFER TO FIX issues (not just report)
 actions:
   duplicates:
@@ -70,8 +92,17 @@ actions:
     description: "Archive records with no activity in 90+ days, or flag for manual review"
     requires_approval: true
 
+# Narrative hints — how the AI agent should describe each step
+narrative:
+  connecting: "Connecting to your {crm}..."
+  syncing: "Syncing your contacts and companies... {count} records so far..."
+  insights: "Generating insights from your data... {count} patterns found..."
+  activating: "Activating your CRM Hygiene agent..."
+  running: "Running the first audit now. This usually takes about a minute..."
+  done: "Done! Here's what your agent found."
+
 success_message: |
   Your CRM Hygiene Agent is live! Here's what it found in its first run.
-  It'll run daily from now on. Use `nex-cli agents findings crm-hygiene`
+  It runs daily at 9am from now on. Use `nex-cli agents findings crm-hygiene`
   to check findings anytime, or ask your AI agent "what did my CRM
   hygiene agent find?"


### PR DESCRIPTION
## Summary
- Copy-paste prompt upgraded with 5-phase flow: discovery questions → template matching → narrated setup → findings report → schedule display
- AI agent asks 4 questions to understand the business before picking a template, then narrates progress in plain English instead of dumping CLI output
- Template YAML (`crm-hygiene.yaml`) gains `discovery_hints`, `schedule`, and `narrative` hints so AI agents can match intent and describe steps naturally

## Changes
- `templates/README.md` — Short + full copy-paste prompts with discovery flow and two-path architecture (template vs custom)
- `plugin-commands/nex:template.md` — Slash command with wizard mode, narrative translation table, findings report format
- `templates/crm-hygiene.yaml` — v3 with discovery_hints (keywords + natural language), schedule (cron + human), narrative per step

## Test plan
- [x] `nex-cli template list` returns 3 templates
- [x] `nex-cli template list --json` returns structured JSON
- [x] `nex-cli template run crm-hygiene --machine --dry-run` shows 10-step plan
- [ ] Paste short prompt into fresh Claude Code session, verify discovery flow triggers
- [ ] Paste full prompt into ChatGPT, verify narrative mode works with instructed commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)