### PR TITLE
chore: bump to v0.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nex-ai/nex",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Nex CLI provides organizational context & memory to AI agents. Connect email, CRM, Slack, meetings, and 100+ tools into one knowledge graph. Delegates to the nex-cli binary.",
   "mcpName": "io.github.nex-crm/nex",
   "type": "module",


### PR DESCRIPTION
Sync the root package version with the already-published npm package `@nex-ai/nex@0.2.4`.

Verification:
- npm `0.2.4` matches the current `origin/main` package contents
- only `package.json` version was out of sync in git
- `node --check bin/nex.js && node --check bin/nex-mcp.js`
- `npm pack --dry-run`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version update to 0.2.4

<!-- end of auto-generated comment: release notes by coderabbit.ai -->