### PR TITLE
ci(security): swap Trivy for nex-crm/.github scan-deps reusable

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,25 +1,21 @@
 name: Security Scan
 
+# Delegates to the org-wide reusable bun-audit workflow. Replaces the
+# previous Trivy filesystem scanner — bun audit reads bun.lock directly
+# and queries the same GitHub Advisory DB.
+#
+# Suppress an advisory by adding its GHSA id to .bunauditignore with a
+# `# rationale + revisit date` comment. Aim to revisit quarterly.
+#
+# Source: https://github.com/nex-crm/.github/blob/main/.github/workflows/scan-deps.yml
+
 on:
   pull_request:
   push:
     branches: [main]
 
-permissions:
-  contents: read
-
 jobs:
-  trivy:
-    name: Trivy Vulnerability Scan
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Run Trivy filesystem scanner
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-        with:
-          scan-type: "fs"
-          scan-ref: "."
-          severity: "HIGH,CRITICAL"
-          exit-code: "1"
-          ignore-unfixed: true
+  scan-deps:
+    uses: nex-crm/.github/.github/workflows/scan-deps.yml@27c30b663694d84232c10106cb6f0545a526710d # ratchet:nex-crm/.github/.github/workflows/scan-deps.yml@v0.9.0
+    secrets:
+      CORE_REPO_TOKEN: ${{ secrets.CORE_REPO_TOKEN }}

--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,9 @@
       },
     },
   },
+  "overrides": {
+    "fast-uri": "^3.1.2",
+  },
   "packages": {
     "@azu/format-text": ["@azu/format-text@1.0.2", "", {}, "sha512-Swi4N7Edy1Eqq82GxgEECXSSLyn6GOb5htRFPzBDdUkECGXtlf12ynO5oJSpWKPwCaUssOu7NfhDcCWpIC6Ywg=="],
 
@@ -177,7 +180,7 @@
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
-    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+    "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 

--- a/package.json
+++ b/package.json
@@ -56,5 +56,8 @@
     "@secretlint/secretlint-rule-preset-recommend": "^13.0.0",
     "lefthook": "^2.1.6",
     "secretlint": "^13.0.0"
+  },
+  "overrides": {
+    "fast-uri": "^3.1.2"
   }
 }


### PR DESCRIPTION
## Summary

Replaces the Trivy filesystem scanner with `bun audit` via the new org-wide reusable [`scan-deps.yml`](https://github.com/nex-crm/.github/pull/88) (pinned to commit `27c30b66`; bumps to `v0.9.0` once that PR cuts a release).

## What changes

- `.github/workflows/security-scan.yml` delegates to the reusable. Job name renames from `Trivy Vulnerability Scan` → `scan-deps / scan-deps`.
- `package.json` gains an `overrides` clause forcing `fast-uri ^3.1.2` to resolve 2 transitive high advisories that Trivy was missing.
- `bun.lock` regenerated to reflect the override.

## Why the override

The transitive dep `fast-uri@3.1.0` had two high advisories:

- `GHSA-v39h-62p7-jpjc` — host confusion via percent-encoded authority delimiters
- `GHSA-q3j6-qgpj-74h6` — path traversal via percent-encoded dot segments

Both fixed in `3.1.2`. Trivy's filesystem scan was missing these because it reads `package.json` declarations rather than resolved lockfile versions. `ajv` (pulled in via secretlint) declares `fast-uri: ^3.0.1`, so a normal `bun update` would resolve to the latest semver-compatible version — the `overrides` clause makes that intent explicit and stable across reinstalls.

## Test plan

- [x] `bun audit --json` at `high+` floor → 0 findings.
- [ ] CI run on this PR exercises the SHA-pinned reusable end-to-end.
- [ ] After `nex-crm/.github` v0.9.0 cuts, bump the pin from `@27c30b66` to `@v0.9.0` and re-push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)