### PR TITLE
chore: cover nested plugin workspaces in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,3 +33,37 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+
+  - package-ecosystem: "npm"
+    directory: "/openclaw-plugin"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 5
+    # reviewers: ["nex-crm/engineering"]
+    # labels: ["dependencies"]
+    groups:
+      all-dependencies:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "npm"
+    directory: "/claude-code-plugin"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 5
+    # reviewers: ["nex-crm/engineering"]
+    # labels: ["dependencies"]
+    groups:
+      all-dependencies:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    commit-message:
+      prefix: "chore"
+      include: "scope"


### PR DESCRIPTION
## Summary
Closes audit Table D row 103 — `openclaw-plugin/` and `claude-code-plugin/` each ship their own `bun.lock` + `package.json` but were uncovered by Dependabot.

These are **not** bun workspaces (root `package.json` has no `workspaces` key) — each plugin is an independent npm project, so each needs its own `directory` entry.

- `/openclaw-plugin` — `@sinclair/typebox`, `typescript`, `@types/bun`, `@types/node`
- `/claude-code-plugin` — `typescript`, `@types/node`

Per `nex-crm/.github/profile/dependabot-template.yml` conventions (weekly Monday 09:00 UTC, grouped minor+patch).

## Context
- Doesn't address Table E "Secret Scan red on main since 2026-04-23" or "publish-cli.yml has no env gate" — those are separate items in R7 #6 and #7.
- No change to existing `github-actions /` and `npm /` blocks.

## Test plan
- [ ] CI: lefthook pre-commit (secret-scan, commitlint) green locally.
- [ ] After merge, confirm Dependabot scans both plugin dirs on next Monday cycle (or trigger via `gh api -X POST repos/nex-crm/nex-as-a-skill/dependabot/updates`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded automated dependency management configuration to ensure consistent weekly updates with improved control over pull request limits and update types across additional package scopes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->