### PR TITLE
feat(install): download nex-cli binary in npm postinstall

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 dist/
 node_modules/
+
+# nex-cli binary fetched by scripts/postinstall.js — never committed/published.
+bin/nex-cli
+bin/nex-cli.exe

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Talk to the team, share feedback, and connect with other developers building AI 
 # Option A: install the nex-cli binary (no Node.js required)
 curl -fsSL https://raw.githubusercontent.com/nex-crm/nex-as-a-skill/main/install.sh | sh
 
-# Option B: install via npm (or bun/pnpm) — thin shim that delegates to nex-cli
+# Option B: install via npm (or bun/pnpm) — downloads the nex-cli binary for you
 npm install -g @nex-ai/nex
 ```
 
@@ -245,9 +245,11 @@ cd openclaw-plugin && bun install && bun run build && bun test
 
 ### How it works
 
-**npm package** (`bin/nex.js`, `bin/nex-mcp.js`): Thin Node.js shims that find `nex-cli` on PATH or common install locations and delegate all commands. For `npx @nex-ai/nex` and MCP Registry compatibility.
+**npm package** (`bin/nex.js`, `bin/nex-mcp.js`): Thin Node.js shims that delegate every command to the `nex-cli` binary. On `npm install`, the `scripts/postinstall.js` hook downloads the binary for the current platform from the latest GitHub release and verifies it against `checksums.txt` before placing it next to the shims as `bin/nex-cli`. The shims also fall back to `nex-cli` on PATH and the directories `install.sh` writes to (see `bin/shim-core.js`). For `npx @nex-ai/nex` and MCP Registry compatibility.
 
-The `nex-cli` binary is built and released from [nex-crm/nex-cli](https://github.com/nex-crm/nex-cli). Install it with:
+Postinstall escape hatches: `NEX_SKIP_POSTINSTALL=1` skips the download (offline mirrors, prebuilt CI images); `NEX_POSTINSTALL_STRICT=1` makes a network failure fatal instead of deferring to the runtime hint. A checksum mismatch is always fatal.
+
+The `nex-cli` binary is built and released from [nex-crm/nex-cli](https://github.com/nex-crm/nex-cli). To install it standalone (no Node.js):
 ```bash
 curl -fsSL https://raw.githubusercontent.com/nex-crm/nex-as-a-skill/main/install.sh | sh
 ```

--- a/bin/nex-mcp.js
+++ b/bin/nex-mcp.js
@@ -1,50 +1,14 @@
 #!/usr/bin/env node
 
 /**
- * Thin shim for nex-mcp — delegates to nex-cli mcp.
+ * Thin shim for nex-mcp — delegates to `nex-cli mcp`.
  *
- * This entry point exists for MCP registry compatibility.
- * Platforms like Claude Desktop install MCP servers via: npx @nex-ai/nex
- * which resolves to this shim, which delegates to the nex-cli binary.
+ * This entry point exists for MCP registry compatibility. Platforms like
+ * Claude Desktop install MCP servers via `npx @nex-ai/nex`, which resolves to
+ * this shim. The binary is fetched by scripts/postinstall.js; see
+ * bin/shim-core.js for the full resolution order.
  */
 
-import { execFileSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { runShim } from "./shim-core.js";
 
-const args = ["mcp", ...process.argv.slice(2)];
-
-function tryExec(command, commandArgs) {
-  try {
-    execFileSync(command, commandArgs, { stdio: "inherit" });
-    return true;
-  } catch (err) {
-    if (err.status !== null && err.status !== undefined) {
-      process.exit(err.status);
-    }
-    return false;
-  }
-}
-
-if (tryExec("nex-cli", args)) {
-  process.exit(0);
-}
-
-const commonPaths = ["/usr/local/bin/nex-cli"];
-if (process.env.HOME) {
-  commonPaths.push(`${process.env.HOME}/.local/bin/nex-cli`);
-}
-for (const p of commonPaths) {
-  if (existsSync(p) && tryExec(p, args)) {
-    process.exit(0);
-  }
-}
-
-console.error(`
-  nex-cli binary not found.
-
-  Install it with:
-    curl -fsSL https://raw.githubusercontent.com/nex-crm/nex-as-a-skill/main/install.sh | sh
-
-  Then run your command again.
-`);
-process.exit(1);
+runShim(["mcp", ...process.argv.slice(2)]);

--- a/bin/nex.js
+++ b/bin/nex.js
@@ -3,51 +3,10 @@
 /**
  * Thin shim for @nex-ai/nex — delegates all commands to the nex-cli binary.
  *
- * Install the binary: curl -fsSL https://raw.githubusercontent.com/nex-crm/nex-as-a-skill/main/install.sh | sh
+ * The binary is fetched by scripts/postinstall.js when this package is
+ * installed; see bin/shim-core.js for the full resolution order.
  */
 
-import { execFileSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { runShim } from "./shim-core.js";
 
-const args = process.argv.slice(2);
-
-// Try nex-cli on PATH first
-function tryExec(command, commandArgs) {
-  try {
-    execFileSync(command, commandArgs, { stdio: "inherit" });
-    return true;
-  } catch (err) {
-    // If the command was found but returned non-zero, propagate the exit code
-    if (err.status !== null && err.status !== undefined) {
-      process.exit(err.status);
-    }
-    return false;
-  }
-}
-
-// 1. Try nex-cli directly (installed via curl | sh)
-if (tryExec("nex-cli", args)) {
-  process.exit(0);
-}
-
-// 2. Try common install locations
-const commonPaths = ["/usr/local/bin/nex-cli"];
-if (process.env.HOME) {
-  commonPaths.push(`${process.env.HOME}/.local/bin/nex-cli`);
-}
-for (const p of commonPaths) {
-  if (existsSync(p) && tryExec(p, args)) {
-    process.exit(0);
-  }
-}
-
-// 3. Not found — show install instructions
-console.error(`
-  nex-cli binary not found.
-
-  Install it with:
-    curl -fsSL https://raw.githubusercontent.com/nex-crm/nex-as-a-skill/main/install.sh | sh
-
-  Then run your command again.
-`);
-process.exit(1);
+runShim(process.argv.slice(2));

--- a/bin/shim-core.js
+++ b/bin/shim-core.js
@@ -1,0 +1,75 @@
+/**
+ * Shared resolution + exec logic for the @nex-ai/nex npm shims
+ * (bin/nex.js and bin/nex-mcp.js).
+ *
+ * The npm package ships only those thin shims; the real `nex-cli` binary is
+ * fetched by scripts/postinstall.js when `npm install @nex-ai/nex` runs and
+ * placed next to this file as bin/nex-cli. resolveCandidates() lists every
+ * place the binary might live, in priority order, so the shim works whether
+ * the user installed via npm, the curl install script, or a manual copy.
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+// On win32 Node needs the extension to exec; the release ships no Windows
+// binary today, but keep the name correct so a future one Just Works.
+const BINARY_NAME = process.platform === "win32" ? "nex-cli.exe" : "nex-cli";
+
+const INSTALL_HINT = `
+  nex-cli binary not found.
+
+  The @nex-ai/nex package downloads it automatically on install. To retry:
+    npm install -g @nex-ai/nex
+
+  Or install the binary directly:
+    curl -fsSL https://raw.githubusercontent.com/nex-crm/nex-as-a-skill/main/install.sh | sh
+
+  Then run your command again.
+`;
+
+/**
+ * nex-cli locations to try, in priority order:
+ *   1. bin/nex-cli inside this package — placed by scripts/postinstall.js.
+ *   2. `nex-cli` on PATH — resolved by execFileSync at exec time.
+ *   3. The directories install.sh writes to, in case they are not on PATH.
+ */
+export function resolveCandidates() {
+  const candidates = [join(here, BINARY_NAME)];
+  candidates.push(BINARY_NAME); // bare name → PATH lookup
+  candidates.push("/usr/local/bin/nex-cli");
+  if (process.env.HOME) {
+    candidates.push(join(process.env.HOME, ".local", "bin", "nex-cli"));
+  }
+  return candidates;
+}
+
+/**
+ * Resolve nex-cli and exec it with `args`, inheriting stdio. Always exits the
+ * process: with the binary's own exit code when it runs, or 1 with an
+ * actionable install hint when no binary can be found.
+ */
+export function runShim(args) {
+  for (const candidate of resolveCandidates()) {
+    const isBareName = candidate === BINARY_NAME;
+    // Absolute paths are stat-checked first so a removed file doesn't throw a
+    // confusing ENOENT; the bare name is left for execFileSync's PATH search.
+    if (!isBareName && !existsSync(candidate)) continue;
+    try {
+      execFileSync(candidate, args, { stdio: "inherit" });
+      process.exit(0);
+    } catch (err) {
+      // Found, but exited non-zero — propagate the real exit code.
+      if (err.status !== null && err.status !== undefined) {
+        process.exit(err.status);
+      }
+      // Not executable here (e.g. bare name not on PATH) — try the next one.
+    }
+  }
+  process.stderr.write(`${INSTALL_HINT}\n`);
+  process.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,11 @@
     "nex-mcp": "bin/nex-mcp.js"
   },
   "files": [
-    "bin",
+    "bin/nex.js",
+    "bin/nex-mcp.js",
+    "bin/shim-core.js",
+    "scripts/postinstall.js",
+    "scripts/download-binary.js",
     "plugin-commands",
     "platform-rules",
     "platform-plugins",
@@ -32,7 +36,8 @@
     "integrations"
   ],
   "scripts": {
-    "test": "node --check bin/nex.js && node --check bin/nex-mcp.js"
+    "postinstall": "node scripts/postinstall.js",
+    "test": "node --check bin/nex.js && node --check bin/nex-mcp.js && node --check bin/shim-core.js && node --check scripts/postinstall.js && node --check scripts/download-binary.js && bun test scripts/download-binary.test.js"
   },
   "repository": {
     "type": "git",

--- a/scripts/download-binary.js
+++ b/scripts/download-binary.js
@@ -1,0 +1,175 @@
+/**
+ * Downloads the `nex-cli` binary for the current platform from the latest
+ * GitHub release and places it at bin/nex-cli inside this package.
+ *
+ * The release publishes one bare binary per platform plus a checksums.txt
+ * (see install.sh, which targets the same assets):
+ *
+ *   nex-cli-darwin-arm64  nex-cli-darwin-x64
+ *   nex-cli-linux-arm64   nex-cli-linux-x64
+ *
+ * ---------------------------------------------------------------------------
+ * Integrity verification contract
+ * ---------------------------------------------------------------------------
+ * Every download is verified against the SHA256 listed for it in the
+ * `checksums.txt` asset published on the same release. A mismatch — or an
+ * unreachable / incomplete checksums file — aborts the install rather than
+ * shipping an unverified binary: a compromised release token could otherwise
+ * plant a backdoored binary on every machine that runs `npm install`.
+ *
+ * The npm package version is intentionally decoupled from the binary release
+ * tag, so we resolve `releases/latest` (same as install.sh) rather than
+ * pinning to package.json's version.
+ */
+
+import { createHash } from "node:crypto";
+import fsp from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO = "nex-crm/nex-as-a-skill";
+const CHECKSUMS_FILENAME = "checksums.txt";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const PACKAGE_ROOT = join(here, "..");
+
+/**
+ * Thrown when the current OS/arch has no prebuilt nex-cli binary. Callers
+ * (postinstall) treat this as non-fatal: the npm shim still installs and
+ * surfaces an actionable hint at runtime.
+ */
+export class UnsupportedPlatformError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "UnsupportedPlatformError";
+  }
+}
+
+/** Map Node's process.platform / process.arch onto the release asset naming. */
+export function detectPlatform() {
+  const osMap = { darwin: "darwin", linux: "linux" };
+  const archMap = { x64: "x64", arm64: "arm64" };
+  const os = osMap[process.platform];
+  const arch = archMap[process.arch];
+  if (!os) {
+    throw new UnsupportedPlatformError(
+      `nex-cli has no prebuilt binary for platform "${process.platform}" ` +
+        `(supported: darwin, linux).`,
+    );
+  }
+  if (!arch) {
+    throw new UnsupportedPlatformError(
+      `nex-cli has no prebuilt binary for architecture "${process.arch}" ` +
+        `(supported: x64, arm64).`,
+    );
+  }
+  return { os, arch };
+}
+
+/** Release asset filename for the current platform, e.g. nex-cli-darwin-arm64. */
+export function binaryAssetName() {
+  const { os, arch } = detectPlatform();
+  return `nex-cli-${os}-${arch}`;
+}
+
+function assetUrl(filename) {
+  return `https://github.com/${REPO}/releases/latest/download/${filename}`;
+}
+
+/**
+ * Parse a `checksums.txt` (one `<sha256hex>  <filename>` line per asset) and
+ * return the lowercased hash for `filename`, or null when it is not listed.
+ */
+export function parseChecksums(text, filename) {
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    // `*` prefix on the name marks a binary-mode entry in some sha tools.
+    const match = trimmed.match(/^([0-9a-fA-F]{64})\s+\*?(.+)$/);
+    if (match && match[2] === filename) {
+      return match[1].toLowerCase();
+    }
+  }
+  return null;
+}
+
+async function fetchBuffer(url) {
+  const res = await fetch(url, { redirect: "follow" });
+  if (!res.ok) {
+    throw new Error(`Download failed: ${res.status} ${res.statusText} (${url})`);
+  }
+  return Buffer.from(await res.arrayBuffer());
+}
+
+async function fetchText(url) {
+  const res = await fetch(url, { redirect: "follow" });
+  if (!res.ok) {
+    throw new Error(`Download failed: ${res.status} ${res.statusText} (${url})`);
+  }
+  return res.text();
+}
+
+function sha256(buf) {
+  return createHash("sha256").update(buf).digest("hex");
+}
+
+/**
+ * Download, verify, and install the nex-cli binary into bin/nex-cli.
+ *
+ * Options:
+ *   silent    — suppress progress output on stderr.
+ *   targetDir — directory to install into; defaults to this package's bin/.
+ *
+ * Resolves with the installed binary path. Rejects with an
+ * UnsupportedPlatformError on win32 / unknown arch, or a plain Error on a
+ * network failure or an integrity violation (message contains "SHA256
+ * mismatch" / "verify download integrity" so postinstall can branch on it).
+ */
+export async function downloadBinary({ silent = false, targetDir } = {}) {
+  const assetName = binaryAssetName(); // throws UnsupportedPlatformError
+  const binDir = targetDir ?? join(PACKAGE_ROOT, "bin");
+  const binaryPath = join(binDir, "nex-cli");
+  const log = (msg) => {
+    if (!silent) process.stderr.write(`nex-cli: ${msg}\n`);
+  };
+
+  log(`downloading ${assetName} from the latest release`);
+  const binaryBuf = await fetchBuffer(assetUrl(assetName));
+
+  // Integrity check BEFORE the binary is written anywhere executable.
+  let checksumsText;
+  try {
+    checksumsText = await fetchText(assetUrl(CHECKSUMS_FILENAME));
+  } catch (err) {
+    throw new Error(
+      `Cannot verify download integrity: failed to fetch ${CHECKSUMS_FILENAME} ` +
+        `(${err.message}). Refusing to install an unverified binary.`,
+    );
+  }
+  const expected = parseChecksums(checksumsText, assetName);
+  if (!expected) {
+    throw new Error(
+      `Cannot verify download integrity: ${assetName} is not listed in ` +
+        `${CHECKSUMS_FILENAME}. Refusing to install an unverified binary.`,
+    );
+  }
+  const actual = sha256(binaryBuf);
+  if (actual !== expected) {
+    throw new Error(
+      `SHA256 mismatch for ${assetName}.\n` +
+        `  expected: ${expected}\n` +
+        `  actual:   ${actual}\n` +
+        `Refusing to install. This may indicate a tampered release asset or a ` +
+        `corrupted download. Retry on a clean network; if it persists, file an ` +
+        `issue at https://github.com/${REPO}/issues.`,
+    );
+  }
+  log("checksum verified");
+
+  await fsp.mkdir(binDir, { recursive: true });
+  await fsp.writeFile(binaryPath, binaryBuf);
+  await fsp.chmod(binaryPath, 0o755);
+  log(`installed to ${binaryPath}`);
+
+  return binaryPath;
+}

