### PR TITLE
chore(deps): split dependabot groups — majors open individually

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,12 @@ updates:
       day: "monday"
       time: "09:00"
     open-pull-requests-limit: 5
+    # reviewers: ["nex-crm/engineering"]
+    # labels: ["dependencies"]
     groups:
       github-actions:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
     commit-message:
       prefix: "ci"
       include: "scope"
@@ -21,9 +24,12 @@ updates:
       day: "monday"
       time: "09:00"
     open-pull-requests-limit: 10
+    # reviewers: ["nex-crm/engineering"]
+    # labels: ["dependencies"]
     groups:
       all-dependencies:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
     commit-message:
       prefix: "chore"
       include: "scope"


### PR DESCRIPTION
## Summary

Adds `update-types: ["minor", "patch"]` under each grouped block so major-version bumps open as individual PRs instead of getting bundled with the 5+ safe bumps in a group. Also stubs commented `reviewers`/`labels` per ecosystem so downstream bot PRs auto-route when the stubs are uncommented.

Matches the canonical template landed in [nex-crm/.github#29](https://github.com/nex-crm/.github/pull/29) and the deploy-side application in [nex-crm/deploy#115](https://github.com/nex-crm/deploy/pull/115).

## Why now

Today's dependabot sweep across the org produced several group-bumps that silently bundled 5+ major-version changes into one PR — breaking the assumption that "approve and merge" is safe on group PRs. The new split forces majors to open individually so reviewers see each breaking change on its own, and can close or defer without losing the safe bumps.

## Test plan

- [x] dependabot.yml parses (pre-commit secret-scan + format checks pass)
- [ ] Next Monday's bot cycle opens individual PRs per major-version bump in flight