### PR TITLE
ci(secret-scan): replace bash-regex with secretlint

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -66,27 +66,36 @@ jobs:
           PR_BASE_REF: ${{ github.base_ref }}
         run: |
           set -euo pipefail
-          # Exclude binaries + lockfiles that tend to produce false positives.
-          EXCLUDE='(bun\.lock|package-lock\.json|\.png$|\.jpg$|\.jpeg$|\.gif$|\.ico$|\.woff2?$|\.ttf$|\.eot$|\.svg$|\.pdf$)'
+          # Exclude binaries + lockfiles. Bare filenames anchored with
+          # `(^|/)...$` so `docs/bun.lock.md` or `tools/package-lock.json.bak`
+          # aren't silently skipped.
+          EXCLUDE='((^|/)(bun\.lock|package-lock\.json)$|\.(png|jpe?g|gif|ico|woff2?|ttf|eot|svg|pdf)$)'
 
+          # NUL-delimited pipeline end-to-end — filenames with spaces /
+          # quotes / backslashes don't get split by xargs downstream.
           if [ "$EVENT_NAME" = "pull_request" ]; then
-            files=$(git diff --name-only --diff-filter=ACMR "origin/${PR_BASE_REF}...HEAD")
+            git diff -z --name-only --diff-filter=ACMR "origin/${PR_BASE_REF}...HEAD" > /tmp/raw-files.z
           elif git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
-            files=$(git diff --name-only --diff-filter=ACMR HEAD~1..HEAD)
+            git diff -z --name-only --diff-filter=ACMR HEAD~1..HEAD > /tmp/raw-files.z
           else
-            files=$(git ls-files)
+            git ls-files -z > /tmp/raw-files.z
           fi
 
-          files=$(echo "$files" | grep -v -E "$EXCLUDE" || true)
+          # Guard EXCLUDE: empty regex would match-all and silently skip
+          # the scan. `|| true` absorbs the "no matches" legit case.
+          if [ -n "$EXCLUDE" ]; then
+            tr '\0' '\n' < /tmp/raw-files.z | grep -v -E "$EXCLUDE" | tr '\n' '\0' > /tmp/changed-files.z || true
+          else
+            cp /tmp/raw-files.z /tmp/changed-files.z
+          fi
 