--- a/scripts/download-binary.test.js
+++ b/scripts/download-binary.test.js
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  binaryAssetName,
+  detectPlatform,
+  parseChecksums,
+  UnsupportedPlatformError,
+} from "./download-binary.js";
+
+// install.sh publishes checksums.txt as `<sha256>  <filename>` (two spaces).
+const SAMPLE_CHECKSUMS = `ac8d1dcb8deb8d5a758385239152948d28fab6d7d6a64aa85fb97c61753bb575  nex-cli-darwin-arm64
+432f68dc33a5d0f77f1c56ad54b8de067868a9c40deb4880197026449c1dc892  nex-cli-darwin-x64
+585840fa7efa40447a8380242c95497fbb027e831d28b41cc4c9231f45be63aa  nex-cli-linux-arm64
+97b5e627f92216f87f1a1c96356cf57716f7682c23f122f71d522f994ecfb644  nex-cli-linux-x64
+`;
+
+describe("parseChecksums", () => {
+  test("returns the lowercased hash for a listed asset", () => {
+    expect(parseChecksums(SAMPLE_CHECKSUMS, "nex-cli-darwin-arm64")).toBe(
+      "ac8d1dcb8deb8d5a758385239152948d28fab6d7d6a64aa85fb97c61753bb575",
+    );
+    expect(parseChecksums(SAMPLE_CHECKSUMS, "nex-cli-linux-x64")).toBe(
+      "97b5e627f92216f87f1a1c96356cf57716f7682c23f122f71d522f994ecfb644",
+    );
+  });
+
+  test("returns null for an asset not in the file", () => {
+    expect(parseChecksums(SAMPLE_CHECKSUMS, "nex-cli-windows-x64")).toBeNull();
+  });
+
+  test("does not partial-match a filename prefix", () => {
+    // "nex-cli-darwin" must not match the "nex-cli-darwin-arm64" line.
+    expect(parseChecksums(SAMPLE_CHECKSUMS, "nex-cli-darwin")).toBeNull();
+  });
+
+  test("ignores blank lines and comments", () => {
+    const text = `# checksums\n\n${SAMPLE_CHECKSUMS}`;
+    expect(parseChecksums(text, "nex-cli-darwin-x64")).toBe(
+      "432f68dc33a5d0f77f1c56ad54b8de067868a9c40deb4880197026449c1dc892",
+    );
+  });
+
+  test("tolerates the binary-mode `*` filename prefix", () => {
+    const text =
+      "ac8d1dcb8deb8d5a758385239152948d28fab6d7d6a64aa85fb97c61753bb575 *nex-cli-darwin-arm64\n";
+    expect(parseChecksums(text, "nex-cli-darwin-arm64")).toBe(
+      "ac8d1dcb8deb8d5a758385239152948d28fab6d7d6a64aa85fb97c61753bb575",
+    );
+  });
+
+  test("returns null on empty input", () => {
+    expect(parseChecksums("", "nex-cli-linux-x64")).toBeNull();
+  });
+});
+
+describe("detectPlatform / binaryAssetName", () => {
+  const origPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+  const origArch = Object.getOwnPropertyDescriptor(process, "arch");
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", origPlatform);
+    Object.defineProperty(process, "arch", origArch);
+  });
+
+  function setEnv(platform, arch) {
+    Object.defineProperty(process, "platform", { value: platform, configurable: true });
+    Object.defineProperty(process, "arch", { value: arch, configurable: true });
+  }
+
+  test("maps every supported OS/arch onto the release asset name", () => {
+    setEnv("darwin", "arm64");
+    expect(binaryAssetName()).toBe("nex-cli-darwin-arm64");
+    setEnv("linux", "x64");
+    expect(binaryAssetName()).toBe("nex-cli-linux-x64");
+  });
+
+  test("throws UnsupportedPlatformError on an OS with no prebuilt binary", () => {
+    setEnv("win32", "x64");
+    expect(() => detectPlatform()).toThrow(UnsupportedPlatformError);
+  });
+
+  test("throws UnsupportedPlatformError on an unknown architecture", () => {
+    setEnv("linux", "ia32");
+    expect(() => detectPlatform()).toThrow(UnsupportedPlatformError);
+  });
+
+  test("the current runtime resolves to a well-formed asset name", () => {
+    expect(binaryAssetName()).toMatch(/^nex-cli-(darwin|linux)-(x64|arm64)$/);
+  });
+});

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,55 @@
+/**
+ * Postinstall: fetch and verify the nex-cli binary so `npm install @nex-ai/nex`
+ * (and `npx @nex-ai/nex`) produce a working CLI without a separate curl step.
+ *
+ * Failure policy:
+ *   - Integrity failures (SHA256 mismatch, unverifiable download) are ALWAYS
+ *     fatal. Continuing would let a tampered release asset install silently.
+ *   - Unsupported platforms (Windows) and network failures are NON-fatal: the
+ *     bin/nex.js shim still installs and prints an actionable hint at runtime,
+ *     so a corp proxy blocking github.com must not break `npm install`.
+ *
+ * Escape hatches:
+ *   NEX_SKIP_POSTINSTALL=1  — skip the download entirely (offline mirrors,
+ *                             CI images that restore a prebuilt bin/).
+ *   NEX_POSTINSTALL_STRICT=1 — promote network failures to fatal, for callers
+ *                             that want the install to fail loudly instead.
+ */
+
+import { downloadBinary } from "./download-binary.js";
+
+if (process.env.NEX_SKIP_POSTINSTALL === "1") {
+  process.stderr.write("nex-cli: postinstall skipped via NEX_SKIP_POSTINSTALL=1\n");
+  process.exit(0);
+}
+
+try {
+  await downloadBinary();
+} catch (err) {
+  const message = err?.message ? err.message : String(err);
+  const isIntegrityFailure =
+    message.includes("SHA256 mismatch") || message.includes("verify download integrity");
+
+  // Integrity failures are always fatal — no soft-fail, no strict-mode opt-out.
+  if (isIntegrityFailure) {
+    process.stderr.write(
+      `\nnex-cli: SECURITY: ${message}\n` +
+        "nex-cli: aborting install. No binary has been placed in bin/.\n\n",
+    );
+    process.exit(1);
+  }
+
+  // Unsupported platform / network failure. Non-fatal by default: the shim
+  // degrades gracefully and prints install instructions at runtime.
+  if (process.env.NEX_POSTINSTALL_STRICT === "1") {
+    process.stderr.write(`\nnex-cli: postinstall download failed: ${message}\n\n`);
+    process.exit(1);
+  }
+  process.stderr.write(
+    `nex-cli: postinstall could not download the binary (${message}).\n` +
+      "nex-cli: install will continue; run `npm install -g @nex-ai/nex` again, " +
+      "or the curl install script, to retry. Set NEX_POSTINSTALL_STRICT=1 to " +
+      "make this failure fatal.\n",
+  );
+  process.exit(0);
+}


