### PR TITLE
chore: lint sweep

### DIFF
--- a/claude-code-plugin/src/auto-capture.ts
+++ b/claude-code-plugin/src/auto-capture.ts
@@ -9,13 +9,15 @@
  * On ANY error: outputs {} and exits 0 (graceful degradation).
  */
 
-import { readdirSync, statSync, readFileSync } from "node:fs";
-import { join, extname } from "node:path";
-import { loadConfig, loadScanConfig, isHookEnabled } from "./config.js";
-import { NexClient } from "./nex-client.js";
+import type { Dirent } from "node:fs";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { extname, join } from "node:path";
 import { captureFilter } from "./capture-filter.js";
+import type { NexConfig } from "./config.js";
+import { isHookEnabled, loadConfig, loadScanConfig } from "./config.js";
+import { isChanged, markIngested, readManifest, writeManifest } from "./file-manifest.js";
+import { NexClient } from "./nex-client.js";
 import { RateLimiter } from "./rate-limiter.js";
-import { readManifest, writeManifest, isChanged, markIngested } from "./file-manifest.js";
 
 /** Ingest timeout — 3s leaves buffer within hook timeout */
 const INGEST_TIMEOUT_MS = 3_000;
@@ -37,7 +39,7 @@ async function ingestPlanFiles(client: NexClient): Promise<void> {
 
   const plansDir = join(process.cwd(), ".claude", "plans");
 
-  let entries;
+  let entries: Dirent[];
   try {
     entries = readdirSync(plansDir, { withFileTypes: true });
   } catch {
@@ -64,7 +66,7 @@ async function ingestPlanFiles(client: NexClient): Promise<void> {
 
       let content = readFileSync(fullPath, "utf-8");
       if (content.length > 100_000) {
-        content = content.slice(0, 100_000) + "\n[...truncated]";
+        content = `${content.slice(0, 100_000)}\n[...truncated]`;
       }
 
       const context = `claude-code-plan:${entry.name}`;
@@ -73,7 +75,7 @@ async function ingestPlanFiles(client: NexClient): Promise<void> {
       ingested++;
     } catch (err) {
       process.stderr.write(
-        `[nex-capture] Plan file ingest failed (${entry.name}): ${err instanceof Error ? err.message : String(err)}\n`
+        `[nex-capture] Plan file ingest failed (${entry.name}): ${err instanceof Error ? err.message : String(err)}\n`,
       );
     }
   }
@@ -106,7 +108,7 @@ async function main(): Promise<void> {
       return;
     }
 
-    let cfg;
+    let cfg: NexConfig;
     try {
       cfg = loadConfig();
     } catch {
@@ -127,7 +129,7 @@ async function main(): Promise<void> {
             await client.ingest(filterResult.text, "claude-code-conversation", INGEST_TIMEOUT_MS);
           } catch (err) {
             process.stderr.write(
-              `[nex-capture] Ingest failed: ${err instanceof Error ? err.message : String(err)}\n`
+              `[nex-capture] Ingest failed: ${err instanceof Error ? err.message : String(err)}\n`,
             );
           }
         } else {
@@ -141,17 +143,19 @@ async function main(): Promise<void> {
       await ingestPlanFiles(client);
     } catch (err) {
       process.stderr.write(
-        `[nex-capture] Plan file scan error: ${err instanceof Error ? err.message : String(err)}\n`
+        `[nex-capture] Plan file scan error: ${err instanceof Error ? err.message : String(err)}\n`,
       );
     }
 
     process.stdout.write("{}");
   } catch (err) {
     process.stderr.write(
-      `[nex-capture] Unexpected error: ${err instanceof Error ? err.message : String(err)}\n`
+      `[nex-capture] Unexpected error: ${err instanceof Error ? err.message : String(err)}\n`,
     );
     process.stdout.write("{}");
   }
 }
 
-main().then(() => process.exit(0)).catch(() => process.exit(0));
+main()
+  .then(() => process.exit(0))
+  .catch(() => process.exit(0));

--- a/claude-code-plugin/src/auto-recall-worker.ts
+++ b/claude-code-plugin/src/auto-recall-worker.ts
@@ -21,10 +21,7 @@ function readTimeoutEnv(name: string, fallbackMs: number): number {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallbackMs;
 }
 
-const BACKGROUND_RECALL_TIMEOUT_MS = readTimeoutEnv(
-  "NEX_RECALL_BACKGROUND_TIMEOUT_MS",
-  60_000,
-);
+const BACKGROUND_RECALL_TIMEOUT_MS = readTimeoutEnv("NEX_RECALL_BACKGROUND_TIMEOUT_MS", 60_000);
 const PENDING_CACHE_TTL_MS = readTimeoutEnv(
   "NEX_RECALL_PENDING_TTL_MS",
   BACKGROUND_RECALL_TIMEOUT_MS + 30_000,
@@ -95,4 +92,6 @@ async function main(): Promise<void> {
   }
 }
 
-main().then(() => process.exit(0)).catch(() => process.exit(0));
+main()
+  .then(() => process.exit(0))
+  .catch(() => process.exit(0));

--- a/claude-code-plugin/src/auto-recall.ts
+++ b/claude-code-plugin/src/auto-recall.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+
 /**
  * Claude Code UserPromptSubmit hook — auto-recall from Nex.
  *
@@ -9,33 +10,28 @@
  * On ANY error: outputs {} and exits 0 (graceful degradation).
  */
 
-import { loadConfig, isHookEnabled } from "./config.js";
-import { NexClient } from "./nex-client.js";
-import { formatNexContext } from "./context-format.js";
-import { RecallCache, hashPrompt } from "./recall-cache.js";
-import { SessionStore } from "./session-store.js";
-import { shouldRecall } from "./recall-filter.js";
 import { spawn } from "node:child_process";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import type { NexConfig } from "./config.js";
+import { isHookEnabled, loadConfig } from "./config.js";
+import { formatNexContext } from "./context-format.js";
+import { NexClient } from "./nex-client.js";
+import { hashPrompt, RecallCache } from "./recall-cache.js";
+import { shouldRecall } from "./recall-filter.js";
+import { SessionStore } from "./session-store.js";
 
 const sessions = new SessionStore();
 const recallCache = new RecallCache();
 
 const FAST_RECALL_BUDGET_MS = readTimeoutEnv("NEX_RECALL_SYNC_BUDGET_MS", 8_000);
-const BACKGROUND_RECALL_TIMEOUT_MS = readTimeoutEnv(
-  "NEX_RECALL_BACKGROUND_TIMEOUT_MS",
-  60_000,
-);
+const BACKGROUND_RECALL_TIMEOUT_MS = readTimeoutEnv("NEX_RECALL_BACKGROUND_TIMEOUT_MS", 60_000);
 const READY_CACHE_TTL_MS = readTimeoutEnv("NEX_RECALL_READY_TTL_MS", 5 * 60_000);
 const PENDING_CACHE_TTL_MS = readTimeoutEnv(
   "NEX_RECALL_PENDING_TTL_MS",
   BACKGROUND_RECALL_TIMEOUT_MS + 30_000,
 );
-const WORKER_PATH = join(
-  dirname(fileURLToPath(import.meta.url)),
-  "auto-recall-worker.js",
-);
+const WORKER_PATH = join(dirname(fileURLToPath(import.meta.url)), "auto-recall-worker.js");
 
 interface HookInput {
   prompt?: string;
@@ -49,23 +45,21 @@ function readTimeoutEnv(name: string, fallbackMs: number): number {
 }
 
 function writeHookContext(context: string): void {
-  process.stdout.write(JSON.stringify({
-    hookSpecificOutput: {
-      hookEventName: "UserPromptSubmit",
-      additionalContext: context,
-    },
-  }));
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "UserPromptSubmit",
+        additionalContext: context,
+      },
+    }),
+  );
 }
 
 function isAbortError(error: unknown): boolean {
   return error instanceof Error && error.name === "AbortError";
 }
 
