### PR TITLE
chore: add advisory CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Advisory only — NOT enforced by branch protection.
+#
+# classic branch protection on `main` has `require_code_owner_reviews: false`,
+# so this file does not gate merges. GitHub uses it solely to auto-request
+# reviewers on new PRs. If you need enforcement, enable the rule on branch
+# protection explicitly.
+
+* @FranDias @nex-crm/backend


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` auto-assigning @FranDias + @nex-crm/backend on every PR.
- Advisory only — branch protection still has `require_code_owner_reviews: false`. Flip the protection rule when ready to enforce.

Closes audit row Table B "CODEOWNERS file: ✗ absent" for `nex-crm/nex-as-a-skill` per `NEX_CRM_REPO_AUDIT_2026_04_24.md`.

## Test plan
- [ ] Confirm GitHub auto-requests review from @FranDias and @nex-crm/backend on a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)