### PR TITLE
fix(openclaw): rename is_multi_value → is_multivalue in attribute options

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -346,7 +346,7 @@ Discover available object types (person, company, etc.) and their attribute sche
           "options": {
             "is_required": true,
             "is_unique": false,
-            "is_multi_value": false
+            "is_multivalue": false
           }
         }
       ]
@@ -406,7 +406,7 @@ Add a new attribute to an object type.
 | `slug` | string | yes | URL-safe identifier |
 | `type` | string | yes | `"text"`, `"number"`, `"email"`, `"phone"`, `"url"`, `"date"`, `"boolean"`, `"currency"`, `"location"`, `"select"`, `"social_profile"`, `"domain"`, `"full_name"` |
 | `description` | string | no | Description |
-| `options` | object | no | `is_required`, `is_unique`, `is_multi_value`, `use_raw_format`, `is_whole_number`, `select_options` |
+| `options` | object | no | `is_required`, `is_unique`, `is_multivalue`, `use_raw_format`, `is_whole_number`, `select_options` |
 
 ```json
 {

--- a/openclaw-plugin/src/index.ts
+++ b/openclaw-plugin/src/index.ts
@@ -622,7 +622,7 @@ const plugin = {
         Type.Object({
           is_required: Type.Optional(Type.Boolean()),
           is_unique: Type.Optional(Type.Boolean()),
-          is_multi_value: Type.Optional(Type.Boolean()),
+          is_multivalue: Type.Optional(Type.Boolean()),
           use_raw_format: Type.Optional(Type.Boolean()),
           is_whole_number: Type.Optional(Type.Boolean()),
           select_options: Type.Optional(Type.Array(Type.Object({ name: Type.String() }))),


### PR DESCRIPTION
## Summary

Aligns the MCP `nex_create_attribute` tool schema with the canonical
attribute_options wire shape landed in [nex-crm/core#1242](https://github.com/nex-crm/core/pull/1242).

Renames \`is_multi_value\` → \`is_multivalue\` in:
- \`openclaw-plugin/src/index.ts:625\` — \`CreateAttributeParams.options\` TypeBox schema
- \`SKILL.md\` — request body example + docs

Upstream proto has both \`is_multi_value\` field number (4) and name reserved, so the
wire is forward/backward safe — only the published tool schema changes.

## Test plan

- [x] \`bun install\` — clean
- [x] No other references to \`is_multi_value\` in the repo
- [ ] CI passes
- [ ] Manual: call \`nex_create_attribute\` from an MCP-aware client and confirm the new key is accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed field naming inconsistency in the attribute options to ensure proper API schema compliance.

* **Documentation**
  * Updated documentation with corrected attribute option field names for clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/nex-as-a-skill/pull/160)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->