### PR TITLE
chore(deps): group typescript + @types/* in plugin dependabot configs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,8 +44,18 @@ updates:
     # reviewers: ["nex-crm/engineering"]
     # labels: ["dependencies"]
     groups:
+      # typescript and its companion @types/* packages must move together —
+      # bumping `typescript` to a new major (e.g. 5→6) without bumping
+      # `@types/node` produced two PRs that step on each other's lockfile
+      # and tsconfig (TS 6 stops auto-loading @types/*; the tsconfig fix
+      # belongs in the same PR as the typescript bump). Group them so
+      # Dependabot ships one PR with both, including major bumps.
+      typescript-types:
+        patterns: ["typescript", "@types/*"]
+        update-types: ["major", "minor", "patch"]
       all-dependencies:
         patterns: ["*"]
+        exclude-patterns: ["typescript", "@types/*"]
         update-types: ["minor", "patch"]
     commit-message:
       prefix: "chore"
@@ -61,8 +71,14 @@ updates:
     # reviewers: ["nex-crm/engineering"]
     # labels: ["dependencies"]
     groups:
+      # See note in /openclaw-plugin entry — typescript + @types/* must
+      # move together (same lockfile, same tsconfig fix).
+      typescript-types:
+        patterns: ["typescript", "@types/*"]
+        update-types: ["major", "minor", "patch"]
       all-dependencies:
         patterns: ["*"]
+        exclude-patterns: ["typescript", "@types/*"]
         update-types: ["minor", "patch"]
     commit-message:
       prefix: "chore"


### PR DESCRIPTION
## Summary
- Adds a `typescript-types` group to both `/openclaw-plugin` and `/claude-code-plugin` Dependabot npm entries
- Captures `typescript` and any `@types/*` package together — including major bumps — so a TS major and its matching `@types/node` bump arrive as one PR
- Excludes those patterns from the existing `all-dependencies` group to avoid double-grouping

## Why
Today's Dependabot sweep landed separate PRs for typescript 5→6 (#140, #142) and @types/node 20/22→25 (#139, #141) in the same plugin dirs. They serialized through main and stepped on each other's bun.lock, requiring four manual rebases. They also need the same tsconfig fix (`"types": ["node"]`, since TS 6 stops auto-loading @types/*) — which only makes sense to write once, not twice.

## Test plan
- [ ] Confirm Dependabot's next weekly run produces one combined `typescript-types` PR per plugin instead of two
- [ ] Confirm minor/patch bumps for non-types deps still group under `all-dependencies`
- [ ] No change to root `/` or github-actions ecosystem grouping

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to streamline TypeScript and related package updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->