### PR TITLE
chore(agents): adopt canonical Claude settings.json (bun gate + CWD guard)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,11 @@
           {
             "type": "command",
             "command": "cmd=$(jq -r '.tool_input.command // empty'); if [ -z \"$cmd\" ]; then echo '{\"decision\":\"block\",\"reason\":\"Unable to inspect command.\"}'; elif printf '%s' \"$cmd\" | grep -qE '(^|\\s|&&|\\|\\||;|\\|)\\s*(npm|npx|pnpm|yarn)\\b'; then echo '{\"decision\":\"block\",\"reason\":\"Use bun/bunx instead of npm/npx/pnpm/yarn. This project uses bun as its package manager.\"}'; fi"
+          },
+          {
+            "type": "command",
+            "command": "cat >/dev/null; cwd=$(pwd -P 2>/dev/null || true); if [ -z \"$cwd\" ] || ! [ -d \"$cwd\" ]; then jq -n '{hookSpecificOutput:{hookEventName:\"PreToolUse\",permissionDecision:\"deny\",permissionDecisionReason:\"Shell CWD has been deleted (likely a worktree cleanup). STOP and report this to the user — do NOT retry shell commands blind. Any remaining work needs to be moved to a valid directory first.\"}}'; fi; exit 0",
+            "timeout": 5
           }
         ]
       }

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -22,6 +22,7 @@ pre-commit:
         - "**/node_modules/**"
         - "dist/**"
         - "**/dist/**"
+        - ".claude/**"
     check-merge-conflicts:
       glob: "*.{ts,tsx,js,jsx,json,yaml,yml,md}"
       run: grep -rlE '^(<{7}|>{7}|={7})' {staged_files} && echo "Merge conflict markers found" && exit 1 || true


### PR DESCRIPTION
Standardizes `.claude/settings.json` across all Nex repos:

- **Bun gate**: blocks accidental invocations of non-Bun JS package managers
- **CWD-deletion guard**: prevents agents retrying blind shell commands after worktree cleanup deletes the working directory

Config-only change; no runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to detect and handle missing working directories with user guidance
  
* **Chores**
  * Updated configuration to exclude development directories from linting

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/nex-as-a-skill/pull/153)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->