### PR TITLE
chore(dependabot): adopt v0.9.0 cadence - monthly + 21-day cooldown + group everything

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,16 +21,15 @@ updates:
     registries:
       - nex-crm-github
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
+      interval: "monthly"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 21
     # reviewers: ["nex-crm/engineering"]
     # labels: ["dependencies"]
     groups:
       github-actions:
         patterns: ["*"]
-        update-types: ["minor", "patch"]
     commit-message:
       prefix: "ci"
       include: "scope"
@@ -38,16 +37,15 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
+      interval: "monthly"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 21
     # reviewers: ["nex-crm/engineering"]
     # labels: ["dependencies"]
     groups:
       all-dependencies:
         patterns: ["*"]
-        update-types: ["minor", "patch"]
     commit-message:
       prefix: "chore"
       include: "scope"
@@ -55,16 +53,15 @@ updates:
   - package-ecosystem: "npm"
     directory: "/openclaw-plugin"
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
+      interval: "monthly"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 21
     # reviewers: ["nex-crm/engineering"]
     # labels: ["dependencies"]
     groups:
       all-dependencies:
         patterns: ["*"]
-        update-types: ["minor", "patch"]
     commit-message:
       prefix: "chore"
       include: "scope"
@@ -72,16 +69,15 @@ updates:
   - package-ecosystem: "npm"
     directory: "/claude-code-plugin"
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
+      interval: "monthly"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 21
     # reviewers: ["nex-crm/engineering"]
     # labels: ["dependencies"]
     groups:
       all-dependencies:
         patterns: ["*"]
-        update-types: ["minor", "patch"]
     commit-message:
       prefix: "chore"
       include: "scope"


### PR DESCRIPTION
Adopts the v0.9.0 canonical Dependabot policy from `nex-crm/.github`.

## Changes (per ecosystem)

- Cadence: weekly Monday 09:00 → monthly
- Added `cooldown.default-days: 21`
- Dropped `update-types: ["minor", "patch"]` filter from catch-all groups (majors now join)

## Preserved

- `registries: nex-crm-github` block (private nex-crm reusable-workflow refs)
- Per-ecosystem `commit-message.prefix` overrides
- Existing comments + rationale
- `ignore:` blocks, `directory:` values, `open-pull-requests-limit:` tuning
- Specialized groups (e.g. docker base-image group, terraform `directories:` plural)

## Tradeoffs

- Worst-case latency ~51 days (monthly + 21-day cooldown).
- Multi-update grouped PRs lose auto-merge — single-update grouped PRs still match the title parser.
- Security updates bypass cooldown.

## Rollout note

Adopting this config triggers an immediate update check, so any existing pending updates older than 21 days will open right away on merge — expect a one-time burst before monthly cadence settles.

See [nex-crm/.github#88](https://github.com/nex-crm/.github/pull/88) and `docs/DEPENDABOT.md` for full context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Dependabot configuration to adjust dependency update schedules and registry settings for automated dependency management.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/nex-as-a-skill/pull/159)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->