-function launchBackgroundRecall(
-  prompt: string,
-  sessionKey: string,
-  promptHash: string,
-): void {
+function launchBackgroundRecall(prompt: string, sessionKey: string, promptHash: string): void {
   try {
     const child = spawn(process.execPath, [WORKER_PATH], {
       detached: true,
@@ -76,11 +70,13 @@ function launchBackgroundRecall(
       },
       stdio: ["pipe", "ignore", "ignore"],
     });
-    child.stdin.end(JSON.stringify({
-      prompt,
-      prompt_hash: promptHash,
-      session_id: sessionKey,
-    }));
+    child.stdin.end(
+      JSON.stringify({
+        prompt,
+        prompt_hash: promptHash,
+        session_id: sessionKey,
+      }),
+    );
     child.unref();
   } catch {
     recallCache.clearPending(sessionKey, promptHash);
@@ -141,12 +137,12 @@ async function main(): Promise<void> {
       return;
     }
 
-    let cfg;
+    let cfg: NexConfig;
     try {
       cfg = loadConfig();
     } catch (err) {
       process.stderr.write(
-        `[nex-recall] Config error: ${err instanceof Error ? err.message : String(err)}\n`
+        `[nex-recall] Config error: ${err instanceof Error ? err.message : String(err)}\n`,
       );
       process.stdout.write("{}");
       return;
@@ -201,7 +197,7 @@ async function main(): Promise<void> {
           shouldStartBackground = true;
         } else {
           process.stderr.write(
-            `[nex-recall] Fast-path error: ${err instanceof Error ? err.message : String(err)}\n`
+            `[nex-recall] Fast-path error: ${err instanceof Error ? err.message : String(err)}\n`,
           );
         }
       }
@@ -221,10 +217,12 @@ async function main(): Promise<void> {
     process.stdout.write("{}");
   } catch (err) {
     process.stderr.write(
-      `[nex-recall] Unexpected error: ${err instanceof Error ? err.message : String(err)}\n`
+      `[nex-recall] Unexpected error: ${err instanceof Error ? err.message : String(err)}\n`,
     );
     process.stdout.write("{}");
   }
 }
 
-main().then(() => process.exit(0)).catch(() => process.exit(0));
+main()
+  .then(() => process.exit(0))
+  .catch(() => process.exit(0));

--- a/claude-code-plugin/src/auto-register.ts
+++ b/claude-code-plugin/src/auto-register.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+
 /**
  * Registration entry point — creates a Nex account and persists the API key.
  *
@@ -8,11 +9,17 @@
  * If already registered (API key exists): prints status and exits.
  */
 
-import { loadMcpConfig, loadWorkspaceCredentials, persistRegistration, loadBaseUrl, MCP_CONFIG_PATH } from "./config.js";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  loadBaseUrl,
+  loadMcpConfig,
+  loadWorkspaceCredentials,
+  MCP_CONFIG_PATH,
+  persistRegistration,
+} from "./config.js";
 import { NexClient } from "./nex-client.js";
 import { workspaceDataDir } from "./workspace-data-dir.js";
-import { writeFileSync, mkdirSync } from "node:fs";
-import { join } from "node:path";
 
 /** Persist credentials to the active workspace directory. */
 function persistWorkspaceCredentials(data: Record<string, unknown>): void {
@@ -25,10 +32,11 @@ function persistWorkspaceCredentials(data: Record<string, unknown>): void {
   const creds = {
     api_key: data.api_key,
     email: data.email,
-    workspace_id: typeof data.workspace_id === "number" ? String(data.workspace_id) : data.workspace_id,
+    workspace_id:
+      typeof data.workspace_id === "number" ? String(data.workspace_id) : data.workspace_id,
     workspace_slug: slug,
   };
-  writeFileSync(join(wsDir, "credentials.json"), JSON.stringify(creds, null, 2) + "\n", "utf-8");
+  writeFileSync(join(wsDir, "credentials.json"), `${JSON.stringify(creds, null, 2)}\n`, "utf-8");
 }
 
 async function main(): Promise<void> {

--- a/claude-code-plugin/src/auto-scan.ts
+++ b/claude-code-plugin/src/auto-scan.ts
@@ -25,6 +25,10 @@ async function main(): Promise<void> {
       cfg = loadConfig();
     } catch (err) {
       console.error(`Config error: ${err instanceof Error ? err.message : String(err)}`);
+      // The bare `return` is here because the plugin sub-packages don't
+      // install @types/node, so TS can't see that `process.exit(1)` is
+      // `never`. Without the return, `cfg` below would be flagged as
+      // possibly-unassigned.
       process.exit(1);
       return;
     }

--- a/claude-code-plugin/src/auto-scan.ts
+++ b/claude-code-plugin/src/auto-scan.ts
@@ -8,23 +8,25 @@
  * Usage: node dist/auto-scan.js [directory]
  */
 
+import type { NexConfig } from "./config.js";
 import { loadConfig, loadScanConfig } from "./config.js";
+import { markScanned, readManifest, writeManifest } from "./file-manifest.js";
+import { scanAndIngest } from "./file-scanner.js";
 import { NexClient } from "./nex-client.js";
 import { RateLimiter } from "./rate-limiter.js";
-import { scanAndIngest } from "./file-scanner.js";
-import { readManifest, markScanned, writeManifest } from "./file-manifest.js";
 
 async function main(): Promise<void> {
   try {
     // Determine target directory: argv[2] > cwd
     const targetDir = process.argv[2] || process.cwd();
 
-    let cfg;
+    let cfg: NexConfig;
     try {
       cfg = loadConfig();
     } catch (err) {
       console.error(`Config error: ${err instanceof Error ? err.message : String(err)}`);
       process.exit(1);
+      return;
     }
 
     const scanConfig = loadScanConfig();

--- a/claude-code-plugin/src/auto-session-start.ts
+++ b/claude-code-plugin/src/auto-session-start.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+
 /**
  * Claude Code SessionStart hook — bulk context load from Nex + file scan.
  *
@@ -12,16 +13,22 @@
  * On ANY error: outputs {} and exits 0 (graceful degradation).
  */
 
-import { loadConfig, loadScanConfig, ConfigError, isHookEnabled } from "./config.js";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { NexConfig } from "./config.js";
+import { ConfigError, isHookEnabled, loadConfig, loadScanConfig } from "./config.js";
+import { ingestContextFiles } from "./context-files.js";
+import { formatNexContext } from "./context-format.js";
+import {
+  isScanFresh,
+  markScanned,
+  readManifest as readScanManifest,
+  writeManifest as writeScanManifest,
+} from "./file-manifest.js";
+import { scanAndIngest } from "./file-scanner.js";
 import { NexClient } from "./nex-client.js";
 import { RateLimiter } from "./rate-limiter.js";
-import { formatNexContext } from "./context-format.js";
 import { SessionStore } from "./session-store.js";
-import { scanAndIngest } from "./file-scanner.js";
-import { ingestContextFiles } from "./context-files.js";
-import { readManifest as readScanManifest, isScanFresh, markScanned, writeManifest as writeScanManifest } from "./file-manifest.js";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
 
 const sessions = new SessionStore();
 
@@ -30,7 +37,8 @@ interface HookInput {
   source?: string; // "startup" | "resume" | "clear" | "compact"
 }
 
-const SESSION_START_QUERY = "Summarize the key active context, recent interactions, and important updates for this user.";
+const SESSION_START_QUERY =
+  "Summarize the key active context, recent interactions, and important updates for this user.";
 
 async function main(): Promise<void> {
   try {
@@ -51,10 +59,12 @@ async function main(): Promise<void> {
     try {
       input = JSON.parse(raw) as HookInput;
     } catch {
-      process.stderr.write("[nex-session-start] Failed to parse stdin JSON, continuing with defaults\n");
+      process.stderr.write(
+        "[nex-session-start] Failed to parse stdin JSON, continuing with defaults\n",
+      );
     }
 
-    let cfg;
+    let cfg: NexConfig;
     try {
       cfg = loadConfig();
     } catch (err) {
@@ -67,7 +77,7 @@ async function main(): Promise<void> {
           "",
           "IMPORTANT: Before proceeding with the user's request, you must set up Nex memory:",
           "1. Ask the user for their email address to register for a Nex account",
-          "2. Run the registration command: node " + registerScript + " <email> [name] [company]",
+          `2. Run the registration command: node ${registerScript} <email> [name] [company]`,
           "3. Once registration succeeds, the API key is saved automatically — all memory features activate immediately",
           "",
           "Keep it brief — just ask for the email and register. No restart needed after registration.",
@@ -83,7 +93,7 @@ async function main(): Promise<void> {
         return;
       }
       process.stderr.write(
-        `[nex-session-start] Config error: ${err instanceof Error ? err.message : String(err)}\n`
+        `[nex-session-start] Config error: ${err instanceof Error ? err.message : String(err)}\n`,
       );
       process.stdout.write("{}");
       return;
@@ -113,12 +123,12 @@ async function main(): Promise<void> {
           const ctxResult = await ingestContextFiles(client, rateLimiter, cwd);
           if (ctxResult.ingested > 0) {
             contextParts.push(
-              `[Context files: ${ctxResult.ingested} ingested (${ctxResult.files.join(", ")})]`
+              `[Context files: ${ctxResult.ingested} ingested (${ctxResult.files.join(", ")})]`,
             );
           }
         } catch (err) {
           process.stderr.write(
-            `[nex-session-start] Context files error: ${err instanceof Error ? err.message : String(err)}\n`
+            `[nex-session-start] Context files error: ${err instanceof Error ? err.message : String(err)}\n`,
           );
         }
 
@@ -130,13 +140,13 @@ async function main(): Promise<void> {
 
             if (scanResult.ingested > 0) {
               contextParts.push(
-                `[File scan: ${scanResult.ingested} file${scanResult.ingested === 1 ? "" : "s"} ingested, ${scanResult.scanned} scanned]`
+                `[File scan: ${scanResult.ingested} file${scanResult.ingested === 1 ? "" : "s"} ingested, ${scanResult.scanned} scanned]`,
               );
             }
           }
         } catch (err) {
           process.stderr.write(
-            `[nex-session-start] File scan error: ${err instanceof Error ? err.message : String(err)}\n`
+            `[nex-session-start] File scan error: ${err instanceof Error ? err.message : String(err)}\n`,
           );
         }
 
@@ -167,9 +177,8 @@ async function main(): Promise<void> {
     });
 
     // Append scan summary if any
-    const fullContext = contextParts.length > 0
-      ? `${context}\n${contextParts.join("\n")}`
-      : context;
+    const fullContext =
+      contextParts.length > 0 ? `${context}\n${contextParts.join("\n")}` : context;
 
     const output = JSON.stringify({
       hookSpecificOutput: {
@@ -180,10 +189,12 @@ async function main(): Promise<void> {
     process.stdout.write(output);
   } catch (err) {
     process.stderr.write(
-      `[nex-session-start] Unexpected error: ${err instanceof Error ? err.message : String(err)}\n`
+      `[nex-session-start] Unexpected error: ${err instanceof Error ? err.message : String(err)}\n`,
     );
     process.stdout.write("{}");
   }
 }
 
-main().then(() => process.exit(0)).catch(() => process.exit(0));
+main()
+  .then(() => process.exit(0))
+  .catch(() => process.exit(0));

--- a/claude-code-plugin/src/config.ts
+++ b/claude-code-plugin/src/config.ts
@@ -3,9 +3,9 @@
  * with fallback to workspace credentials and legacy ~/.nex-mcp.json.
  */
 
-import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
-import { join, dirname } from "node:path";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
+import { dirname, join } from "node:path";
 import { workspaceDataDir } from "./workspace-data-dir.js";
 
 export interface NexConfig {
@@ -60,7 +60,7 @@ export function persistRegistration(data: Record<string, unknown>): void {
   }
   if (typeof data.workspace_slug === "string") existing.workspace_slug = data.workspace_slug;
   mkdirSync(dirname(MCP_CONFIG_PATH), { recursive: true });
-  writeFileSync(MCP_CONFIG_PATH, JSON.stringify(existing, null, 2) + "\n", "utf-8");
+  writeFileSync(MCP_CONFIG_PATH, `${JSON.stringify(existing, null, 2)}\n`, "utf-8");
 }
 
 interface WorkspaceCredentials {
@@ -103,7 +103,7 @@ export function loadConfig(): NexConfig {
 
   if (!apiKey) {
     throw new ConfigError(
-      "No API key found. Set NEX_API_KEY or run /nex:register to create an account."
+      "No API key found. Set NEX_API_KEY or run /nex:register to create an account.",
     );
   }
 
@@ -119,7 +119,7 @@ export function loadConfig(): NexConfig {
  * Used for registration (which doesn't need auth).
  */
 export function loadBaseUrl(): string {
-  let baseUrl = process.env.NEX_API_BASE_URL ?? "https://app.nex.ai";
+  const baseUrl = process.env.NEX_API_BASE_URL ?? "https://app.nex.ai";
   return baseUrl.replace(/\/+$/, "");
 }
 
@@ -214,8 +214,18 @@ export function isHookEnabled(hookName: "recall" | "capture" | "session_start"):
 
 const DEFAULT_SCAN_EXTENSIONS = [".md", ".txt", ".csv", ".json", ".yaml", ".yml"];
 const DEFAULT_IGNORE_DIRS = [
-  "node_modules", ".git", "dist", "build", ".next", "__pycache__",
-  "vendor", ".venv", ".claude", "coverage", ".turbo", ".cache",
+  "node_modules",
+  ".git",
+  "dist",
+  "build",
+  ".next",
+  "__pycache__",
+  "vendor",
+  ".venv",
+  ".claude",
+  "coverage",
+  ".turbo",
+  ".cache",
 ];
 
 /**
@@ -237,9 +247,7 @@ export function loadScanConfig(): ScanConfig {
     ? parseInt(process.env.NEX_SCAN_MAX_FILES, 10)
     : 5;
 
-  const scanDepth = process.env.NEX_SCAN_DEPTH
-    ? parseInt(process.env.NEX_SCAN_DEPTH, 10)
-    : 2;
+  const scanDepth = process.env.NEX_SCAN_DEPTH ? parseInt(process.env.NEX_SCAN_DEPTH, 10) : 2;
 
   const ignoreDirs = process.env.NEX_SCAN_IGNORE_DIRS
     ? process.env.NEX_SCAN_IGNORE_DIRS.split(",").map((d) => d.trim())

--- a/claude-code-plugin/src/context-files.ts
+++ b/claude-code-plugin/src/context-files.ts
@@ -10,12 +10,12 @@
  * Uses the file manifest for change detection — unchanged files are skipped.
  */
 
-import { existsSync, readdirSync, statSync, readFileSync } from "node:fs";
-import { join, extname, basename } from "node:path";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
+import { basename, extname, join } from "node:path";
+import { isChanged, markIngested, readManifest, writeManifest } from "./file-manifest.js";
 import type { NexClient } from "./nex-client.js";
 import type { RateLimiter } from "./rate-limiter.js";
-import { readManifest, writeManifest, isChanged, markIngested } from "./file-manifest.js";
 
 const CLAUDE_DIR = join(homedir(), ".claude");
 const INGEST_TIMEOUT_MS = 10_000;
@@ -81,7 +81,7 @@ function collectContextFiles(cwd: string): Array<{ path: string; contextTag: str
 export async function ingestContextFiles(
   client: NexClient,
   rateLimiter: RateLimiter,
-  cwd: string
+  cwd: string,
 ): Promise<ContextFilesResult> {
   const result: ContextFilesResult = { ingested: 0, skipped: 0, errors: 0, files: [] };
   const manifest = readManifest();
@@ -104,7 +104,7 @@ export async function ingestContextFiles(
 
       let content = readFileSync(path, "utf-8");
       if (content.length > MAX_FILE_SIZE) {
-        content = content.slice(0, MAX_FILE_SIZE) + "\n[...truncated]";
+        content = `${content.slice(0, MAX_FILE_SIZE)}\n[...truncated]`;
       }
 
       await client.ingest(content, contextTag, INGEST_TIMEOUT_MS);
@@ -114,7 +114,7 @@ export async function ingestContextFiles(
       dirty = true;
     } catch (err) {
       process.stderr.write(
-        `[nex-context-files] Failed to ingest ${contextTag}: ${err instanceof Error ? err.message : String(err)}\n`
+        `[nex-context-files] Failed to ingest ${contextTag}: ${err instanceof Error ? err.message : String(err)}\n`,
       );
       result.errors++;
     }

--- a/claude-code-plugin/src/file-manifest.ts
+++ b/claude-code-plugin/src/file-manifest.ts
@@ -5,15 +5,15 @@
  * Stored at ~/.nex/file-scan-manifest.json. Follows session-store.ts pattern.
  */
 
-import { readFileSync, writeFileSync, mkdirSync, type Stats } from "node:fs";
+import { mkdirSync, readFileSync, type Stats, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { workspaceDataDir } from "./workspace-data-dir.js";
 
 export interface FileManifestEntry {
-  mtime: number;      // fs.statSync().mtimeMs
-  size: number;       // fs.statSync().size
+  mtime: number; // fs.statSync().mtimeMs
+  size: number; // fs.statSync().size
   ingestedAt: number; // Date.now()
-  context: string;    // context tag used for ingest
+  context: string; // context tag used for ingest
 }
 
 export interface FileManifest {
@@ -62,7 +62,7 @@ export function markIngested(
   path: string,
   stat: Stats,
   context: string,
-  manifest: FileManifest
+  manifest: FileManifest,
 ): void {
   manifest.files[path] = {
     mtime: stat.mtimeMs,

--- a/claude-code-plugin/src/file-scanner.ts
+++ b/claude-code-plugin/src/file-scanner.ts
@@ -5,13 +5,13 @@
  * No new dependencies — uses only Node.js built-ins.
  */
 
-import { readdirSync, statSync, readFileSync } from "node:fs";
-import { join, relative, extname } from "node:path";
-import type { Stats } from "node:fs";
+import type { Dirent, Stats } from "node:fs";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { extname, join, relative } from "node:path";
+import type { ScanConfig } from "./config.js";
+import { isChanged, markIngested, readManifest, writeManifest } from "./file-manifest.js";
 import type { NexClient } from "./nex-client.js";
 import type { RateLimiter } from "./rate-limiter.js";
-import type { ScanConfig } from "./config.js";
-import { readManifest, writeManifest, isChanged, markIngested } from "./file-manifest.js";
 
 export interface ScanResult {
   scanned: number;
@@ -34,11 +34,11 @@ function walkDir(
   cwd: string,
   config: ScanConfig,
   depth: number,
-  results: CandidateFile[]
+  results: CandidateFile[],
 ): void {
   if (depth > config.scanDepth) return;
 
-  let entries;
+  let entries: Dirent[];
   try {
     entries = readdirSync(dir, { withFileTypes: true });
   } catch {
@@ -76,7 +76,7 @@ export async function scanAndIngest(
   client: NexClient,
   rateLimiter: RateLimiter,
   cwd: string,
-  config: ScanConfig
+  config: ScanConfig,
 ): Promise<ScanResult> {
   const result: ScanResult = { scanned: 0, ingested: 0, skipped: 0, errors: 0 };
 
@@ -108,7 +108,7 @@ export async function scanAndIngest(
 
       // Truncate large files
       if (content.length > config.maxFileSize) {
-        content = content.slice(0, config.maxFileSize) + "\n[...truncated]";
+        content = `${content.slice(0, config.maxFileSize)}\n[...truncated]`;
       }
 
       const context = `file-scan:${file.relativePath}`;
@@ -117,7 +117,7 @@ export async function scanAndIngest(
       result.ingested++;
     } catch (err) {
       process.stderr.write(
-        `[nex-scan] Failed to ingest ${file.relativePath}: ${err instanceof Error ? err.message : String(err)}\n`
+        `[nex-scan] Failed to ingest ${file.relativePath}: ${err instanceof Error ? err.message : String(err)}\n`,
       );
       result.errors++;
     }

--- a/claude-code-plugin/src/nex-client.ts
+++ b/claude-code-plugin/src/nex-client.ts
@@ -73,7 +73,7 @@ export class NexClient {
     method: string,
     path: string,
     body?: unknown,
-    timeoutMs = 10_000
+    timeoutMs = 10_000,
   ): Promise<T> {
     const url = `${this.baseUrl}/api/developers${path}`;
     const controller = new AbortController();
@@ -115,7 +115,7 @@ export class NexClient {
       }
 
       const text = await res.text();
-      if (!text || !text.trim()) return {} as T;
+      if (!text?.trim()) return {} as T;
       return JSON.parse(text) as T;
     } finally {
       clearTimeout(timer);
@@ -150,11 +150,15 @@ export class NexClient {
 
       if (!res.ok) {
         let errorBody: string | undefined;
-        try { errorBody = await res.text(); } catch { /* ignore */ }
+        try {
+          errorBody = await res.text();
+        } catch {
+          /* ignore */
+        }
         throw new NexServerError(res.status, errorBody);
       }
 
-      return await res.json() as RegisterResponse;
+      return (await res.json()) as RegisterResponse;
     } finally {
       clearTimeout(timer);
     }

--- a/claude-code-plugin/src/rate-limiter.ts
+++ b/claude-code-plugin/src/rate-limiter.ts
@@ -7,7 +7,7 @@
  * timestamps to a JSON file so rate limits are respected across invocations.
  */
 
-import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { workspaceDataDir } from "./workspace-data-dir.js";
 
@@ -58,9 +58,7 @@ export class RateLimiter {
    */
   canProceed(): boolean {
     const now = Date.now();
-    const timestamps = this.readTimestamps().filter(
-      (t) => now - t < this.config.windowMs
-    );
+    const timestamps = this.readTimestamps().filter((t) => now - t < this.config.windowMs);
 
     if (timestamps.length >= this.config.maxRequests) {
       // Write back pruned timestamps

--- a/claude-code-plugin/src/recall-cache.ts
+++ b/claude-code-plugin/src/recall-cache.ts
@@ -108,14 +108,12 @@ export class RecallCache {
   private trimStore(store: Record<string, RecallSessionEntry>): void {
     const keys = Object.keys(store);
     while (keys.length > this.maxSize) {
-      delete store[keys.shift()!];
+      const oldest = keys.shift();
+      if (oldest !== undefined) delete store[oldest];
     }
   }
 
-  private pruneEmptyEntry(
-    store: Record<string, RecallSessionEntry>,
-    sessionKey: string,
-  ): void {
+  private pruneEmptyEntry(store: Record<string, RecallSessionEntry>, sessionKey: string): void {
     const entry = store[sessionKey];
     if (!entry) return;
     if (!entry.pending && !entry.ready) {
@@ -140,12 +138,7 @@ export class RecallCache {
     this.writeStore(store);
   }
 
-  hasPending(
-    sessionKey: string,
-    promptHash: string,
-    maxAgeMs: number,
-    now = Date.now(),
-  ): boolean {
+  hasPending(sessionKey: string, promptHash: string, maxAgeMs: number, now = Date.now()): boolean {
     const store = this.readStore();
     const current = store[sessionKey];
     const pending = current?.pending;

--- a/claude-code-plugin/src/recall-filter.ts
+++ b/claude-code-plugin/src/recall-filter.ts
@@ -12,7 +12,8 @@ const NATURAL_LANGUAGE_HINTS =
   /\b(please|can|could|would|should|what|when|where|why|how|who|tell|explain|describe|summarize|check|review|look|find|show|help|about|for|to|with|without|into|from|before|after|need|want|current|my|our|this|that)\b/i;
 const BARE_SHELL_COMMAND =
   /^(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)*(?:ls|pwd|cd|cat|grep|rg|find|mkdir|rm|cp|mv|touch|echo|git|npm|npx|yarn|pnpm|bun|node|python|python3|pytest|make|docker|kubectl|terraform)\b/i;
-const COMMAND_TOKEN = /^(?:[A-Za-z_][A-Za-z0-9_]*=\S+|--?[\w./:=@%+,~-]+|[\w./:=@%+,~-]+|["'][^"']*["'])$/;
+const COMMAND_TOKEN =
+  /^(?:[A-Za-z_][A-Za-z0-9_]*=\S+|--?[\w./:=@%+,~-]+|[\w./:=@%+,~-]+|["'][^"']*["'])$/;
 
 export interface RecallDecision {
   shouldRecall: boolean;

--- a/claude-code-plugin/src/session-store.ts
+++ b/claude-code-plugin/src/session-store.ts
@@ -6,7 +6,7 @@
  * session mappings to a JSON file so multi-turn continuity works.
  */
 
-import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { workspaceDataDir } from "./workspace-data-dir.js";
 
@@ -61,8 +61,8 @@ export class SessionStore {
     // Evict oldest entries if over max size
     const keys = Object.keys(store);
     while (keys.length > this.maxSize) {
-      const oldest = keys.shift()!;
-      delete store[oldest];
+      const oldest = keys.shift();
+      if (oldest !== undefined) delete store[oldest];
     }
 
     this.writeStore(store);

--- a/claude-code-plugin/src/workspace-data-dir.ts
+++ b/claude-code-plugin/src/workspace-data-dir.ts
@@ -6,8 +6,8 @@
  * Lightweight reader — no migration logic.
  */
 import { readFileSync } from "node:fs";
-import { join } from "node:path";
 import { homedir } from "node:os";
+import { join } from "node:path";
 
 const BASE_DIR = process.env.NEX_BASE_DIR || join(homedir(), ".nex");
 
@@ -22,7 +22,9 @@ export function workspaceDataDir(): string {
       _cached = join(BASE_DIR, "workspaces", config.active_workspace);
       return _cached;
     }
-  } catch { /* No config or parse error — fall back */ }
+  } catch {
+    /* No config or parse error — fall back */
+  }
   return BASE_DIR;
 }
 

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -6,7 +6,9 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "openclaw": {
-    "extensions": ["./dist/index.js"]
+    "extensions": [
+      "./dist/index.js"
+    ]
   },
   "scripts": {
     "build": "tsc",

--- a/openclaw-plugin/src/capture-filter.ts
+++ b/openclaw-plugin/src/capture-filter.ts
@@ -3,8 +3,8 @@
  * Cherry-picked from Supermemory (provider skip), Engram (dedup), MemOS Cloud (capture modes).
  */
 
-import { stripNexContext } from "./context-format.js";
 import type { NexPluginConfig } from "./config.js";
+import { stripNexContext } from "./context-format.js";
 
 /** Message shape from OpenClaw agent_end event. */
 export interface AgentMessage {
@@ -66,10 +66,7 @@ function isDuplicate(hash: string): boolean {
 function extractText(msg: AgentMessage): string {
   if (typeof msg.content === "string") return msg.content;
   if (Array.isArray(msg.content)) {
-    return msg.content
-      .filter((p) => p.type === "text" && p.text)
-      .map((p) => p.text!)
-      .join("\n");
+    return msg.content.flatMap((p) => (p.type === "text" && p.text ? [p.text] : [])).join("\n");
   }
   return "";
 }
@@ -91,7 +88,7 @@ export interface CaptureFilterSkip {
 export function captureFilter(
   messages: AgentMessage[],
   config: NexPluginConfig,
-  opts?: { messageProvider?: string; success?: boolean }
+  opts?: { messageProvider?: string; success?: boolean },
 ): CaptureFilterResult | CaptureFilterSkip {
   // Skip failed agent runs
   if (opts?.success === false) {

--- a/openclaw-plugin/src/config.ts
+++ b/openclaw-plugin/src/config.ts
@@ -54,25 +54,32 @@ export function parseConfig(raw?: Record<string, unknown>): NexPluginConfig {
   }
   if (!apiKey) {
     throw new ConfigError(
-      "No API key configured. Set 'apiKey' in plugin config or export NEX_API_KEY environment variable."
+      "No API key configured. Set 'apiKey' in plugin config or export NEX_API_KEY environment variable.",
     );
   }
 
-  let baseUrl = process.env.NEX_DEV_URL
-    ?? (typeof cfg.baseUrl === "string" ? resolveEnvVars(cfg.baseUrl).replace(/\/+$/, "") : undefined)
-    ?? DEFAULTS.baseUrl;
+  const baseUrl =
+    process.env.NEX_DEV_URL ??
+    (typeof cfg.baseUrl === "string"
+      ? resolveEnvVars(cfg.baseUrl).replace(/\/+$/, "")
+      : undefined) ??
+    DEFAULTS.baseUrl;
 
   const captureMode = cfg.captureMode as string | undefined;
   if (captureMode !== undefined && captureMode !== "last_turn" && captureMode !== "full_session") {
-    throw new ConfigError(`Invalid captureMode: "${captureMode}". Must be "last_turn" or "full_session".`);
+    throw new ConfigError(
+      `Invalid captureMode: "${captureMode}". Must be "last_turn" or "full_session".`,
+    );
   }
 
-  const maxRecallResults = typeof cfg.maxRecallResults === "number" ? cfg.maxRecallResults : DEFAULTS.maxRecallResults;
+  const maxRecallResults =
+    typeof cfg.maxRecallResults === "number" ? cfg.maxRecallResults : DEFAULTS.maxRecallResults;
   if (maxRecallResults < 1 || maxRecallResults > 20) {
     throw new ConfigError(`maxRecallResults must be between 1 and 20, got ${maxRecallResults}.`);
   }
 
-  const recallTimeoutMs = typeof cfg.recallTimeoutMs === "number" ? cfg.recallTimeoutMs : DEFAULTS.recallTimeoutMs;
+  const recallTimeoutMs =
+    typeof cfg.recallTimeoutMs === "number" ? cfg.recallTimeoutMs : DEFAULTS.recallTimeoutMs;
   if (recallTimeoutMs < 500 || recallTimeoutMs > 10000) {
     throw new ConfigError(`recallTimeoutMs must be between 500 and 10000, got ${recallTimeoutMs}.`);
   }
@@ -84,7 +91,8 @@ export function parseConfig(raw?: Record<string, unknown>): NexPluginConfig {
     autoCapture: typeof cfg.autoCapture === "boolean" ? cfg.autoCapture : DEFAULTS.autoCapture,
     captureMode: (captureMode as NexPluginConfig["captureMode"]) ?? DEFAULTS.captureMode,
     maxRecallResults,
-    sessionTracking: typeof cfg.sessionTracking === "boolean" ? cfg.sessionTracking : DEFAULTS.sessionTracking,
+    sessionTracking:
+      typeof cfg.sessionTracking === "boolean" ? cfg.sessionTracking : DEFAULTS.sessionTracking,
     recallTimeoutMs,
     debug: typeof cfg.debug === "boolean" ? cfg.debug : DEFAULTS.debug,
   };

--- a/openclaw-plugin/src/file-scanner.ts
+++ b/openclaw-plugin/src/file-scanner.ts
@@ -5,10 +5,11 @@
  */
 
 import { createHash } from "node:crypto";
-import { readFileSync, writeFileSync, mkdirSync, statSync, readdirSync } from "node:fs";
-import { join, extname, resolve, dirname } from "node:path";
+import type { Stats } from "node:fs";
+import { mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { NexClient, type IngestResponse } from "./nex-client.js";
+import { dirname, extname, join, resolve } from "node:path";
+import type { NexClient } from "./nex-client.js";
 
 // --- Types ---
 
@@ -34,16 +35,54 @@ export interface ScanResult {
 
 const MANIFEST_PATH = join(homedir(), ".nex", "file-scan-manifest.json");
 const DEFAULT_EXTENSIONS = [
-  ".md", ".txt", ".rtf", ".html", ".htm",
-  ".csv", ".tsv", ".json", ".yaml", ".yml", ".toml", ".xml",
-  ".js", ".ts", ".jsx", ".tsx", ".py", ".rb", ".go", ".rs", ".java",
-  ".sh", ".bash", ".zsh", ".fish",
-  ".org", ".rst", ".adoc", ".tex", ".log",
-  ".env", ".ini", ".cfg", ".conf", ".properties",
+  ".md",
+  ".txt",
+  ".rtf",
+  ".html",
+  ".htm",
+  ".csv",
+  ".tsv",
+  ".json",
+  ".yaml",
+  ".yml",
+  ".toml",
+  ".xml",
+  ".js",
+  ".ts",
+  ".jsx",
+  ".tsx",
+  ".py",
+  ".rb",
+  ".go",
+  ".rs",
+  ".java",
+  ".sh",
+  ".bash",
+  ".zsh",
+  ".fish",
+  ".org",
+  ".rst",
+  ".adoc",
+  ".tex",
+  ".log",
+  ".env",
+  ".ini",
+  ".cfg",
+  ".conf",
+  ".properties",
 ];
 const SKIP_DIRS = new Set([
-  "node_modules", ".git", "dist", "build", ".next", "__pycache__", ".venv",
-  ".cache", ".turbo", "coverage", ".nyc_output",
+  "node_modules",
+  ".git",
+  "dist",
+  "build",
+  ".next",
+  "__pycache__",
+  ".venv",
+  ".cache",
+  ".turbo",
+  "coverage",
+  ".nyc_output",
 ]);
 
 // --- Manifest ---
@@ -53,13 +92,15 @@ function loadManifest(): Manifest {
     const raw = readFileSync(MANIFEST_PATH, "utf-8");
     const data = JSON.parse(raw) as Manifest;
     if (data.version === 1 && typeof data.files === "object") return data;
-  } catch { /* missing or corrupt */ }
+  } catch {
+    /* missing or corrupt */
+  }
   return { version: 1, files: {} };
 }
 
 function saveManifest(manifest: Manifest): void {
   mkdirSync(dirname(MANIFEST_PATH), { recursive: true });
-  writeFileSync(MANIFEST_PATH, JSON.stringify(manifest, null, 2) + "\n", "utf-8");
+  writeFileSync(MANIFEST_PATH, `${JSON.stringify(manifest, null, 2)}\n`, "utf-8");
 }
 
 // --- Discovery ---
@@ -70,17 +111,30 @@ interface DiscoveredFile {
   mtime: number;
 }
 
-function discoverFiles(dir: string, extensions: Set<string>, maxDepth: number, depth = 0): DiscoveredFile[] {
+function discoverFiles(
+  dir: string,
+  extensions: Set<string>,
+  maxDepth: number,
+  depth = 0,
+): DiscoveredFile[] {
   if (depth > maxDepth) return [];
   const results: DiscoveredFile[] = [];
   let entries: string[];
-  try { entries = readdirSync(dir); } catch { return results; }
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return results;
+  }
 
   for (const entry of entries) {
     if (SKIP_DIRS.has(entry)) continue;
     const fullPath = join(dir, entry);
-    let stat;
-    try { stat = statSync(fullPath); } catch { continue; }
+    let stat: Stats;
+    try {
+      stat = statSync(fullPath);
+    } catch {
+      continue;
+    }
 
     if (stat.isDirectory()) {
       results.push(...discoverFiles(fullPath, extensions, maxDepth, depth + 1));
@@ -93,7 +147,7 @@ function discoverFiles(dir: string, extensions: Set<string>, maxDepth: number, d
 
 function hashFile(filePath: string): string {
   const content = readFileSync(filePath);
-  return "sha256-" + createHash("sha256").update(content).digest("hex");
+  return `sha256-${createHash("sha256").update(content).digest("hex")}`;
 }
 
 // --- Scanner ---
@@ -119,7 +173,7 @@ export async function scanFiles(
   discovered.sort((a, b) => b.mtime - a.mtime);
   const candidates = discovered.slice(0, maxFiles);
 
-  const manifest = force ? { version: 1, files: {} } as Manifest : loadManifest();
+  const manifest = force ? ({ version: 1, files: {} } as Manifest) : loadManifest();
   const result: ScanResult = { scanned: 0, skipped: 0, errors: 0, files: [] };
 
   for (const file of candidates) {
@@ -149,10 +203,18 @@ export async function scanFiles(
       };
 
       result.scanned++;
-      result.files.push({ path: file.path, status: "ingested", reason: existing ? "changed" : "new" });
+      result.files.push({
+        path: file.path,
+        status: "ingested",
+        reason: existing ? "changed" : "new",
+      });
     } catch (err) {
       result.errors++;
-      result.files.push({ path: file.path, status: "error", reason: err instanceof Error ? err.message : String(err) });
+      result.files.push({
+        path: file.path,
+        status: "error",
+        reason: err instanceof Error ? err.message : String(err),
+      });
     }
   }
 

--- a/openclaw-plugin/src/index.ts
+++ b/openclaw-plugin/src/index.ts
@@ -101,7 +101,7 @@ interface OpenClawPluginApi {
     handler: (
       event: BeforeAgentStartEvent,
       ctx: PluginHookAgentContext,
-    ) => Promise<{ prependContext?: string } | undefined> | { prependContext?: string } | undefined,
+    ) => Promise<{ prependContext?: string } | void> | { prependContext?: string } | void,
     opts?: { priority?: number },
   ): void;
 

--- a/openclaw-plugin/src/index.ts
+++ b/openclaw-plugin/src/index.ts
@@ -6,14 +6,14 @@
  * agent turn and auto-captures conversation facts after each turn.
  */
 
-import { Type, type Static } from "@sinclair/typebox";
-import { parseConfig, type NexPluginConfig } from "./config.js";
-import { NexClient, NexAuthError } from "./nex-client.js";
+import { type Static, Type } from "@sinclair/typebox";
+import { type AgentMessage, captureFilter } from "./capture-filter.js";
+import { type NexPluginConfig, parseConfig } from "./config.js";
+import { formatNexContext } from "./context-format.js";
+import { scanFiles as scanFilesUtil } from "./file-scanner.js";
+import { NexAuthError, NexClient } from "./nex-client.js";
 import { RateLimiter } from "./rate-limiter.js";
 import { SessionStore } from "./session-store.js";
-import { formatNexContext, stripNexContext } from "./context-format.js";
-import { captureFilter, type AgentMessage } from "./capture-filter.js";
-import { scanFiles as scanFilesUtil, type ScanResult } from "./file-scanner.js";
 
 // --- TypeBox schemas for tool parameters ---
 
@@ -23,7 +23,9 @@ const SearchParams = Type.Object({
 
 const RememberParams = Type.Object({
   content: Type.String({ description: "The information to remember" }),
-  label: Type.Optional(Type.String({ description: "Optional context label (e.g. 'meeting notes', 'preference')" })),
+  label: Type.Optional(
+    Type.String({ description: "Optional context label (e.g. 'meeting notes', 'preference')" }),
+  ),
 });
 
 const EntitiesParams = Type.Object({
@@ -32,10 +34,18 @@ const EntitiesParams = Type.Object({
 
 const ScanFilesParams = Type.Object({
   dir: Type.String({ description: "Directory path to scan for text files" }),
-  extensions: Type.Optional(Type.String({ description: "Comma-separated file extensions (default: .md,.txt,.csv,.json,.yaml,.yml)" })),
-  max_files: Type.Optional(Type.Number({ description: "Maximum files to scan per run (default: 5)" })),
+  extensions: Type.Optional(
+    Type.String({
+      description: "Comma-separated file extensions (default: .md,.txt,.csv,.json,.yaml,.yml)",
+    }),
+  ),
+  max_files: Type.Optional(
+    Type.Number({ description: "Maximum files to scan per run (default: 5)" }),
+  ),
   depth: Type.Optional(Type.Number({ description: "Maximum directory depth (default: 2)" })),
-  force: Type.Optional(Type.Boolean({ description: "Re-scan all files ignoring manifest (default: false)" })),
+  force: Type.Optional(
+    Type.Boolean({ description: "Re-scan all files ignoring manifest (default: false)" }),
+  ),
 });
 
 // --- Plugin Logger interface (matches OpenClaw's PluginLogger) ---
@@ -88,15 +98,17 @@ interface OpenClawPluginApi {
 
   on(
     hookName: "before_agent_start",
-    handler: (event: BeforeAgentStartEvent, ctx: PluginHookAgentContext) =>
-      Promise<{ prependContext?: string } | void> | { prependContext?: string } | void,
-    opts?: { priority?: number }
+    handler: (
+      event: BeforeAgentStartEvent,
+      ctx: PluginHookAgentContext,
+    ) => Promise<{ prependContext?: string } | undefined> | { prependContext?: string } | undefined,
+    opts?: { priority?: number },
   ): void;
 
   on(
     hookName: "agent_end",
     handler: (event: AgentEndEvent, ctx: PluginHookAgentContext) => Promise<void> | void,
-    opts?: { priority?: number }
+    opts?: { priority?: number },
   ): void;
 
   registerTool(tool: {
@@ -155,7 +167,11 @@ const plugin = {
       if (cfg.debug && log.debug) log.debug("[nex]", ...args);
     };
 
-    debug("Plugin config loaded", { baseUrl: cfg.baseUrl, autoRecall: cfg.autoRecall, autoCapture: cfg.autoCapture });
+    debug("Plugin config loaded", {
+      baseUrl: cfg.baseUrl,
+      autoRecall: cfg.autoRecall,
+      autoCapture: cfg.autoCapture,
+    });
 
     // --- Service (health check on start, cleanup on stop) ---
 
@@ -172,7 +188,9 @@ const plugin = {
           }
         } catch (err) {
           if (err instanceof NexAuthError) {
-            logger.error("Nex API key is invalid. Check your apiKey config or NEX_API_KEY env var.");
+            logger.error(
+              "Nex API key is invalid. Check your apiKey config or NEX_API_KEY env var.",
+            );
           } else {
             logger.warn("Could not reach Nex API:", err);
           }
@@ -201,13 +219,15 @@ const plugin = {
         async (event, ctx) => {
           if (!event.prompt) return;
 
-          debug("Auto-recall triggered", { sessionKey: ctx.sessionKey, promptLength: event.prompt.length });
+          debug("Auto-recall triggered", {
+            sessionKey: ctx.sessionKey,
+            promptLength: event.prompt.length,
+          });
 
           try {
             // Resolve session ID for multi-turn continuity
-            const nexSessionId = ctx.sessionKey && cfg.sessionTracking
-              ? sessions.get(ctx.sessionKey)
-              : undefined;
+            const nexSessionId =
+              ctx.sessionKey && cfg.sessionTracking ? sessions.get(ctx.sessionKey) : undefined;
 
             const result = await client.ask(event.prompt, nexSessionId, cfg.recallTimeoutMs);
 
@@ -263,16 +283,18 @@ const plugin = {
         debug("Capture enqueued", { textLength: result.text.length });
 
         // Fire-and-forget via rate limiter
-        rateLimiter.enqueue(async () => {
-          try {
-            const res = await client.ingest(result.text, "openclaw-conversation");
-            debug("Capture complete", { artifactId: res.artifact_id });
-          } catch (err) {
-            log.warn("Nex capture failed:", err);
-          }
-        }).catch(() => {
-          // Queue full / dropped — already logged by rate limiter
-        });
+        rateLimiter
+          .enqueue(async () => {
+            try {
+              const res = await client.ingest(result.text, "openclaw-conversation");
+              debug("Capture complete", { artifactId: res.artifact_id });
+            } catch (err) {
+              log.warn("Nex capture failed:", err);
+            }
+          })
+          .catch(() => {
+            // Queue full / dropped — already logged by rate limiter
+          });
       });
     }
 
@@ -347,11 +369,16 @@ const plugin = {
         }
 
         const lines = result.entity_references.map(
-          (ref) => `- ${ref.name} (${ref.type})${ref.count ? ` — ${ref.count} mentions` : ""}`
+          (ref) => `- ${ref.name} (${ref.type})${ref.count ? ` — ${ref.count} mentions` : ""}`,
         );
 
         return {
-          content: [{ type: "text", text: `Found ${result.entity_references.length} entities:\n${lines.join("\n")}` }],
+          content: [
+            {
+              type: "text",
+              text: `Found ${result.entity_references.length} entities:\n${lines.join("\n")}`,
+            },
+          ],
           details: { entities: result.entity_references },
         };
       },
@@ -364,11 +391,11 @@ const plugin = {
         "Scan a directory for text files (.md, .txt, .csv, .json, .yaml, .yml) and ingest new or changed files into the Nex knowledge base. Uses SHA-256 content hashing to skip already-ingested files.",
       parameters: ScanFilesParams,
       async execute(_toolCallId, params) {
-        const { dir, extensions, max_files, depth, force } = params as Static<typeof ScanFilesParams>;
+        const { dir, extensions, max_files, depth, force } = params as Static<
+          typeof ScanFilesParams
+        >;
 
-        const extList = extensions
-          ? extensions.split(",").map((e: string) => e.trim())
-          : undefined;
+        const extList = extensions ? extensions.split(",").map((e: string) => e.trim()) : undefined;
 
         const result = await scanFilesUtil(dir, client, {
           extensions: extList,
@@ -396,7 +423,8 @@ const plugin = {
     api.registerTool({
       name: "nex_list_integrations",
       label: "List Integrations",
-      description: "List available third-party integrations and their connection status. Calendar integrations (Google Calendar, Outlook Calendar) enable the Nex Meeting Bot which joins calls on any platform (Google Meet, Zoom, Webex, Teams, etc.) and feeds transcripts into the context graph.",
+      description:
+        "List available third-party integrations and their connection status. Calendar integrations (Google Calendar, Outlook Calendar) enable the Nex Meeting Bot which joins calls on any platform (Google Meet, Zoom, Webex, Teams, etc.) and feeds transcripts into the context graph.",
       parameters: ListIntegrationsParams,
       async execute(_toolCallId, _params) {
         const result = await client.get("/v1/integrations/");
@@ -409,18 +437,21 @@ const plugin = {
 
     const ConnectIntegrationParams = Type.Object({
       type: Type.String({ description: "Integration type: email, calendar, crm, messaging" }),
-      provider: Type.String({ description: "Provider: google, microsoft, attio, slack, salesforce, hubspot" }),
+      provider: Type.String({
+        description: "Provider: google, microsoft, attio, slack, salesforce, hubspot",
+      }),
     });
 
     api.registerTool({
       name: "nex_connect_integration",
       label: "Connect Integration",
-      description: "Start connecting a third-party integration via OAuth. Returns an auth_url for the user to open in their browser. Calendar integrations (type: 'calendar') enable the Nex Meeting Bot which auto-joins calls and processes transcripts. Types: email, calendar, crm, messaging. Providers: google, microsoft, attio, slack, salesforce, hubspot.",
+      description:
+        "Start connecting a third-party integration via OAuth. Returns an auth_url for the user to open in their browser. Calendar integrations (type: 'calendar') enable the Nex Meeting Bot which auto-joins calls and processes transcripts. Types: email, calendar, crm, messaging. Providers: google, microsoft, attio, slack, salesforce, hubspot.",
       parameters: ConnectIntegrationParams,
       async execute(_toolCallId, params) {
         const { type, provider } = params as Static<typeof ConnectIntegrationParams>;
         const result = await client.post(
-          `/v1/integrations/${encodeURIComponent(type)}/${encodeURIComponent(provider)}/connect`
+          `/v1/integrations/${encodeURIComponent(type)}/${encodeURIComponent(provider)}/connect`,
         );
         return {
           content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
@@ -436,12 +467,13 @@ const plugin = {
     api.registerTool({
       name: "nex_disconnect_integration",
       label: "Disconnect Integration",
-      description: "Disconnect a third-party integration by connection ID. Get connection IDs from nex_list_integrations.",
+      description:
+        "Disconnect a third-party integration by connection ID. Get connection IDs from nex_list_integrations.",
       parameters: DisconnectIntegrationParams,
       async execute(_toolCallId, params) {
         const { connection_id } = params as Static<typeof DisconnectIntegrationParams>;
         const result = await client.delete(
-          `/v1/integrations/connections/${encodeURIComponent(connection_id)}`
+          `/v1/integrations/connections/${encodeURIComponent(connection_id)}`,
         );
         return {
           content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
@@ -453,13 +485,16 @@ const plugin = {
     // --- Schema tools ---
 
     const ListObjectsParams = Type.Object({
-      include_attributes: Type.Optional(Type.Boolean({ description: "Include attribute definitions in the response" })),
+      include_attributes: Type.Optional(
+        Type.Boolean({ description: "Include attribute definitions in the response" }),
+      ),
     });
 
     api.registerTool({
       name: "nex_list_objects",
       label: "List Object Types",
-      description: "List all object type definitions in the workspace. Call this first to discover available object types and their schemas.",
+      description:
+        "List all object type definitions in the workspace. Call this first to discover available object types and their schemas.",
       parameters: ListObjectsParams,
       async execute(_toolCallId, params) {
         const { include_attributes } = params as Static<typeof ListObjectsParams>;
@@ -467,7 +502,10 @@ const plugin = {
         if (include_attributes) qs.set("include_attributes", "true");
         const q = qs.toString();
         const result = await client.get(`/v1/objects${q ? `?${q}` : ""}`);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
@@ -483,7 +521,10 @@ const plugin = {
       async execute(_toolCallId, params) {
         const { slug } = params as Static<typeof GetObjectParams>;
         const result = await client.get(`/v1/objects/${encodeURIComponent(slug)}`);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
@@ -492,7 +533,11 @@ const plugin = {
       slug: Type.String({ description: "URL-safe identifier (lowercase, hyphens)" }),
       name_plural: Type.Optional(Type.String({ description: "Plural display name" })),
       description: Type.Optional(Type.String({ description: "Description of the object type" })),
-      type: Type.Optional(Type.String({ description: "Object category: person, company, custom, deal (default: custom)" })),
+      type: Type.Optional(
+        Type.String({
+          description: "Object category: person, company, custom, deal (default: custom)",
+        }),
+      ),
     });
 
     api.registerTool({
@@ -501,13 +546,18 @@ const plugin = {
       description: "Create a new custom object type definition (e.g. 'Project', 'Deal').",
       parameters: CreateObjectParams,
       async execute(_toolCallId, params) {
-        const { name, slug, name_plural, description, type } = params as Static<typeof CreateObjectParams>;
+        const { name, slug, name_plural, description, type } = params as Static<
+          typeof CreateObjectParams
+        >;
         const body: Record<string, unknown> = { name, slug };
         if (name_plural !== undefined) body.name_plural = name_plural;
         if (description !== undefined) body.description = description;
         if (type !== undefined) body.type = type;
         const result = await client.post("/v1/objects", body);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
@@ -524,13 +574,18 @@ const plugin = {
       description: "Update an existing object type definition (name, description, plural name).",
       parameters: UpdateObjectParams,
       async execute(_toolCallId, params) {
-        const { slug, name, name_plural, description } = params as Static<typeof UpdateObjectParams>;
+        const { slug, name, name_plural, description } = params as Static<
+          typeof UpdateObjectParams
+        >;
         const body: Record<string, unknown> = {};
         if (name !== undefined) body.name = name;
         if (name_plural !== undefined) body.name_plural = name_plural;
         if (description !== undefined) body.description = description;
         const result = await client.patch(`/v1/objects/${encodeURIComponent(slug)}`, body);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
@@ -541,12 +596,16 @@ const plugin = {
     api.registerTool({
       name: "nex_delete_object",
       label: "Delete Object Type",
-      description: "Delete an object type definition and ALL its records. This is destructive and cannot be undone.",
+      description:
+        "Delete an object type definition and ALL its records. This is destructive and cannot be undone.",
       parameters: DeleteObjectParams,
       async execute(_toolCallId, params) {
         const { slug } = params as Static<typeof DeleteObjectParams>;
         const result = await client.delete(`/v1/objects/${encodeURIComponent(slug)}`);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
@@ -554,30 +613,44 @@ const plugin = {
       object_slug: Type.String({ description: "Object type slug to add the attribute to" }),
       name: Type.String({ description: "Display name for the attribute" }),
       slug: Type.String({ description: "URL-safe identifier for the attribute" }),
-      type: Type.String({ description: "Attribute data type: text, number, email, phone, url, date, boolean, currency, location, select, social_profile, domain, full_name" }),
+      type: Type.String({
+        description:
+          "Attribute data type: text, number, email, phone, url, date, boolean, currency, location, select, social_profile, domain, full_name",
+      }),
       description: Type.Optional(Type.String({ description: "Description of the attribute" })),
-      options: Type.Optional(Type.Object({
-        is_required: Type.Optional(Type.Boolean()),
-        is_unique: Type.Optional(Type.Boolean()),
-        is_multi_value: Type.Optional(Type.Boolean()),
-        use_raw_format: Type.Optional(Type.Boolean()),
-        is_whole_number: Type.Optional(Type.Boolean()),
-        select_options: Type.Optional(Type.Array(Type.Object({ name: Type.String() }))),
-      })),
+      options: Type.Optional(
+        Type.Object({
+          is_required: Type.Optional(Type.Boolean()),
+          is_unique: Type.Optional(Type.Boolean()),
+          is_multi_value: Type.Optional(Type.Boolean()),
+          use_raw_format: Type.Optional(Type.Boolean()),
+          is_whole_number: Type.Optional(Type.Boolean()),
+          select_options: Type.Optional(Type.Array(Type.Object({ name: Type.String() }))),
+        }),
+      ),
     });
 
     api.registerTool({
       name: "nex_create_attribute",
       label: "Create Attribute",
-      description: "Add a new attribute (field) to an object type. Supports types: text, number, email, phone, url, date, boolean, currency, location, select, social_profile, domain, full_name.",
+      description:
+        "Add a new attribute (field) to an object type. Supports types: text, number, email, phone, url, date, boolean, currency, location, select, social_profile, domain, full_name.",
       parameters: CreateAttributeParams,
       async execute(_toolCallId, params) {
-        const { object_slug, name, slug, type, description, options } = params as Static<typeof CreateAttributeParams>;
+        const { object_slug, name, slug, type, description, options } = params as Static<
+          typeof CreateAttributeParams
+        >;
         const body: Record<string, unknown> = { name, slug, type };
         if (description !== undefined) body.description = description;
         if (options) body.options = options;
-        const result = await client.post(`/v1/objects/${encodeURIComponent(object_slug)}/attributes`, body);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        const result = await client.post(
+          `/v1/objects/${encodeURIComponent(object_slug)}/attributes`,
+          body,
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
@@ -586,12 +659,14 @@ const plugin = {
       attribute_id: Type.String({ description: "Attribute ID to update" }),
       name: Type.Optional(Type.String({ description: "New display name" })),
       description: Type.Optional(Type.String({ description: "New description" })),
-      options: Type.Optional(Type.Object({
-        is_required: Type.Optional(Type.Boolean()),
-        select_options: Type.Optional(Type.Array(Type.Object({ name: Type.String() }))),
-        use_raw_format: Type.Optional(Type.Boolean()),
-        is_whole_number: Type.Optional(Type.Boolean()),
-      })),
+      options: Type.Optional(
+        Type.Object({
+          is_required: Type.Optional(Type.Boolean()),
+          select_options: Type.Optional(Type.Array(Type.Object({ name: Type.String() }))),
+          use_raw_format: Type.Optional(Type.Boolean()),
+          is_whole_number: Type.Optional(Type.Boolean()),
+        }),
+      ),
     });
 
     api.registerTool({
@@ -600,13 +675,21 @@ const plugin = {
       description: "Update an existing attribute definition on an object type.",
       parameters: UpdateAttributeParams,
       async execute(_toolCallId, params) {
-        const { object_slug, attribute_id, name, description, options } = params as Static<typeof UpdateAttributeParams>;
+        const { object_slug, attribute_id, name, description, options } = params as Static<
+          typeof UpdateAttributeParams
+        >;
         const body: Record<string, unknown> = {};
         if (name !== undefined) body.name = name;
         if (description !== undefined) body.description = description;
         if (options) body.options = options;
-        const result = await client.patch(`/v1/objects/${encodeURIComponent(object_slug)}/attributes/${encodeURIComponent(attribute_id)}`, body);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        const result = await client.patch(
+          `/v1/objects/${encodeURIComponent(object_slug)}/attributes/${encodeURIComponent(attribute_id)}`,
+          body,
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
@@ -618,12 +701,18 @@ const plugin = {
     api.registerTool({
       name: "nex_delete_attribute",
       label: "Delete Attribute",
-      description: "Delete an attribute from an object type. Removes the field and its data from all records. Cannot be undone.",
+      description:
+        "Delete an attribute from an object type. Removes the field and its data from all records. Cannot be undone.",
       parameters: DeleteAttributeParams,
       async execute(_toolCallId, params) {
         const { object_slug, attribute_id } = params as Static<typeof DeleteAttributeParams>;
-        const result = await client.delete(`/v1/objects/${encodeURIComponent(object_slug)}/attributes/${encodeURIComponent(attribute_id)}`);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        const result = await client.delete(
+          `/v1/objects/${encodeURIComponent(object_slug)}/attributes/${encodeURIComponent(attribute_id)}`,
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
@@ -631,67 +720,101 @@ const plugin = {
 
     const CreateRecordParams = Type.Object({
       object_slug: Type.String({ description: "Object type slug (e.g. 'person', 'company')" }),
-      attributes: Type.Record(Type.String(), Type.Unknown(), { description: "Record attributes — must include 'name'" }),
+      attributes: Type.Record(Type.String(), Type.Unknown(), {
+        description: "Record attributes — must include 'name'",
+      }),
     });
 
     api.registerTool({
       name: "nex_create_record",
       label: "Create Record",
-      description: "Create a new record for an object type. Use only when you have clean, structured data with known attribute slugs.",
+      description:
+        "Create a new record for an object type. Use only when you have clean, structured data with known attribute slugs.",
       parameters: CreateRecordParams,
       async execute(_toolCallId, params) {
         const { object_slug, attributes } = params as Static<typeof CreateRecordParams>;
-        const result = await client.post(`/v1/objects/${encodeURIComponent(object_slug)}`, { attributes });
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        const result = await client.post(`/v1/objects/${encodeURIComponent(object_slug)}`, {
+          attributes,
+        });
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
     const UpsertRecordParams = Type.Object({
       object_slug: Type.String({ description: "Object type slug (e.g. 'person', 'company')" }),
-      matching_attribute: Type.String({ description: "Attribute slug or ID to match on for dedup (e.g. 'email')" }),
-      attributes: Type.Record(Type.String(), Type.Unknown(), { description: "Record attributes — must include 'name' when creating" }),
+      matching_attribute: Type.String({
+        description: "Attribute slug or ID to match on for dedup (e.g. 'email')",
+      }),
+      attributes: Type.Record(Type.String(), Type.Unknown(), {
+        description: "Record attributes — must include 'name' when creating",
+      }),
     });
 
     api.registerTool({
       name: "nex_upsert_record",
       label: "Upsert Record",
-      description: "Create a record if it doesn't exist, or update it if a match is found on the specified attribute. Useful for deduplication.",
+      description:
+        "Create a record if it doesn't exist, or update it if a match is found on the specified attribute. Useful for deduplication.",
       parameters: UpsertRecordParams,
       async execute(_toolCallId, params) {
-        const { object_slug, matching_attribute, attributes } = params as Static<typeof UpsertRecordParams>;
-        const result = await client.put(`/v1/objects/${encodeURIComponent(object_slug)}`, { matching_attribute, attributes });
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        const { object_slug, matching_attribute, attributes } = params as Static<
+          typeof UpsertRecordParams
+        >;
+        const result = await client.put(`/v1/objects/${encodeURIComponent(object_slug)}`, {
+          matching_attribute,
+          attributes,
+        });
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
     const ListRecordsParams = Type.Object({
       object_slug: Type.String({ description: "Object type slug (e.g. 'person', 'company')" }),
-      attributes: Type.Optional(Type.Union([
-        Type.String({ description: "'all', 'primary', or 'none'" }),
-        Type.Record(Type.String(), Type.Unknown()),
-      ])),
+      attributes: Type.Optional(
+        Type.Union([
+          Type.String({ description: "'all', 'primary', or 'none'" }),
+          Type.Record(Type.String(), Type.Unknown()),
+        ]),
+      ),
       limit: Type.Optional(Type.Number({ description: "Number of records to return" })),
       offset: Type.Optional(Type.Number({ description: "Pagination offset" })),
-      sort: Type.Optional(Type.Object({
-        attribute: Type.String({ description: "Attribute slug to sort by" }),
-        direction: Type.String({ description: "Sort direction: asc or desc" }),
-      })),
+      sort: Type.Optional(
+        Type.Object({
+          attribute: Type.String({ description: "Attribute slug to sort by" }),
+          direction: Type.String({ description: "Sort direction: asc or desc" }),
+        }),
+      ),
     });
 
     api.registerTool({
       name: "nex_list_records",
       label: "List Records",
-      description: "List records for an object type with optional filtering, sorting, and pagination.",
+      description:
+        "List records for an object type with optional filtering, sorting, and pagination.",
       parameters: ListRecordsParams,
       async execute(_toolCallId, params) {
-        const { object_slug, attributes, limit, offset, sort } = params as Static<typeof ListRecordsParams>;
+        const { object_slug, attributes, limit, offset, sort } = params as Static<
+          typeof ListRecordsParams
+        >;
         const body: Record<string, unknown> = {};
         if (attributes !== undefined) body.attributes = attributes;
         if (limit !== undefined) body.limit = limit;
         if (offset !== undefined) body.offset = offset;
         if (sort) body.sort = sort;
-        const result = await client.post(`/v1/objects/${encodeURIComponent(object_slug)}/records`, body);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        const result = await client.post(
+          `/v1/objects/${encodeURIComponent(object_slug)}/records`,
+          body,
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
@@ -707,24 +830,35 @@ const plugin = {
       async execute(_toolCallId, params) {
         const { record_id } = params as Static<typeof GetRecordParams>;
         const result = await client.get(`/v1/records/${encodeURIComponent(record_id)}`);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
     const UpdateRecordParams = Type.Object({
       record_id: Type.String({ description: "Record ID to update" }),
-      attributes: Type.Record(Type.String(), Type.Unknown(), { description: "Attributes to update (only provided fields are changed)" }),
+      attributes: Type.Record(Type.String(), Type.Unknown(), {
+        description: "Attributes to update (only provided fields are changed)",
+      }),
     });
 
     api.registerTool({
       name: "nex_update_record",
       label: "Update Record",
-      description: "Update specific attributes on an existing record. Only the provided attributes are changed.",
+      description:
+        "Update specific attributes on an existing record. Only the provided attributes are changed.",
       parameters: UpdateRecordParams,
       async execute(_toolCallId, params) {
         const { record_id, attributes } = params as Static<typeof UpdateRecordParams>;
-        const result = await client.patch(`/v1/records/${encodeURIComponent(record_id)}`, { attributes });
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        const result = await client.patch(`/v1/records/${encodeURIComponent(record_id)}`, {
+          attributes,
+        });
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
@@ -740,20 +874,26 @@ const plugin = {
       async execute(_toolCallId, params) {
         const { record_id } = params as Static<typeof DeleteRecordParams>;
         const result = await client.delete(`/v1/records/${encodeURIComponent(record_id)}`);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
     const GetRecordTimelineParams = Type.Object({
       record_id: Type.String({ description: "Record ID" }),
       limit: Type.Optional(Type.Number({ description: "Max events (1-100, default: 50)" })),
-      cursor: Type.Optional(Type.String({ description: "Pagination cursor from previous response" })),
+      cursor: Type.Optional(
+        Type.String({ description: "Pagination cursor from previous response" }),
+      ),
     });
 
     api.registerTool({
       name: "nex_get_record_timeline",
       label: "Get Record Timeline",
-      description: "Get paginated timeline events for a record (tasks, notes, attribute changes, etc.).",
+      description:
+        "Get paginated timeline events for a record (tasks, notes, attribute changes, etc.).",
       parameters: GetRecordTimelineParams,
       async execute(_toolCallId, params) {
         const { record_id, limit, cursor } = params as Static<typeof GetRecordTimelineParams>;
@@ -761,8 +901,13 @@ const plugin = {
         if (limit !== undefined) qs.set("limit", String(limit));
         if (cursor) qs.set("cursor", cursor);
         const q = qs.toString();
-        const result = await client.get(`/v1/records/${encodeURIComponent(record_id)}/timeline${q ? `?${q}` : ""}`);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        const result = await client.get(
+          `/v1/records/${encodeURIComponent(record_id)}/timeline${q ? `?${q}` : ""}`,
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
@@ -775,12 +920,16 @@ const plugin = {
     api.registerTool({
       name: "nex_search_records",
       label: "Search Records",
-      description: "Search records by name across all object types. Returns matches grouped by object type with relevance scores.",
+      description:
+        "Search records by name across all object types. Returns matches grouped by object type with relevance scores.",
       parameters: SearchRecordsParams,
       async execute(_toolCallId, params) {
         const { query } = params as Static<typeof SearchRecordsParams>;
         const result = await client.post("/v1/search", { query });
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
@@ -795,30 +944,55 @@ const plugin = {
       parameters: ListRelationshipDefsParams,
       async execute(_toolCallId, _params) {
         const result = await client.get("/v1/relationships");
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
     const CreateRelationshipDefParams = Type.Object({
-      type: Type.String({ description: "Relationship cardinality: one_to_one, one_to_many, many_to_many" }),
+      type: Type.String({
+        description: "Relationship cardinality: one_to_one, one_to_many, many_to_many",
+      }),
       entity_definition_1_id: Type.String({ description: "First object definition ID" }),
       entity_definition_2_id: Type.String({ description: "Second object definition ID" }),
-      entity_1_to_2_predicate: Type.Optional(Type.String({ description: "Label for 1→2 direction (e.g. 'works at')" })),
-      entity_2_to_1_predicate: Type.Optional(Type.String({ description: "Label for 2→1 direction (e.g. 'employs')" })),
+      entity_1_to_2_predicate: Type.Optional(
+        Type.String({ description: "Label for 1→2 direction (e.g. 'works at')" }),
+      ),
+      entity_2_to_1_predicate: Type.Optional(
+        Type.String({ description: "Label for 2→1 direction (e.g. 'employs')" }),
+      ),
     });
 
     api.registerTool({
       name: "nex_create_relationship_def",
       label: "Create Relationship Definition",
-      description: "Define a new relationship type between two object types (e.g. person 'works at' company).",
+      description:
+        "Define a new relationship type between two object types (e.g. person 'works at' company).",
       parameters: CreateRelationshipDefParams,
       async execute(_toolCallId, params) {
-        const { type, entity_definition_1_id, entity_definition_2_id, entity_1_to_2_predicate, entity_2_to_1_predicate } = params as Static<typeof CreateRelationshipDefParams>;
-        const body: Record<string, unknown> = { type, entity_definition_1_id, entity_definition_2_id };
-        if (entity_1_to_2_predicate !== undefined) body.entity_1_to_2_predicate = entity_1_to_2_predicate;
-        if (entity_2_to_1_predicate !== undefined) body.entity_2_to_1_predicate = entity_2_to_1_predicate;
+        const {
+          type,
+          entity_definition_1_id,
+          entity_definition_2_id,
+          entity_1_to_2_predicate,
+          entity_2_to_1_predicate,
+        } = params as Static<typeof CreateRelationshipDefParams>;
+        const body: Record<string, unknown> = {
+          type,
+          entity_definition_1_id,
+          entity_definition_2_id,
+        };
+        if (entity_1_to_2_predicate !== undefined)
+          body.entity_1_to_2_predicate = entity_1_to_2_predicate;
+        if (entity_2_to_1_predicate !== undefined)
+          body.entity_2_to_1_predicate = entity_2_to_1_predicate;
         const result = await client.post("/v1/relationships", body);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
@@ -829,12 +1003,16 @@ const plugin = {
     api.registerTool({
       name: "nex_delete_relationship_def",
       label: "Delete Relationship Definition",
-      description: "Delete a relationship type definition. Removes all instances of this relationship. Cannot be undone.",
+      description:
+        "Delete a relationship type definition. Removes all instances of this relationship. Cannot be undone.",
       parameters: DeleteRelationshipDefParams,
       async execute(_toolCallId, params) {
         const { id } = params as Static<typeof DeleteRelationshipDefParams>;
         const result = await client.delete(`/v1/relationships/${encodeURIComponent(id)}`);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
@@ -851,13 +1029,21 @@ const plugin = {
       description: "Link two records using an existing relationship definition.",
       parameters: CreateRelationshipParams,
       async execute(_toolCallId, params) {
-        const { record_id, definition_id, entity_1_id, entity_2_id } = params as Static<typeof CreateRelationshipParams>;
-        const result = await client.post(`/v1/records/${encodeURIComponent(record_id)}/relationships`, {
-          definition_id,
-          entity_1_id,
-          entity_2_id,
-        });
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        const { record_id, definition_id, entity_1_id, entity_2_id } = params as Static<
+          typeof CreateRelationshipParams
+        >;
+        const result = await client.post(
+          `/v1/records/${encodeURIComponent(record_id)}/relationships`,
+          {
+            definition_id,
+            entity_1_id,
+            entity_2_id,
+          },
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
@@ -873,8 +1059,13 @@ const plugin = {
       parameters: DeleteRelationshipParams,
       async execute(_toolCallId, params) {
         const { record_id, relationship_id } = params as Static<typeof DeleteRelationshipParams>;
-        const result = await client.delete(`/v1/records/${encodeURIComponent(record_id)}/relationships/${encodeURIComponent(relationship_id)}`);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        const result = await client.delete(
+          `/v1/records/${encodeURIComponent(record_id)}/relationships/${encodeURIComponent(relationship_id)}`,
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
@@ -882,7 +1073,9 @@ const plugin = {
 
     const ListListsParams = Type.Object({
       object_slug: Type.String({ description: "Object type slug (e.g. 'person', 'company')" }),
-      include_attributes: Type.Optional(Type.Boolean({ description: "Include attribute definitions" })),
+      include_attributes: Type.Optional(
+        Type.Boolean({ description: "Include attribute definitions" }),
+      ),
     });
 
     api.registerTool({
@@ -895,8 +1088,13 @@ const plugin = {
         const qs = new URLSearchParams();
         if (include_attributes) qs.set("include_attributes", "true");
         const q = qs.toString();
-        const result = await client.get(`/v1/objects/${encodeURIComponent(object_slug)}/lists${q ? `?${q}` : ""}`);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        const result = await client.get(
+          `/v1/objects/${encodeURIComponent(object_slug)}/lists${q ? `?${q}` : ""}`,
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
@@ -914,12 +1112,20 @@ const plugin = {
       description: "Create a new list under an object type.",
       parameters: CreateListParams,
       async execute(_toolCallId, params) {
-        const { object_slug, name, slug, name_plural, description } = params as Static<typeof CreateListParams>;
+        const { object_slug, name, slug, name_plural, description } = params as Static<
+          typeof CreateListParams
+        >;
         const body: Record<string, unknown> = { name, slug };
         if (name_plural !== undefined) body.name_plural = name_plural;
         if (description !== undefined) body.description = description;
-        const result = await client.post(`/v1/objects/${encodeURIComponent(object_slug)}/lists`, body);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        const result = await client.post(
+          `/v1/objects/${encodeURIComponent(object_slug)}/lists`,
+          body,
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
@@ -935,7 +1141,10 @@ const plugin = {
       async execute(_toolCallId, params) {
         const { list_id } = params as Static<typeof GetListParams>;
         const result = await client.get(`/v1/lists/${encodeURIComponent(list_id)}`);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
@@ -951,14 +1160,21 @@ const plugin = {
       async execute(_toolCallId, params) {
         const { list_id } = params as Static<typeof DeleteListParams>;
         const result = await client.delete(`/v1/lists/${encodeURIComponent(list_id)}`);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
     const AddListMemberParams = Type.Object({
       list_id: Type.String({ description: "List ID" }),
       parent_id: Type.String({ description: "ID of the existing record to add" }),
-      attributes: Type.Optional(Type.Record(Type.String(), Type.Unknown(), { description: "List-specific attribute values" })),
+      attributes: Type.Optional(
+        Type.Record(Type.String(), Type.Unknown(), {
+          description: "List-specific attribute values",
+        }),
+      ),
     });
 
     api.registerTool({
@@ -971,42 +1187,57 @@ const plugin = {
         const body: Record<string, unknown> = { parent_id };
         if (attributes) body.attributes = attributes;
         const result = await client.post(`/v1/lists/${encodeURIComponent(list_id)}`, body);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
     const UpsertListMemberParams = Type.Object({
       list_id: Type.String({ description: "List ID" }),
       parent_id: Type.String({ description: "ID of the record" }),
-      attributes: Type.Optional(Type.Record(Type.String(), Type.Unknown(), { description: "List-specific attribute values" })),
+      attributes: Type.Optional(
+        Type.Record(Type.String(), Type.Unknown(), {
+          description: "List-specific attribute values",
+        }),
+      ),
     });
 
     api.registerTool({
       name: "nex_upsert_list_member",
       label: "Upsert List Member",
-      description: "Add a record to a list, or update its list-specific attributes if already a member.",
+      description:
+        "Add a record to a list, or update its list-specific attributes if already a member.",
       parameters: UpsertListMemberParams,
       async execute(_toolCallId, params) {
         const { list_id, parent_id, attributes } = params as Static<typeof UpsertListMemberParams>;
         const body: Record<string, unknown> = { parent_id };
         if (attributes) body.attributes = attributes;
         const result = await client.put(`/v1/lists/${encodeURIComponent(list_id)}`, body);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
     const ListListRecordsParams = Type.Object({
       list_id: Type.String({ description: "List ID" }),
-      attributes: Type.Optional(Type.Union([
-        Type.String({ description: "'all', 'primary', or 'none'" }),
-        Type.Record(Type.String(), Type.Unknown()),
-      ])),
+      attributes: Type.Optional(
+        Type.Union([
+          Type.String({ description: "'all', 'primary', or 'none'" }),
+          Type.Record(Type.String(), Type.Unknown()),
+        ]),
+      ),
       limit: Type.Optional(Type.Number({ description: "Number of records to return" })),
       offset: Type.Optional(Type.Number({ description: "Pagination offset" })),
-      sort: Type.Optional(Type.Object({
-        attribute: Type.String({ description: "Attribute slug to sort by" }),
-        direction: Type.String({ description: "Sort direction: asc or desc" }),
-      })),
+      sort: Type.Optional(
+        Type.Object({
+          attribute: Type.String({ description: "Attribute slug to sort by" }),
+          direction: Type.String({ description: "Sort direction: asc or desc" }),
+        }),
+      ),
     });
 
     api.registerTool({
@@ -1015,21 +1246,28 @@ const plugin = {
       description: "Get paginated records from a specific list.",
       parameters: ListListRecordsParams,
       async execute(_toolCallId, params) {
-        const { list_id, attributes, limit, offset, sort } = params as Static<typeof ListListRecordsParams>;
+        const { list_id, attributes, limit, offset, sort } = params as Static<
+          typeof ListListRecordsParams
+        >;
         const body: Record<string, unknown> = {};
         if (attributes !== undefined) body.attributes = attributes;
         if (limit !== undefined) body.limit = limit;
         if (offset !== undefined) body.offset = offset;
         if (sort) body.sort = sort;
         const result = await client.post(`/v1/lists/${encodeURIComponent(list_id)}/records`, body);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
     const UpdateListRecordParams = Type.Object({
       list_id: Type.String({ description: "List ID" }),
       record_id: Type.String({ description: "Record ID within the list" }),
-      attributes: Type.Record(Type.String(), Type.Unknown(), { description: "Attributes to update" }),
+      attributes: Type.Record(Type.String(), Type.Unknown(), {
+        description: "Attributes to update",
+      }),
     });
 
     api.registerTool({
@@ -1039,8 +1277,14 @@ const plugin = {
       parameters: UpdateListRecordParams,
       async execute(_toolCallId, params) {
         const { list_id, record_id, attributes } = params as Static<typeof UpdateListRecordParams>;
-        const result = await client.patch(`/v1/lists/${encodeURIComponent(list_id)}/records/${encodeURIComponent(record_id)}`, { attributes });
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        const result = await client.patch(
+          `/v1/lists/${encodeURIComponent(list_id)}/records/${encodeURIComponent(record_id)}`,
+          { attributes },
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
@@ -1056,8 +1300,13 @@ const plugin = {
       parameters: RemoveListRecordParams,
       async execute(_toolCallId, params) {
         const { list_id, record_id } = params as Static<typeof RemoveListRecordParams>;
-        const result = await client.delete(`/v1/lists/${encodeURIComponent(list_id)}/records/${encodeURIComponent(record_id)}`);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        const result = await client.delete(
+          `/v1/lists/${encodeURIComponent(list_id)}/records/${encodeURIComponent(record_id)}`,
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
@@ -1066,7 +1315,9 @@ const plugin = {
     const CreateTaskParams = Type.Object({
       title: Type.String({ description: "Task title" }),
       description: Type.Optional(Type.String({ description: "Task description" })),
-      priority: Type.Optional(Type.String({ description: "Task priority: low, medium, high, urgent" })),
+      priority: Type.Optional(
+        Type.String({ description: "Task priority: low, medium, high, urgent" }),
+      ),
       due_date: Type.Optional(Type.String({ description: "Due date in RFC3339 format" })),
       entity_ids: Type.Optional(Type.Array(Type.String({ description: "Record ID" }))),
       assignee_ids: Type.Optional(Type.Array(Type.String({ description: "User ID" }))),
@@ -1078,7 +1329,8 @@ const plugin = {
       description: "Create a new task, optionally linked to records and assigned to users.",
       parameters: CreateTaskParams,
       async execute(_toolCallId, params) {
-        const { title, description, priority, due_date, entity_ids, assignee_ids } = params as Static<typeof CreateTaskParams>;
+        const { title, description, priority, due_date, entity_ids, assignee_ids } =
+          params as Static<typeof CreateTaskParams>;
         const body: Record<string, unknown> = { title };
         if (description !== undefined) body.description = description;
         if (priority !== undefined) body.priority = priority;
@@ -1086,7 +1338,10 @@ const plugin = {
         if (entity_ids) body.entity_ids = entity_ids;
         if (assignee_ids) body.assignee_ids = assignee_ids;
         const result = await client.post("/v1/tasks", body);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
@@ -1102,10 +1357,13 @@ const plugin = {
     api.registerTool({
       name: "nex_list_tasks",
       label: "List Tasks",
-      description: "List tasks with optional filtering by record, assignee, completion status, or search query.",
+      description:
+        "List tasks with optional filtering by record, assignee, completion status, or search query.",
       parameters: ListTasksParams,
       async execute(_toolCallId, params) {
-        const { entity_id, assignee_id, search, is_completed, limit, offset } = params as Static<typeof ListTasksParams>;
+        const { entity_id, assignee_id, search, is_completed, limit, offset } = params as Static<
+          typeof ListTasksParams
+        >;
         const qs = new URLSearchParams();
         if (entity_id) qs.set("entity_id", entity_id);
         if (assignee_id) qs.set("assignee_id", assignee_id);
@@ -1115,7 +1373,10 @@ const plugin = {
         if (offset !== undefined) qs.set("offset", String(offset));
         const q = qs.toString();
         const result = await client.get(`/v1/tasks${q ? `?${q}` : ""}`);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
@@ -1131,7 +1392,10 @@ const plugin = {
       async execute(_toolCallId, params) {
         const { task_id } = params as Static<typeof GetTaskParams>;
         const result = await client.get(`/v1/tasks/${encodeURIComponent(task_id)}`);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
@@ -1149,10 +1413,20 @@ const plugin = {
     api.registerTool({
       name: "nex_update_task",
       label: "Update Task",
-      description: "Update a task's fields. All fields are optional — only provided fields are changed.",
+      description:
+        "Update a task's fields. All fields are optional — only provided fields are changed.",
       parameters: UpdateTaskParams,
       async execute(_toolCallId, params) {
-        const { task_id, title, description, priority, due_date, is_completed, entity_ids, assignee_ids } = params as Static<typeof UpdateTaskParams>;
+        const {
+          task_id,
+          title,
+          description,
+          priority,
+          due_date,
+          is_completed,
+          entity_ids,
+          assignee_ids,
+        } = params as Static<typeof UpdateTaskParams>;
         const body: Record<string, unknown> = {};
         if (title !== undefined) body.title = title;
         if (description !== undefined) body.description = description;
@@ -1162,7 +1436,10 @@ const plugin = {
         if (entity_ids !== undefined) body.entity_ids = entity_ids;
         if (assignee_ids !== undefined) body.assignee_ids = assignee_ids;
         const result = await client.patch(`/v1/tasks/${encodeURIComponent(task_id)}`, body);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
@@ -1178,7 +1455,10 @@ const plugin = {
       async execute(_toolCallId, params) {
         const { task_id } = params as Static<typeof DeleteTaskParams>;
         const result = await client.delete(`/v1/tasks/${encodeURIComponent(task_id)}`);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
@@ -1201,12 +1481,17 @@ const plugin = {
         if (content !== undefined) body.content = content;
         if (entity_id !== undefined) body.entity_id = entity_id;
         const result = await client.post("/v1/notes", body);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
     const ListNotesParams = Type.Object({
-      entity_id: Type.Optional(Type.String({ description: "Filter notes by associated record ID" })),
+      entity_id: Type.Optional(
+        Type.String({ description: "Filter notes by associated record ID" }),
+      ),
     });
 
     api.registerTool({
@@ -1220,7 +1505,10 @@ const plugin = {
         if (entity_id) qs.set("entity_id", entity_id);
         const q = qs.toString();
         const result = await client.get(`/v1/notes${q ? `?${q}` : ""}`);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
@@ -1236,7 +1524,10 @@ const plugin = {
       async execute(_toolCallId, params) {
         const { note_id } = params as Static<typeof GetNoteParams>;
         const result = await client.get(`/v1/notes/${encodeURIComponent(note_id)}`);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
@@ -1250,7 +1541,8 @@ const plugin = {
     api.registerTool({
       name: "nex_update_note",
       label: "Update Note",
-      description: "Update a note's fields. All fields are optional — only provided fields are changed.",
+      description:
+        "Update a note's fields. All fields are optional — only provided fields are changed.",
       parameters: UpdateNoteParams,
       async execute(_toolCallId, params) {
         const { note_id, title, content, entity_id } = params as Static<typeof UpdateNoteParams>;
@@ -1259,7 +1551,10 @@ const plugin = {
         if (content !== undefined) body.content = content;
         if (entity_id !== undefined) body.entity_id = entity_id;
         const result = await client.patch(`/v1/notes/${encodeURIComponent(note_id)}`, body);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
@@ -1275,30 +1570,41 @@ const plugin = {
       async execute(_toolCallId, params) {
         const { note_id } = params as Static<typeof DeleteNoteParams>;
         const result = await client.delete(`/v1/notes/${encodeURIComponent(note_id)}`);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
     // --- Context tools ---
 
     const GetArtifactStatusParams = Type.Object({
-      artifact_id: Type.String({ description: "The artifact ID returned by nex_remember or add_context" }),
+      artifact_id: Type.String({
+        description: "The artifact ID returned by nex_remember or add_context",
+      }),
     });
 
     api.registerTool({
       name: "nex_get_artifact_status",
       label: "Get Artifact Status",
-      description: "Check the processing status and results of a previously submitted text artifact. Poll until status is 'completed' or 'failed'.",
+      description:
+        "Check the processing status and results of a previously submitted text artifact. Poll until status is 'completed' or 'failed'.",
       parameters: GetArtifactStatusParams,
       async execute(_toolCallId, params) {
         const { artifact_id } = params as Static<typeof GetArtifactStatusParams>;
         const result = await client.get(`/v1/context/artifacts/${encodeURIComponent(artifact_id)}`);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
     const GetInsightsParams = Type.Object({
-      last: Type.Optional(Type.String({ description: "Duration window, e.g. '30m', '2h', '1h30m'" })),
+      last: Type.Optional(
+        Type.String({ description: "Duration window, e.g. '30m', '2h', '1h30m'" }),
+      ),
       from: Type.Optional(Type.String({ description: "Start of time range in RFC3339 format" })),
       to: Type.Optional(Type.String({ description: "End of time range in RFC3339 format" })),
       limit: Type.Optional(Type.Number({ description: "Max results (default: 20, max: 100)" })),
@@ -1307,7 +1613,8 @@ const plugin = {
     api.registerTool({
       name: "nex_get_insights",
       label: "Get Insights",
-      description: "Query insights by time window. Returns discovered opportunities, risks, relationship changes, milestones, and other insights.",
+      description:
+        "Query insights by time window. Returns discovered opportunities, risks, relationship changes, milestones, and other insights.",
       parameters: GetInsightsParams,
       async execute(_toolCallId, params) {
         const { last, from, to, limit } = params as Static<typeof GetInsightsParams>;
@@ -1318,7 +1625,10 @@ const plugin = {
         if (limit !== undefined) qs.set("limit", String(limit));
         const q = qs.toString();
         const result = await client.get(`/v1/insights${q ? `?${q}` : ""}`);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
       },
     });
 
@@ -1341,9 +1651,12 @@ const plugin = {
           if (result.entity_references && result.entity_references.length > 0) {
             const typeLabel = (t: string) => {
               switch (t) {
-                case "14": return "Person";
-                case "15": return "Company";
-                default: return "Entity";
+                case "14":
+                  return "Person";
+                case "15":
+                  return "Company";
+                default:
+                  return "Entity";
               }
             };
             // Deduplicate by name+type
@@ -1405,7 +1718,9 @@ const plugin = {
       },
     });
 
-    log.info(`Nex memory plugin registered (recall: ${cfg.autoRecall}, capture: ${cfg.autoCapture})`);
+    log.info(
+      `Nex memory plugin registered (recall: ${cfg.autoRecall}, capture: ${cfg.autoCapture})`,
+    );
   },
 };
 

--- a/openclaw-plugin/src/nex-client.ts
+++ b/openclaw-plugin/src/nex-client.ts
@@ -66,7 +66,7 @@ export class NexClient {
     method: string,
     path: string,
     body?: unknown,
-    timeoutMs = 10_000
+    timeoutMs = 10_000,
   ): Promise<T> {
     const url = `${this.baseUrl}/api/developers${path}`;
     const controller = new AbortController();

--- a/openclaw-plugin/src/rate-limiter.ts
+++ b/openclaw-plugin/src/rate-limiter.ts
@@ -39,7 +39,8 @@ export class RateLimiter {
 
       // LIFO eviction: if queue exceeds max depth, drop oldest (front)
       while (this.queue.length > this.config.maxQueueDepth) {
-        const dropped = this.queue.shift()!;
+        const dropped = this.queue.shift();
+        if (!dropped) break;
         dropped.reject(new Error("Rate limiter queue full — request dropped (LIFO eviction)"));
       }
 
@@ -67,7 +68,8 @@ export class RateLimiter {
     try {
       while (this.queue.length > 0) {
         if (this.canProceed()) {
-          const item = this.queue.shift()!;
+          const item = this.queue.shift();
+          if (!item) break;
           this.timestamps.push(Date.now());
           try {
             await item.fn();

--- a/openclaw-plugin/src/session-store.ts
+++ b/openclaw-plugin/src/session-store.ts
@@ -33,7 +33,8 @@ export class SessionStore {
 
     // LRU eviction
     while (this.map.size > this.maxSize) {
-      const oldest = this.map.keys().next().value!;
+      const oldest = this.map.keys().next().value;
+      if (oldest === undefined) break;
       this.map.delete(oldest);
     }
   }

--- a/openclaw-plugin/tests/index.test.ts
+++ b/openclaw-plugin/tests/index.test.ts
@@ -1,10 +1,10 @@
-import { describe, test, expect, beforeEach, afterEach, jest } from "bun:test";
-import { parseConfig, ConfigError } from "../src/config.ts";
-import { formatNexContext, stripNexContext, hasNexContext } from "../src/context-format.ts";
-import { captureFilter, resetDedupCache, type AgentMessage } from "../src/capture-filter.ts";
+import { afterEach, beforeEach, describe, expect, jest, test } from "bun:test";
+import { type AgentMessage, captureFilter, resetDedupCache } from "../src/capture-filter.ts";
+import { ConfigError, parseConfig } from "../src/config.ts";
+import { formatNexContext, hasNexContext, stripNexContext } from "../src/context-format.ts";
+import plugin from "../src/index.ts";
 import { RateLimiter } from "../src/rate-limiter.ts";
 import { SessionStore } from "../src/session-store.ts";
-import plugin from "../src/index.ts";
 
 // --- Config ---
 
@@ -33,15 +33,15 @@ describe("config", () => {
     expect(cfg.apiKey).toBe("sk-from-env");
   });
 
-  test("resolves ${VAR} syntax in apiKey", () => {
+  test("resolves env var placeholder syntax in apiKey", () => {
     process.env.MY_KEY = "sk-interpolated";
-    const cfg = parseConfig({ apiKey: "${MY_KEY}" });
+    const cfg = parseConfig({ apiKey: `\${MY_KEY}` });
     expect(cfg.apiKey).toBe("sk-interpolated");
   });
 
-  test("resolves ${VAR} syntax in baseUrl", () => {
+  test("resolves env var placeholder syntax in baseUrl", () => {
     process.env.MY_URL = "https://staging.nex.io";
-    const cfg = parseConfig({ apiKey: "sk-test", baseUrl: "${MY_URL}" });
+    const cfg = parseConfig({ apiKey: "sk-test", baseUrl: `\${MY_URL}` });
     expect(cfg.baseUrl).toBe("https://staging.nex.io");
   });
 
@@ -183,47 +183,35 @@ describe("capture-filter", () => {
   });
 
   test("skips failed agent runs", () => {
-    const result = captureFilter(
-      [{ role: "user", content: "hello world test" }],
-      defaultConfig,
-      { success: false },
-    );
+    const result = captureFilter([{ role: "user", content: "hello world test" }], defaultConfig, {
+      success: false,
+    });
     expect(result.skipped).toBe(true);
     if (result.skipped) expect(result.reason).toContain("failed");
   });
 
   test("skips exec-event provider", () => {
-    const result = captureFilter(
-      [{ role: "user", content: "hello world test" }],
-      defaultConfig,
-      { messageProvider: "exec-event" },
-    );
+    const result = captureFilter([{ role: "user", content: "hello world test" }], defaultConfig, {
+      messageProvider: "exec-event",
+    });
     expect(result.skipped).toBe(true);
   });
 
   test("skips cron-event provider", () => {
-    const result = captureFilter(
-      [{ role: "user", content: "hello world test" }],
-      defaultConfig,
-      { messageProvider: "cron-event" },
-    );
+    const result = captureFilter([{ role: "user", content: "hello world test" }], defaultConfig, {
+      messageProvider: "cron-event",
+    });
     expect(result.skipped).toBe(true);
   });
 
   test("skips slash commands", () => {
-    const result = captureFilter(
-      [{ role: "user", content: "/help me out please" }],
-      defaultConfig,
-    );
+    const result = captureFilter([{ role: "user", content: "/help me out please" }], defaultConfig);
     expect(result.skipped).toBe(true);
     if (result.skipped) expect(result.reason).toContain("slash command");
   });
 
   test("skips short messages", () => {
-    const result = captureFilter(
-      [{ role: "user", content: "hi" }],
-      defaultConfig,
-    );
+    const result = captureFilter([{ role: "user", content: "hi" }], defaultConfig);
     expect(result.skipped).toBe(true);
     if (result.skipped) expect(result.reason).toContain("short");
   });
@@ -280,9 +268,15 @@ describe("rate-limiter", () => {
     const limiter = new RateLimiter({ maxRequests: 3, windowMs: 1000, maxQueueDepth: 5 });
     const results: number[] = [];
 
-    const p1 = limiter.enqueue(async () => { results.push(1); });
-    const p2 = limiter.enqueue(async () => { results.push(2); });
-    const p3 = limiter.enqueue(async () => { results.push(3); });
+    const p1 = limiter.enqueue(async () => {
+      results.push(1);
+    });
+    const p2 = limiter.enqueue(async () => {
+      results.push(2);
+    });
+    const p3 = limiter.enqueue(async () => {
+      results.push(3);
+    });
 
     await Promise.all([p1, p2, p3]);
     expect(results).toEqual([1, 2, 3]);
@@ -293,9 +287,15 @@ describe("rate-limiter", () => {
     const limiter = new RateLimiter({ maxRequests: 2, windowMs: 1000, maxQueueDepth: 5 });
     const results: number[] = [];
 
-    const p1 = limiter.enqueue(async () => { results.push(1); });
-    const p2 = limiter.enqueue(async () => { results.push(2); });
-    const p3 = limiter.enqueue(async () => { results.push(3); });
+    const p1 = limiter.enqueue(async () => {
+      results.push(1);
+    });
+    const p2 = limiter.enqueue(async () => {
+      results.push(2);
+    });
+    const p3 = limiter.enqueue(async () => {
+      results.push(3);
+    });
 
     // First two execute immediately
     await p1;
@@ -314,13 +314,27 @@ describe("rate-limiter", () => {
     const results: number[] = [];
     const errors: string[] = [];
 
-    const p1 = limiter.enqueue(async () => { results.push(1); }); // executes immediately
+    const p1 = limiter.enqueue(async () => {
+      results.push(1);
+    }); // executes immediately
     await p1;
 
     // These 3 queue up, but max depth is 2 — oldest gets evicted
-    const p2 = limiter.enqueue(async () => { results.push(2); }).catch((e) => errors.push(e.message));
-    const p3 = limiter.enqueue(async () => { results.push(3); }).catch((e) => errors.push(e.message));
-    const p4 = limiter.enqueue(async () => { results.push(4); }).catch((e) => errors.push(e.message));
+    const _p2 = limiter
+      .enqueue(async () => {
+        results.push(2);
+      })
+      .catch((e) => errors.push(e.message));
+    const _p3 = limiter
+      .enqueue(async () => {
+        results.push(3);
+      })
+      .catch((e) => errors.push(e.message));
+    const _p4 = limiter
+      .enqueue(async () => {
+        results.push(4);
+      })
+      .catch((e) => errors.push(e.message));
 
     // Let eviction happen — need a microtask tick for async queue processing
     await new Promise((r) => process.nextTick(r));

--- a/openclaw-plugin/tests/live-test.mjs
+++ b/openclaw-plugin/tests/live-test.mjs
@@ -6,12 +6,12 @@
  * Requires: mock-nex-server.mjs running on port 31999
  */
 
+import { captureFilter, resetDedupCache } from "../dist/capture-filter.js";
+import { parseConfig } from "../dist/config.js";
+import { formatNexContext, stripNexContext } from "../dist/context-format.js";
 import { NexClient } from "../dist/nex-client.js";
 import { RateLimiter } from "../dist/rate-limiter.js";
 import { SessionStore } from "../dist/session-store.js";
-import { formatNexContext, stripNexContext } from "../dist/context-format.js";
-import { captureFilter, resetDedupCache } from "../dist/capture-filter.js";
-import { parseConfig } from "../dist/config.js";
 
 const BASE_URL = "http://localhost:31999";
 const API_KEY = "sk-test-mock-key";
@@ -43,7 +43,10 @@ async function main() {
   const ingest1 = await client.ingest("My favorite color is blue and I love TypeScript");
   assert(ingest1.artifact_id, `ingest returned artifact_id: ${ingest1.artifact_id}`);
 
-  const ingest2 = await client.ingest("Sarah Johnson is VP of Engineering at Acme Corp", "meeting-notes");
+  const ingest2 = await client.ingest(
+    "Sarah Johnson is VP of Engineering at Acme Corp",
+    "meeting-notes",
+  );
   assert(ingest2.artifact_id, `ingest with context returned artifact_id: ${ingest2.artifact_id}`);
 
   console.log("\n=== Test 3: Recall via /ask ===");
@@ -58,8 +61,14 @@ async function main() {
 
   const ask2 = await client.ask("Tell me about Sarah", storedSession);
   assert(ask2.answer.includes("Sarah Johnson"), `recall with session found 'Sarah Johnson'`);
-  assert(ask2.entity_references.length > 0, `recall returned ${ask2.entity_references.length} entity references`);
-  assert(ask2.entity_references[0].name === "Sarah Johnson", `entity ref name: ${ask2.entity_references[0].name}`);
+  assert(
+    ask2.entity_references.length > 0,
+    `recall returned ${ask2.entity_references.length} entity references`,
+  );
+  assert(
+    ask2.entity_references[0].name === "Sarah Johnson",
+    `entity ref name: ${ask2.entity_references[0].name}`,
+  );
 
   console.log("\n=== Test 5: Context Formatting ===");
   const context = formatNexContext({
@@ -116,7 +125,7 @@ async function main() {
       limiter.enqueue(async () => {
         await client.ingest(`Rate limit test message ${i}`);
         ingestCount++;
-      })
+      }),
     );
   }
   await Promise.all(promises);
@@ -133,7 +142,10 @@ async function main() {
 
   console.log("\n=== Test 9: No Match Recall ===");
   const noMatch = await client.ask("quantum physics theories");
-  assert(noMatch.answer.includes("don't have specific information"), "no-match returns graceful message");
+  assert(
+    noMatch.answer.includes("don't have specific information"),
+    "no-match returns graceful message",
+  );
   assert(noMatch.entity_references.length === 0, "no-match returns empty entity refs");
 
   // Cleanup

--- a/openclaw-plugin/tests/mock-nex-server.mjs
+++ b/openclaw-plugin/tests/mock-nex-server.mjs
@@ -24,8 +24,11 @@ function readBody(req) {
     const chunks = [];
     req.on("data", (c) => chunks.push(c));
     req.on("end", () => {
-      try { resolve(JSON.parse(Buffer.concat(chunks).toString())); }
-      catch { resolve(null); }
+      try {
+        resolve(JSON.parse(Buffer.concat(chunks).toString()));
+      } catch {
+        resolve(null);
+      }
     });
   });
 }
@@ -48,7 +51,9 @@ const server = http.createServer(async (req, res) => {
     }
     const id = ++artifactCounter;
     memories.push({ id, content: body.content, context: body.context, ts: Date.now() });
-    console.log(`[ingest] artifact_id=${id} content="${body.content.slice(0, 80)}..." (${memories.length} total)`);
+    console.log(
+      `[ingest] artifact_id=${id} content="${body.content.slice(0, 80)}..." (${memories.length} total)`,
+    );
     return json(res, 200, { artifact_id: id });
   }
 
@@ -63,9 +68,10 @@ const server = http.createServer(async (req, res) => {
     console.log(`[recall] query="${body.query}" session_id=${body.session_id || "new"}`);
 
     // Search memories for matches
-    const matches = memories.filter((m) =>
-      m.content.toLowerCase().includes(query) ||
-      query.split(" ").some((w) => w.length > 3 && m.content.toLowerCase().includes(w))
+    const matches = memories.filter(
+      (m) =>
+        m.content.toLowerCase().includes(query) ||
+        query.split(" ").some((w) => w.length > 3 && m.content.toLowerCase().includes(w)),
     );
 
     const sessionId = body.session_id || `session-${++sessionCounter}`;
@@ -78,8 +84,7 @@ const server = http.createServer(async (req, res) => {
       // Extract simple entity references from matched content
       const namePattern = /(?:^|\s)([A-Z][a-z]+ [A-Z][a-z]+)/g;
       for (const m of matches) {
-        let match;
-        while ((match = namePattern.exec(m.content)) !== null) {
+        for (const match of m.content.matchAll(namePattern)) {
           entityRefs.push({ name: match[1].trim(), type: "person", count: 1 });
         }
       }
@@ -102,7 +107,9 @@ const server = http.createServer(async (req, res) => {
 server.listen(PORT, () => {
   console.log(`Mock Nex API running on http://localhost:${PORT}`);
   console.log(`Auth key: ${VALID_KEY}`);
-  console.log(`Endpoints: POST /api/developers/v1/context/text, POST /api/developers/v1/context/ask`);
+  console.log(
+    `Endpoints: POST /api/developers/v1/context/text, POST /api/developers/v1/context/ask`,
+  );
   console.log(`Memories stored: ${memories.length}`);
   console.log("---");
 });

--- a/platform-plugins/continue-provider.ts
+++ b/platform-plugins/continue-provider.ts
@@ -10,8 +10,8 @@
  */
 
 import { readFileSync } from "node:fs";
-import { join } from "node:path";
 import { homedir } from "node:os";
+import { join } from "node:path";
 
 function loadApiKey(): string | null {
   try {

--- a/platform-plugins/opencode-plugin.ts
+++ b/platform-plugins/opencode-plugin.ts
@@ -10,8 +10,8 @@
  */
 
 import { readFileSync } from "node:fs";
-import { join } from "node:path";
 import { homedir } from "node:os";
+import { join } from "node:path";
 
 // Read API key from shared Nex config
 function loadApiKey(): string | null {
@@ -36,7 +36,7 @@ async function nexAsk(query: string, apiKey: string): Promise<string> {
     signal: AbortSignal.timeout(10_000),
   });
   if (!res.ok) return "";
-  const data = await res.json() as { answer?: string };
+  const data = (await res.json()) as { answer?: string };
   return data.answer ?? "";
 }
 
@@ -88,7 +88,7 @@ export default {
     if (!apiKey) return;
 
     // Capture last assistant message
-    const messages = (_input as any)?.messages;
+    const messages = _input.messages;
     if (!Array.isArray(messages)) return;
 
     const lastAssistant = [...messages].reverse().find((m) => m.role === "assistant");

--- a/platform-plugins/opencode-plugin.ts
+++ b/platform-plugins/opencode-plugin.ts
@@ -87,8 +87,9 @@ export default {
     const apiKey = loadApiKey();
     if (!apiKey) return;
 
-    // Capture last assistant message
-    const messages = _input.messages;
+    // Capture last assistant message. Use optional chaining in case the
+    // host passes a nullish payload — we prefer silent no-op over a throw.
+    const messages = _input?.messages;
     if (!Array.isArray(messages)) return;
 
     const lastAssistant = [...messages].reverse().find((m) => m.role === "assistant");


### PR DESCRIPTION
## Summary
- Apply biome check + format auto-fixes across the TS codebase
- Manually fix all errors and warnings biome surfaced

## Fixes
| Rule | Count | Fix |
|---|---|---|
| noImplicitAnyLet | 7 | Explicit `NexConfig` / `Dirent` / `Stats` types on `let` decls |
| noAssignInExpressions | 1 | Use `matchAll()` instead of `exec()` in while loop |
| noNonNullAssertion | 6 | Guard `shift()` / `next().value` results with undefined checks |
| noExplicitAny | 1 | Drop redundant `as any` cast in opencode-plugin |
| noTemplateCurlyInString | 4 | Escape template syntax (\`\\\${...}\`) + rephrase test descriptions |

## Test plan
- [x] `bunx biome check .` is clean (0 errors, 0 warnings)
- [x] `bunx tsc --noEmit` passes in both claude-code-plugin and openclaw-plugin (pre-existing `@types/node` errors on main unaffected)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved defensive handling for edge cases in queue and cache eviction logic to prevent potential runtime errors.
  * Enhanced property access safety in plugin operations with optional chaining.

* **Chores**
  * Strengthened type safety throughout codebase with explicit type annotations.
  * Reorganized module imports for consistency.
  * Standardized code formatting across files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->