### PR DESCRIPTION
## Problem

`npm install @nex-ai/nex` / `npx @nex-ai/nex` shipped **only** the thin `bin/nex.js` shim. The shim delegates to a separate, curl-installed `nex-cli` binary — but nothing installed that binary. When a user (or an embedding app) ran a command, the shim *did* run, found no binary, and exited non-zero with a raw blob:

```
nex-cli binary not found.

  Install it with:
    curl -fsSL https://raw.githubusercontent.com/nex-crm/nex-as-a-skill/main/install.sh | sh
```

This surfaced verbatim in WUPHF's onboarding "Power up with Nex" step — WUPHF found the `nex` shim on PATH, treated Nex as installed, ran `nex --cmd "setup <email>"`, and rendered the shim's stderr as a raw JSON error. (WUPHF side fixed separately in nex-crm/wuphf.)

## Fix

Make the npm package self-sufficient — `npm install` now downloads a working binary.

```mermaid
flowchart LR
  A["npm install @nex-ai/nex"] --> B["postinstall.js"]
  B --> C["download-binary.js<br/>fetch nex-cli-&lt;os&gt;-&lt;arch&gt;"]
  C --> D["verify vs checksums.txt"]
  D -->|ok| E["bin/nex-cli (chmod +x)"]
  D -->|mismatch| F["abort install (fatal)"]
  B -->|win32 / network fail| G["non-fatal: shim hint at runtime"]
```

