### PR TITLE
fix(openclaw-plugin): address CodeRabbit review — empty-text narrowing + scanner hardening

### DIFF
--- a/openclaw-plugin/src/capture-filter.ts
+++ b/openclaw-plugin/src/capture-filter.ts
@@ -66,7 +66,9 @@ function isDuplicate(hash: string): boolean {
 function extractText(msg: AgentMessage): string {
   if (typeof msg.content === "string") return msg.content;
   if (Array.isArray(msg.content)) {
-    return msg.content.flatMap((p) => (p.type === "text" && p.text ? [p.text] : [])).join("\n");
+    return msg.content
+      .flatMap((p) => (p.type === "text" && typeof p.text === "string" ? [p.text] : []))
+      .join("\n");
   }
   return "";
 }

--- a/openclaw-plugin/src/file-scanner.ts
+++ b/openclaw-plugin/src/file-scanner.ts
@@ -8,7 +8,7 @@ import { createHash } from "node:crypto";
 import type { Stats } from "node:fs";
 import { mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, extname, join, resolve } from "node:path";
+import { basename, dirname, extname, join, resolve } from "node:path";
 import type { NexClient } from "./nex-client.js";
 
 // --- Types ---
@@ -34,6 +34,10 @@ export interface ScanResult {
 // --- Constants ---
 
 const MANIFEST_PATH = join(homedir(), ".nex", "file-scan-manifest.json");
+// Sensitive extensions (.env, .log, .ini, .cfg, .conf, .properties) are
+// intentionally excluded from the defaults — they routinely hold credentials,
+// tokens, or PII. Callers that want them must pass `extensions` explicitly,
+// and SENSITIVE_BASENAMES below still guards against well-known secret files.
 const DEFAULT_EXTENSIONS = [
   ".md",
   ".txt",
@@ -64,12 +68,6 @@ const DEFAULT_EXTENSIONS = [
   ".rst",
   ".adoc",
   ".tex",
-  ".log",
-  ".env",
-  ".ini",
-  ".cfg",
-  ".conf",
-  ".properties",
 ];
 const SKIP_DIRS = new Set([
   "node_modules",
@@ -84,6 +82,29 @@ const SKIP_DIRS = new Set([
   "coverage",
   ".nyc_output",
 ]);
+
+// Secret-bearing filenames to skip regardless of extension config — prevents
+// an explicit extensions override from re-introducing credential ingestion.
+const SENSITIVE_BASENAMES = new Set([
+  "credentials",
+  "credentials.json",
+  "id_rsa",
+  "id_dsa",
+  "id_ecdsa",
+  "id_ed25519",
+  "secrets.json",
+  "secrets.yaml",
+  "secrets.yml",
+]);
+const SENSITIVE_EXTENSIONS = new Set([".pem", ".key", ".p12", ".pfx", ".asc", ".gpg"]);
+
+function isSensitivePath(filePath: string): boolean {
+  const name = basename(filePath);
+  if (name === ".env" || name.startsWith(".env.")) return true;
+  if (SENSITIVE_BASENAMES.has(name)) return true;
+  if (SENSITIVE_EXTENSIONS.has(extname(name).toLowerCase())) return true;
+  return false;
+}
 
 // --- Manifest ---
 
@@ -177,16 +198,23 @@ export async function scanFiles(
   const result: ScanResult = { scanned: 0, skipped: 0, errors: 0, files: [] };
 
   for (const file of candidates) {
-    const hash = hashFile(file.path);
-    const existing = manifest.files[file.path];
-
-    if (existing && existing.hash === hash && !force) {
+    if (isSensitivePath(file.path)) {
       result.skipped++;
-      result.files.push({ path: file.path, status: "skipped", reason: "unchanged" });
+      result.files.push({ path: file.path, status: "skipped", reason: "sensitive" });
       continue;
     }
 
     try {
+      // Hash inside the try so a single unreadable file doesn't abort the scan.
+      const hash = hashFile(file.path);
+      const existing = manifest.files[file.path];
+
+      if (existing && existing.hash === hash && !force) {
+        result.skipped++;
+        result.files.push({ path: file.path, status: "skipped", reason: "unchanged" });
+        continue;
+      }
+
       const content = readFileSync(file.path, "utf-8");
       if (!content.trim()) {
         result.skipped++;

--- a/openclaw-plugin/src/file-scanner.ts
+++ b/openclaw-plugin/src/file-scanner.ts
@@ -99,10 +99,10 @@ const SENSITIVE_BASENAMES = new Set([
 const SENSITIVE_EXTENSIONS = new Set([".pem", ".key", ".p12", ".pfx", ".asc", ".gpg"]);
 
 function isSensitivePath(filePath: string): boolean {
-  const name = basename(filePath);
+  const name = basename(filePath).toLowerCase();
   if (name === ".env" || name.startsWith(".env.")) return true;
   if (SENSITIVE_BASENAMES.has(name)) return true;
-  if (SENSITIVE_EXTENSIONS.has(extname(name).toLowerCase())) return true;
+  if (SENSITIVE_EXTENSIONS.has(extname(name))) return true;
   return false;
 }
 


### PR DESCRIPTION
## Summary

Branch was reset on top of the new `main` (upstream #121 "lint sweep" subsumed the original biome cleanup commits in this PR). What's left is the CodeRabbit feedback from the review of #119 on two live bugs in `openclaw-plugin`:

### 1. `capture-filter.ts` — preserve empty-string text parts
`p.text` truthy check drops valid empty `""` text chunks, changing joined-content boundaries. Narrowed with `typeof p.text === "string"` instead.

### 2. `file-scanner.ts` — harden against secret ingestion
- **Removed** `.env`, `.log`, `.ini`, `.cfg`, `.conf`, `.properties` from `DEFAULT_EXTENSIONS`. These routinely hold credentials/tokens/PII; callers that want them must pass `extensions` explicitly.
- **Added** a filename/extension denylist (`SENSITIVE_BASENAMES` / `SENSITIVE_EXTENSIONS` + `.env` / `.env.*` match) that runs regardless of the `extensions` config, so an override can't re-introduce ingestion of things like `id_rsa`, `*.pem`, `credentials.json`, `secrets.*`, etc.
- **Moved** `hashFile()` inside the per-file `try/catch` so a single unreadable file is recorded as one skip instead of aborting the entire scan.

No behavior change for the common/valid path; the scanner just stops silently ingesting credentials into Nex.

## Test plan
- [x] `bunx @biomejs/biome check openclaw-plugin/src/*` → clean
- [x] `bun run build` (openclaw-plugin + claude-code-plugin) → pass
- [x] `bun test` (openclaw-plugin) → 38/38 pass
- [x] pre-push hook → pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic filtering to exclude sensitive files (`.env`, `.log`, `.ini`, `.cfg`, `.conf`, `.properties`) from scans, even when force mode is enabled.

* **Bug Fixes**
  * Improved text extraction validation and per-file error reporting for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->