### PR TITLE
chore: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns: ["*"]
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 10
+    groups:
+      all-dependencies:
+        patterns: ["*"]
+    commit-message:
+      prefix: "chore"
+      include: "scope"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` following the canonical template in [nex-crm/.github](https://github.com/nex-crm/.github/pull/29) (`profile/dependabot-template.yml`).

GitHub does **not** inherit `dependabot.yml` from the org `.github` repo — each repo needs its own on the default branch. This PR closes that gap.

## Behaviour

- **Weekly, Monday 09:00 UTC** — one grouped PR per ecosystem.
- **`groups: all-dependencies: patterns: ["*"]`** — a week of bumps becomes one review, not per-package noise.
- Commit prefix `chore` (or `ci` for `github-actions`) per commitlint rules.
- Security updates run independently of this schedule — they fire on CVE disclosure regardless.

Ecosystems picked from the manifests present in the repo (see diff).

## Test plan
- [ ] Merge → first Dependabot run next Monday 09:00 UTC
- [ ] Confirm PRs open under the grouped pattern, not per-package
- [ ] Any existing open security alerts get picked up

🤖 Generated with [Claude Code](https://claude.com/claude-code)