### PR TITLE
fix(ci): break publish-cli bump-PR self-trigger loop

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -4,11 +4,15 @@ on:
   push:
     branches: [main]
     paths:
+      # Do not add package.json here: the "Open version bump PR" step below
+      # touches only package.json, so including it would make every bump PR
+      # merge re-trigger this job and open another bump PR indefinitely.
+      # Manual bumps can publish via workflow_dispatch.
       - "bin/**"
       - "plugin-commands/**"
       - "platform-rules/**"
       - "platform-plugins/**"
-      - "package.json"
+  workflow_dispatch:
 
 concurrency:
   group: publish-cli

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -7,7 +7,10 @@ on:
       # Do not add package.json here: the "Open version bump PR" step below
       # touches only package.json, so including it would make every bump PR
       # merge re-trigger this job and open another bump PR indefinitely.
-      # Manual bumps can publish via workflow_dispatch.
+      #
+      # Consequence: a PR that ONLY changes package.json (e.g. a manual
+      # 0.3.0 minor bump) will not auto-publish on merge. Trigger this
+      # workflow via the Actions tab (workflow_dispatch) after merge.
       - "bin/**"
       - "plugin-commands/**"
       - "platform-rules/**"

--- a/.github/workflows/sync-release.yml
+++ b/.github/workflows/sync-release.yml
@@ -247,6 +247,10 @@ jobs:
             echo "published=true" >> "$GITHUB_OUTPUT"
           fi
 
+      # If a `push` trigger is ever added to this workflow, exclude
+      # package.json from its paths filter — this step opens a bump PR
+      # that only touches package.json, which would self-trigger the
+      # workflow otherwise. See publish-cli.yml for the same guardrail.
       - name: Open version bump PR
         if: steps.npm.outputs.published == 'true'
         env:


### PR DESCRIPTION
## Summary

`publish-cli.yml` listed `package.json` in its push path filter. The workflow's final step opens a bump PR that touches only `package.json` — so merging a bump PR re-triggered the workflow, which saw `local == published` (bumped to match npm), hit `localNum <= pubNum` in `NEEDS_BUMP`, bumped to the next patch, published, and opened another bump PR.

That's what drove the recent chain: [#118](https://github.com/nex-crm/nex-as-a-skill/pull/118) → [#122](https://github.com/nex-crm/nex-as-a-skill/pull/122) → [#123](https://github.com/nex-crm/nex-as-a-skill/pull/123) → [#124](https://github.com/nex-crm/nex-as-a-skill/pull/124).

### Fix
- Drop `package.json` from the path filter. Bump-only merges are now inert.
- Add `workflow_dispatch` so manual version bumps still have a way to kick off a publish.

The `NEEDS_BUMP` `<=` comparison is unchanged on purpose — with `package.json` out of the trigger, the only inputs that fire the workflow are real code changes (`bin/**`, `plugin-commands/**`, `platform-rules/**`, `platform-plugins/**`), where we do want `local == published` to bump.

### Merge order
Once this merges, [#124](https://github.com/nex-crm/nex-as-a-skill/pull/124) (the current live bump PR) can merge cleanly — its push will no longer trigger `publish-cli`, so the loop ends.

## Test plan
- [x] YAML parses (`js-yaml` round-trip)
- [x] Lefthook pre-push `test` script (node --check shims) passes
- [ ] After merge: confirm merging #124 does **not** kick off a new `publish-cli` run
- [ ] After merge: confirm the next real code-change PR still triggers a publish + bump PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)