-          if [ -z "$files" ]; then
+          if [ ! -s /tmp/changed-files.z ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
-            echo "$files" > /tmp/changed-files.txt
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run secretlint
         if: steps.changed.outputs.skip != 'true'
         shell: bash
-        run: cat /tmp/changed-files.txt | xargs node_modules/.bin/secretlint
+        run: xargs -0 -r -a /tmp/changed-files.z node_modules/.bin/secretlint

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,71 +1,92 @@
 name: Secret Scan
 
+# Secretlint scan on PR-changed files (plus post-push diff on main).
+# Replaces the prior bash-regex approach, which hand-maintained ~10
+# token-shape patterns. secretlint's preset-recommend covers AWS,
+# GitHub, Slack, GCP, Linear, npm, Stripe, 1Password, Anthropic,
+# database connection strings, JWTs, and more — all maintained upstream.
+#
+# Inlined (rather than calling nex-crm/.github's reusable) because
+# nex-as-a-skill is a public repo and cannot consume reusable workflows
+# hosted in the private nex-crm/.github repo — GitHub Actions silently
+# fails resolution regardless of access_level: organization.
+# Source of truth: https://github.com/nex-crm/.github/blob/main/.github/workflows/scan-secrets.yml
+
 on:
   pull_request:
   push:
     branches: [main]
 
+concurrency:
+  group: secret-scan-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  secret-scan:
+  scan:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      # Pin to full SHA: third-party action runs on every PR.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
-      - name: Scan for secrets in diff
+      - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
+        with:
+          bun-version: "1"
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.2.3
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-${{ runner.os }}-
+
+      # `--ignore-scripts`: defense against malicious postinstall from a
+      # dep in the tree. secretlint doesn't need a build step.
+      - name: Install deps
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      - name: Verify secretlint is installed
+        shell: bash
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            DIFF=$(git diff origin/${{ github.base_ref }}...HEAD)
-          else
-            if git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
-              DIFF=$(git diff HEAD~1..HEAD)
-            else
-              DIFF=$(git diff $(git hash-object -t tree /dev/null)..HEAD)
-            fi
-          fi
-
-          PATTERNS=(
-            'AKIA[0-9A-Z]{16}'                                    # AWS Access Key ID
-            '(aws_secret_access_key|AWS_SECRET)[=:]\s*[^\s]{20,}' # AWS Secret Key (in config context)
-            'sk-[a-zA-Z0-9]{20,}'                                 # OpenAI / Anthropic / Nex API key
-            'ghp_[a-zA-Z0-9]{36}'                                 # GitHub personal access token
-            'gho_[a-zA-Z0-9]{36}'                                 # GitHub OAuth token
-            'ghs_[a-zA-Z0-9]{36}'                                 # GitHub server token
-            'ghr_[a-zA-Z0-9]{36}'                                 # GitHub refresh token
-            'github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}'          # GitHub fine-grained PAT
-            'xox[boaprs]-[0-9a-zA-Z-]{10,}'                       # Slack token
-            'sk_live_[a-zA-Z0-9]{24,}'                             # Stripe secret key
-            'rk_live_[a-zA-Z0-9]{24,}'                             # Stripe restricted key
-            'SG\.[a-zA-Z0-9_-]{22}\.[a-zA-Z0-9_-]{43}'            # SendGrid API key
-            '-----BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----' # Private keys
-          )
-
-          # Load allowlist if it exists
-          ALLOWLIST_FILE=".secret-scan-allowlist"
-
-          FOUND=0
-          for pattern in "${PATTERNS[@]}"; do
-            # Only scan added lines (starting with +), skip file headers
-            MATCHES=$(echo "$DIFF" | grep -E '^\+[^+]' | grep -oE "$pattern" || true)
-
-            # Filter out allowlisted patterns
-            if [ -n "$MATCHES" ] && [ -f "$ALLOWLIST_FILE" ]; then
-              MATCHES=$(echo "$MATCHES" | grep -vFf "$ALLOWLIST_FILE" || true)
-            fi
-
-            if [ -n "$MATCHES" ]; then
-              echo "::error::Potential secret found matching pattern: $pattern"
-              echo "$MATCHES" | head -3 | sed 's/./*/g'  # mask the actual value
-              FOUND=1
-            fi
-          done
-
-          if [ "$FOUND" -eq 1 ]; then
-            echo ""
-            echo "::error::Secrets detected in the diff. Remove them before merging."
-            echo "If these are false positives, add them to .secret-scan-allowlist (one pattern per line)."
+          set -euo pipefail
+          if [ ! -x node_modules/.bin/secretlint ]; then
+            echo "::error::secretlint is not in this repo's devDependencies."
             exit 1
           fi
 
-          echo "No secrets found."
+      - name: Determine changed files
+        id: changed
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          # Exclude binaries + lockfiles that tend to produce false positives.
+          EXCLUDE='(bun\.lock|package-lock\.json|\.png$|\.jpg$|\.jpeg$|\.gif$|\.ico$|\.woff2?$|\.ttf$|\.eot$|\.svg$|\.pdf$)'
+
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            files=$(git diff --name-only --diff-filter=ACMR "origin/${PR_BASE_REF}...HEAD")
+          elif git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
+            files=$(git diff --name-only --diff-filter=ACMR HEAD~1..HEAD)
+          else
+            files=$(git ls-files)
+          fi
+
+          files=$(echo "$files" | grep -v -E "$EXCLUDE" || true)
+
+          if [ -z "$files" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "$files" > /tmp/changed-files.txt
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run secretlint
+        if: steps.changed.outputs.skip != 'true'
+        shell: bash
+        run: cat /tmp/changed-files.txt | xargs node_modules/.bin/secretlint

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -11,6 +11,12 @@ name: Secret Scan
 # hosted in the private nex-crm/.github repo — GitHub Actions silently
 # fails resolution regardless of access_level: organization.
 # Source of truth: https://github.com/nex-crm/.github/blob/main/.github/workflows/scan-secrets.yml
+#
+# Allowlisting: the old `.secret-scan-allowlist` file is no longer
+# honored. For genuine false-positives add a rule to `.secretlintrc.json`
+# (project-wide) or use `// secretlint-disable-next-line <rule>` on the
+# offending line (per-occurrence). Avoid path-wide ignores unless
+# unavoidable; secretlint's allowlists are coarse.
 
 on:
   pull_request:
@@ -98,4 +104,6 @@ jobs:
       - name: Run secretlint
         if: steps.changed.outputs.skip != 'true'
         shell: bash
-        run: xargs -0 -r -a /tmp/changed-files.z node_modules/.bin/secretlint
+        run: |
+          set -euo pipefail
+          xargs -0 -r -a /tmp/changed-files.z node_modules/.bin/secretlint

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: "1"
 


### PR DESCRIPTION
## Summary

Replaces the prior bash-regex `secret-scan.yml` (hand-maintained ~10 token-shape patterns — AWS, GitHub, Slack, Stripe, etc.) with secretlint + `preset-recommend`, which covers the same set + more (GCP, Linear, npm, 1Password, Anthropic, DB connection strings, JWTs, basic-auth, ...) and stays current with upstream rule maintenance.

secretlint + the preset are **already in devDependencies** (used by the local pre-commit hook); this closes the gap where local and CI were running different rules.

## Why inlined, not a reusable-workflow call

nex-as-a-skill is public; [`nex-crm/.github`](https://github.com/nex-crm/.github) is private. GitHub Actions silently fails to resolve reusable workflows from a private repo when the caller is public. Kept in structural sync with [the reusable source of truth](https://github.com/nex-crm/.github/blob/main/.github/workflows/scan-secrets.yml).

## What changed

- `.github/workflows/secret-scan.yml` — rewritten. No new deps; secretlint was already in the lockfile.
- Full SHA pins on `actions/checkout`, `oven-sh/setup-bun`, `actions/cache`.
- `bun install --ignore-scripts` for supply-chain hygiene.
- Changed-files scoping (PR diff / push diff) instead of scanning the whole tree, so scan time stays bounded on big PRs.

## Scope shift to flag for reviewers

The old bash-regex job scanned only the **added diff lines** of changed files. This job scans the **full contents** of changed files. Net positive — secretlint catches secrets hiding in unchanged lines you happened to touch — but it may flag pre-existing findings on first activation. If that happens, allowlist via `.secretlintrc.json` or fix the offender; do not regress to diff-only scanning.

## Test plan

- [x] `./node_modules/.bin/secretlint '**/*'` locally — clean
- [ ] CI `Secret Scan` passes on this PR
- [ ] Optional smoke post-merge: open throwaway PR with a fake `ghp_...` token and confirm CI catches it


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD secret scanning by replacing manual detection with secretlint for more robust and standardized scanning
  * Migrated allowlist configuration from a separate file to `.secretlintrc.json` or inline comments for easier management
  * Optimized scanning to run only on changed files for improved efficiency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->