- **`scripts/download-binary.js`** — fetches the platform `nex-cli` from the latest GitHub release, verifies SHA256 against `checksums.txt` before installing. Unverifiable download or mismatch aborts.
- **`scripts/postinstall.js`** — wired as the `postinstall` hook. Integrity failures are **always fatal**; unsupported platforms (Windows) and network failures are **non-fatal** (the shim degrades gracefully and prints a hint at runtime). Escape hatches: `NEX_SKIP_POSTINSTALL=1`, `NEX_POSTINSTALL_STRICT=1`.
- **`bin/shim-core.js`** — shared resolver. The shims now check the postinstall-managed `bin/nex-cli` first, then PATH, then `install.sh`'s target dirs. Removes the duplication between `nex.js` and `nex-mcp.js`.
- **`package.json`** — `files` switched to an explicit allowlist so the downloaded `bin/nex-cli` is never packed/published; added `postinstall`; `bin/nex-cli` gitignored.

## Verification

- `bun run test` — 10 tests pass (`parseChecksums`, `detectPlatform`/`binaryAssetName`, unsupported-platform errors) + `node --check` on every script.
- Ran `node scripts/postinstall.js` for real: downloaded `nex-cli-darwin-arm64`, checksum verified, `bin/nex-cli --version` → `0.1.11`.
- `node bin/nex.js --version` → `0.1.11` (resolves the bundled binary); exit codes propagate (success → 0, failing command → 1).
- Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automatic `nex-cli` binary download and checksum verification during npm installation with configurable escape hatches.

* **Documentation**
  * Updated installation guidance and added detailed explanation of the postinstall binary download process.

* **Tests**
  * Added test suite for binary download, platform detection, and checksum validation.

* **Refactor**
  * Simplified CLI entry points to use shared resolution and execution logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/nex-as-a-skill/pull/161?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->