### PR TITLE
fix(release): fallback-path verify, bump-PR pattern, scoped tokens

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -19,10 +19,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:
@@ -68,13 +69,26 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Commit version bump
+      - name: Open version bump PR
         if: steps.bump.outputs.bumped == 'true'
         env:
+          GH_TOKEN: ${{ github.token }}
           BUMP_VERSION: ${{ steps.bump.outputs.version }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          BRANCH="chore/bump-v${BUMP_VERSION}"
+          git checkout -b "$BRANCH"
           git add package.json
-          git commit -m "chore: bump to v${BUMP_VERSION} [skip ci]"
-          git push
+          git commit -m "chore: bump to v${BUMP_VERSION}"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/nex-crm/nex-as-a-skill.git"
+          git push origin "$BRANCH" --force
+          existing=$(gh pr list --head "$BRANCH" --json number -q '.[0].number // empty' 2>/dev/null || true)
+          if [ -z "$existing" ]; then
+            gh pr create \
+              --title "chore: bump to v${BUMP_VERSION}" \
+              --body "Sync package.json with npm-published v${BUMP_VERSION}." \
+              --head "$BRANCH"
+          else
+            echo "Bump PR #${existing} already exists"
+          fi

--- a/.github/workflows/sync-release.yml
+++ b/.github/workflows/sync-release.yml
@@ -165,10 +165,10 @@ jobs:
       - name: Verify install.sh works
         run: |
           curl -fsSL "https://raw.githubusercontent.com/nex-crm/nex-as-a-skill/main/install.sh" -o install.sh
-          # Run in a temp dir without sudo to test the fallback path
-          export HOME=$(mktemp -d)
           sh install.sh
-          "$HOME/.local/bin/nex-cli" --version
+          # install.sh picks /usr/local/bin when writable, else $HOME/.local/bin — extend PATH for both
+          export PATH="${HOME}/.local/bin:/usr/local/bin:${PATH}"
+          nex-cli --version
           echo "PASS: install.sh end-to-end"
 
   publish-npm:
@@ -221,15 +221,3 @@ jobs:
             npm publish --access public
             echo "published=true" >> "$GITHUB_OUTPUT"
           fi
-
-      - name: Commit version bump
-        if: steps.npm.outputs.published == 'true'
-        env:
-          NPM_VERSION: ${{ steps.npm.outputs.version }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add package.json
-          git diff --staged --quiet && exit 0
-          git commit -m "chore: bump to v${NPM_VERSION} [skip ci]"
-          git push

--- a/.github/workflows/sync-release.yml
+++ b/.github/workflows/sync-release.yml
@@ -15,6 +15,7 @@ concurrency:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   mirror-release:
@@ -130,6 +131,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
       - name: Download from public URL (no auth)
         env:
           VERSION: ${{ needs.mirror-release.outputs.version }}
@@ -162,14 +167,34 @@ jobs:
           echo "$VERSION_OUT" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$' \
             || { echo "FAIL: version output is not semver"; exit 1; }
 
-      - name: Verify install.sh works
+      - name: Verify install.sh (default path)
         run: |
-          curl -fsSL "https://raw.githubusercontent.com/nex-crm/nex-as-a-skill/main/install.sh" -o install.sh
           sh install.sh
-          # install.sh picks /usr/local/bin when writable, else $HOME/.local/bin — extend PATH for both
+          # install.sh picks /usr/local/bin when any of: writable, running as root,
+          # or sudo is available. Falls back to $HOME/.local/bin only when all three
+          # fail — exercised by the next step.
           export PATH="${HOME}/.local/bin:/usr/local/bin:${PATH}"
           nex-cli --version
-          echo "PASS: install.sh end-to-end"
+          echo "PASS: install.sh default path"
+
+      - name: Verify install.sh (fallback path)
+        run: |
+          # Exercise the $HOME/.local/bin branch by running install.sh in an env
+          # with no sudo and no write access to /usr/local/bin. Uses a container
+          # rather than runner-level perms so it doesn't poison later steps.
+          docker run --rm -v "$PWD/install.sh:/tmp/install.sh:ro" ubuntu:22.04 bash -c '
+            set -eu
+            apt-get update -qq
+            apt-get install -y -qq curl ca-certificates >/dev/null
+            # Strip sudo so `command -v sudo` fails in install.sh.
+            apt-get remove -y -qq sudo >/dev/null 2>&1 || true
+            useradd -m tester
+            # tester has no write on /usr/local/bin and no sudo → fallback branch.
+            su tester -s /bin/sh -c "sh /tmp/install.sh"
+            test -x /home/tester/.local/bin/nex-cli
+            su tester -s /bin/sh -c "/home/tester/.local/bin/nex-cli --version"
+          '
+          echo "PASS: install.sh fallback path"
 
   publish-npm:
     needs: mirror-release
@@ -180,7 +205,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: main
-          token: ${{ secrets.CLI_REPO_TOKEN }}
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:
@@ -220,4 +245,28 @@ jobs:
           else
             npm publish --access public
             echo "published=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open version bump PR
+        if: steps.npm.outputs.published == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEW_VERSION: ${{ steps.npm.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          BRANCH="chore/bump-v${NEW_VERSION}"
+          git checkout -b "$BRANCH"
+          git add package.json
+          git commit -m "chore: bump to v${NEW_VERSION}"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/nex-crm/nex-as-a-skill.git"
+          git push origin "$BRANCH" --force
+          existing=$(gh pr list --head "$BRANCH" --json number -q '.[0].number // empty' 2>/dev/null || true)
+          if [ -z "$existing" ]; then
+            gh pr create \
+              --title "chore: bump to v${NEW_VERSION}" \
+              --body "Sync package.json with npm-published v${NEW_VERSION}." \
+              --head "$BRANCH"
+          else
+            echo "Bump PR #${existing} already exists"
           fi


### PR DESCRIPTION
## Summary

The **Sync nex-cli Release** workflow on `main` has been red every run since 2026-04-09 with two independent failures, both introduced by #110. Fixes both plus a set of structural issues that came out of code review.

## Root cause

### 1. `verify-release` / Verify install.sh works (exit 127)

The step set `HOME=$(mktemp -d)` and asserted `$HOME/.local/bin/nex-cli`, but `install.sh` picks `/usr/local/bin` when writable (it is, on `ubuntu-latest`). The binary was installed to `/usr/local/bin/nex-cli` while the test looked under `$HOME/.local/bin`.

### 2. `publish-npm` / Commit version bump (exit 128, HTTP 403)

The step pushed the bumped `package.json` directly to `main`:

```
remote: Permission to nex-crm/nex-as-a-skill.git denied to FranDias.
fatal: unable to access ...: The requested URL returned error: 403
```

Branch protection blocks direct pushes to `main` — and this violates the team rule against pushing to main directly.

## Fix

**1. `verify-release` — test _both_ install.sh paths.**

- Default path: checkout the repo, run `sh install.sh` on the runner, extend `PATH` to cover both destinations, verify `nex-cli --version`.
- Fallback path: run `install.sh` inside an `ubuntu:22.04` container as a non-root user with `sudo` purged — so `command -v sudo` fails and `/usr/local/bin` isn't writable. This actually exercises the `$HOME/.local/bin` branch (the previous \"fallback test\" was cargo-culted and tested nothing).

**2. `publish-npm` / `publish-cli.yml` — bump-PR pattern instead of pushing to main.**

Both workflows previously committed the version bump and `git push`ed to `main`. Replaced with a shared pattern: push to `chore/bump-v<version>`, `gh pr create`, bail out if a PR for that branch already exists. This respects branch protection _and_ the team's \"never push directly to main\" rule.

**3. Token scoping.**

- Drop `token: \${{ secrets.CLI_REPO_TOKEN }}` from the `publish-npm` checkout — the job no longer pushes, so checkout doesn't need write. Use `persist-credentials: false`.
- Drop `token: \${{ secrets.GITHUB_TOKEN }}` from the `publish-cli.yml` checkout for the same reason.
- The bump-PR steps supply their own `GH_TOKEN` via `env:`, scoped to just that step.
- Add `pull-requests: write` to `sync-release.yml` workflow permissions (already present on `publish-cli.yml` job permissions).

## Failing run

- https://github.com/nex-crm/nex-as-a-skill/actions/runs/24168436278

## Test plan

- [ ] `verify-release` passes both default-path and fallback-path install.sh tests on the next nex-cli dispatch
- [ ] `publish-npm` opens a bump PR instead of 403-ing on push to main
- [ ] `publish-cli.yml` on the next bin/** change opens a bump PR instead of pushing directly
- [ ] Subsequent release runs read the correct published version from npm (no drift from the PR-based bump loop)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced installation verification process with improved testing across different system configurations
  * Updated CI/CD workflow security permissions and authentication handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->